### PR TITLE
tools/ci: Remove python3-cryptography for psoc-edge setup.

### DIFF
--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -364,7 +364,7 @@ function ci_powerpc_build {
 
 function ci_psoc_edge_setup {
     ci_gcc_arm_setup
-    sudo apt remove python3-packaging python3-jsonschema
+    sudo apt remove python3-packaging python3-jsonschema python3-cryptography
     sudo pip3 install edgeprotecttools
 }
 


### PR DESCRIPTION

### Summary
Fix in python3-cryptography package



