### PR TITLE
psoc-edge: Add minimal machine.SPI with empty methods.

### DIFF
--- a/ports/psoc-edge/Makefile
+++ b/ports/psoc-edge/Makefile
@@ -216,6 +216,7 @@ PSE_LIB_SRC_C += $(addprefix $(PSE_LIB_TOP_DIR)/, \
 	mtb-dsl-pse8xxgp/pdl/drivers/source/cy_rtc.c \
 	mtb-dsl-pse8xxgp/pdl/drivers/source/cy_scb_common.c \
 	mtb-dsl-pse8xxgp/pdl/drivers/source/cy_scb_i2c.c \
+	mtb-dsl-pse8xxgp/pdl/drivers/source/cy_scb_spi.c \
 	mtb-dsl-pse8xxgp/pdl/drivers/source/cy_scb_uart.c \
 	mtb-dsl-pse8xxgp/pdl/drivers/source/cy_smif.c \
 	mtb-dsl-pse8xxgp/pdl/drivers/source/cy_smif_hb_flash.c \
@@ -312,6 +313,7 @@ MOD_SRC_C += \
 	modpsocedge.c \
 	machine_ipc.c \
 	machine_scb.c \
+	machine_spi.c \
 
 ifeq ($(MICROPY_PY_EXT_FLASH),1)
 	CFLAGS += -DMICROPY_ENABLE_EXT_QSPI_FLASH=1

--- a/ports/psoc-edge/machine_spi.c
+++ b/ports/psoc-edge/machine_spi.c
@@ -1,0 +1,73 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022-2026 Infineon Technologies AG
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+// mpy includes
+#include "extmod/modmachine.h"
+#include "py/runtime.h"
+
+// port-specific includes
+#include "modmachine.h"
+
+typedef struct _machine_spi_obj_t {
+    mp_obj_base_t base;
+} machine_spi_obj_t;
+
+/******************************************************************************/
+// MicroPython bindings for machine SPI protocol (stubs)
+
+static void machine_spi_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
+    mp_printf(print, "SPI()");
+}
+
+mp_obj_t mp_machine_spi_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
+    machine_spi_obj_t *self = mp_obj_malloc(machine_spi_obj_t, &machine_spi_type);
+    return MP_OBJ_FROM_PTR(self);
+}
+
+static void machine_spi_init(mp_obj_base_t *self_in, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+}
+
+static void machine_spi_deinit(mp_obj_base_t *self_in) {
+}
+
+static void machine_spi_transfer(mp_obj_base_t *self_in, size_t len, const uint8_t *src, uint8_t *dest) {
+}
+
+static const mp_machine_spi_p_t machine_spi_p = {
+    .init = machine_spi_init,
+    .deinit = machine_spi_deinit,
+    .transfer = machine_spi_transfer,
+};
+
+MP_DEFINE_CONST_OBJ_TYPE(
+    machine_spi_type,
+    MP_QSTR_SPI,
+    MP_TYPE_FLAG_NONE,
+    make_new, mp_machine_spi_make_new,
+    print, machine_spi_print,
+    protocol, &machine_spi_p,
+    locals_dict, &mp_machine_spi_locals_dict
+    );

--- a/ports/psoc-edge/modmachine.c
+++ b/ports/psoc-edge/modmachine.c
@@ -76,5 +76,6 @@ static void mp_machine_set_freq(size_t n_args, const mp_obj_t *args) {
     { MP_ROM_QSTR(MP_QSTR_PDM_PCM),             MP_ROM_PTR(&machine_pdm_pcm_type) }, \
     { MP_ROM_QSTR(MP_QSTR_RTC),                 MP_ROM_PTR(&machine_rtc_type) }, \
     { MP_ROM_QSTR(MP_QSTR_IPC),                 MP_ROM_PTR(&machine_ipc_type) }, \
+    { MP_ROM_QSTR(MP_QSTR_SPI),                 MP_ROM_PTR(&machine_spi_type) }, \
 
 #endif // MICROPY_PY_MACHINE

--- a/ports/psoc-edge/modmachine.h
+++ b/ports/psoc-edge/modmachine.h
@@ -42,6 +42,7 @@ extern enum clock_freq_type PLL0_freq;
 typedef struct _machine_pdm_pcm_obj_t machine_pdm_pcm_obj_t;
 
 extern const mp_obj_type_t machine_i2c_type;
+extern const mp_obj_type_t machine_spi_type;
 extern const mp_obj_type_t machine_pdm_pcm_type;
 extern const mp_obj_type_t machine_rtc_type;
 extern const mp_obj_type_t machine_ipc_type;

--- a/ports/psoc-edge/mpconfigport.h
+++ b/ports/psoc-edge/mpconfigport.h
@@ -113,6 +113,9 @@
 #define MICROPY_PY_MACHINE_I2C                  (1)
 #define MICROPY_PY_MACHINE_SOFTI2C              (0)
 
+#define MICROPY_PY_MACHINE_SPI                  (1)
+#define MICROPY_PY_MACHINE_SOFTSPI              (0)
+
 #define MICROPY_PY_MACHINE_I2C_TARGET           (1)
 #define MICROPY_PY_MACHINE_I2C_TARGET_MAX       (1)
 #define MICROPY_PY_MACHINE_I2C_TARGET_INCLUDEFILE "ports/psoc-edge/machine_i2c_target.c"

--- a/ports/psoc-edge/spi_test.py
+++ b/ports/psoc-edge/spi_test.py
@@ -1,0 +1,134 @@
+# SPI test helper for psoc-edge MicroPython port.
+#
+# Usage from REPL:
+#   import spi_test
+#   spi_test.loopback_test()          # MOSI <-> MISO shorted
+#   spi_test.flash_jedec_test()       # external SPI flash connected
+#
+# Default pin map matches SCB10 setup used in current bring-up:
+#   SCK  = P16_0
+#   MOSI = P16_1
+#   MISO = P16_2
+#   CS   = P16_3
+
+from machine import SPI, Pin
+from time import sleep_us
+
+
+def _new_spi(
+    baudrate=1_000_000,
+    polarity=0,
+    phase=0,
+    bits=8,
+    firstbit=None,
+    sck_pin="P16_0",
+    mosi_pin="P16_1",
+    miso_pin="P16_2",
+):
+    if firstbit is None:
+        firstbit = SPI.MSB
+    return SPI(
+        baudrate=baudrate,
+        polarity=polarity,
+        phase=phase,
+        bits=bits,
+        firstbit=firstbit,
+        sck=Pin(sck_pin),
+        mosi=Pin(mosi_pin),
+        miso=Pin(miso_pin),
+    )
+
+
+def loopback_test(
+    tx=b"\x9f\xf0\x10\x22",
+    baudrate=1_000_000,
+    polarity=0,
+    phase=0,
+    sck_pin="P16_0",
+    mosi_pin="P16_1",
+    miso_pin="P16_2",
+):
+    """Run MOSI->MISO loopback test.
+
+    Hardware:
+      Short MOSI and MISO together.
+      Do not connect external slave for this test.
+    """
+    spi = _new_spi(
+        baudrate=baudrate,
+        polarity=polarity,
+        phase=phase,
+        sck_pin=sck_pin,
+        mosi_pin=mosi_pin,
+        miso_pin=miso_pin,
+    )
+
+    try:
+        rx = bytearray(len(tx))
+        spi.write_readinto(tx, rx)
+        ok = bytes(rx) == bytes(tx)
+        print("[loopback] tx:", tx)
+        print("[loopback] rx:", rx)
+        print("[loopback] status:", "PASS" if ok else "FAIL")
+        return ok, rx
+    finally:
+        spi.deinit()
+
+
+def flash_jedec_test(
+    baudrate=1_000_000,
+    polarity=0,
+    phase=0,
+    sck_pin="P16_0",
+    mosi_pin="P16_1",
+    miso_pin="P16_2",
+    cs_pin="P16_3",
+):
+    """Read JEDEC ID (0x9F) from an SPI flash-like slave.
+
+    Returns tuple (id_bytes, raw_rx).
+    id_bytes is rx[1:4] because rx[0] is during command phase.
+    """
+    spi = _new_spi(
+        baudrate=baudrate,
+        polarity=polarity,
+        phase=phase,
+        sck_pin=sck_pin,
+        mosi_pin=mosi_pin,
+        miso_pin=miso_pin,
+    )
+    cs = Pin(cs_pin, Pin.OUT, value=1)
+
+    try:
+        tx = b"\x9f\x00\x00\x00"
+        rx = bytearray(4)
+
+        cs(1)
+        sleep_us(2)
+        cs(0)
+        sleep_us(2)
+        spi.write_readinto(tx, rx)
+        sleep_us(2)
+        cs(1)
+
+        jedec = bytes(rx[1:4])
+        print("[flash] tx:", tx)
+        print("[flash] rx:", rx)
+        print("[flash] jedec:", jedec)
+
+        if jedec == b"\x00\x00\x00":
+            print("[flash] WARN: no slave response (all zeros)")
+        if bytes(rx) == tx:
+            print("[flash] WARN: full echo detected (possible MOSI/MISO short or loopback)")
+
+        return jedec, rx
+    finally:
+        spi.deinit()
+
+
+def smoke_tests():
+    """Convenience runner: loopback first, then flash read."""
+    print("=== SPI loopback test ===")
+    loopback_test()
+    print("=== SPI flash JEDEC test ===")
+    flash_jedec_test()


### PR DESCRIPTION

### Summary
Add a minimal machine.SPI implementation with empty methods for init, deinit, transfer, and print.

This introduces the machine.SPI type so the port can build and link successfully while SPI functionality is implemented incrementally in follow-up commits.

Changes across files:
- mpconfigport.h: Enable MICROPY_PY_MACHINE_SPI and disable MICROPY_PY_MACHINE_SOFTSPI.
- modmachine.c: Register the SPI type in the machine module globals.
- Makefile: Add machine_spi.c to MOD_SRC_C and cy_scb_spi.c to PSE_LIB_SRC_C.
- machine_spi.c: Define the machine.SPI type and its methods.

### Testing

No tests at this stage of development
locally tested 

