### PR TITLE
Make deploy & make help

### DIFF
--- a/ports/psoc-edge/Makefile
+++ b/ports/psoc-edge/Makefile
@@ -9,6 +9,23 @@ GIT_SUBMODULES += lib/mtb-psoc-edge-libs
 
 all: mtb_build
 
-.PHONY: all
+deploy: mtb_program
+
+port_help:
+	@:
+	$(info )
+	$(info Available commands:)
+	$(info ) 
+	$(info   make submodules                    Initializes port required submodules)
+	$(info   make mtb_init BOARD=<board_name>   Initialized the ModusToolbox libraries for the specified board.)
+	$(info	 ..                                 Only needs to be done once before the first build)
+	$(info   make BOARD=<board_name>            Build the project for the specified board)
+	$(info   make BOARD=<board_name> deploy     Build and deploy the project to the specified board)
+	$(info   make help                          Show this help)
+	$(info )
+
+help: port_help mtb_help
+
+.PHONY: all deploy help
 
 include $(TOP)/py/mkrules.mk

--- a/ports/psoc-edge/README.md
+++ b/ports/psoc-edge/README.md
@@ -27,14 +27,14 @@ Then initialize the ModusToolbox™ environment:
 Build the firmware:
 
     make BOARD=KIT_PSE84_AI
+  
+And flash it to the board:
 
-> [!WARNING]
-> Work in progress ->  This is currently only triggering the MTB project compilation.
+    make deploy BOARD=KIT_PSE84_AI
 
------------------------------------------------------
-*TODO: From here on, this is not implemented:*
+If you have multiple boards connected, you can specify the serial number of the board to be programmed:
 
-    make deploy
+    make deploy BOARD=KIT_PSE84_AI DEVICE_SN=123456
 
 Find more information about the available makefile targets:
 


### PR DESCRIPTION
* Added make deploy target (including option to pass DEVICE_SN). This I haven´t tested, and later will required extension to program multiple devices (for testing automation).
* Added instructions to deploy in README.md

