### PR TITLE
Spi target and transfer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "cmake.sourceDirectory": "/home/ajaynagzarka/machine-spi/micropython-psoc-edge/ports/rp2"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "cmake.sourceDirectory": "/home/ajaynagzarka/machine-spi/micropython-psoc-edge/ports/rp2"
+}

--- a/ports/psoc-edge/Makefile
+++ b/ports/psoc-edge/Makefile
@@ -314,6 +314,7 @@ MOD_SRC_C += \
 	machine_ipc.c \
 	machine_scb.c \
 	machine_spi.c \
+	machine_spi_target.c \
 
 ifeq ($(MICROPY_PY_EXT_FLASH),1)
 	CFLAGS += -DMICROPY_ENABLE_EXT_QSPI_FLASH=1

--- a/ports/psoc-edge/machine_spi.c
+++ b/ports/psoc-edge/machine_spi.c
@@ -36,8 +36,6 @@
 #include "genhdr/pins_af.h"
 #include "mplogger.h"
 #include "machine_scb.h"
-
-// Port-specific include
 #include "modmachine.h"
 
 #define DEFAULT_SPI_BAUDRATE    (115200)
@@ -115,23 +113,23 @@ static void machine_spi_scb_isr(mp_obj_t hw_spi_obj) {
 }
 
 static void machine_spi_hw_init(machine_spi_obj_t *self) {
-    // Validatition condition
-    // Disabled for now [testing purpose] – assumes parameters are already validated
-    // polarity/phase: 0 or 1
-    // bits: must be 8
-    // firstbit: MSB or LSB
-
-
-    // if ((self->polarity > 1U) || (self->phase > 1U)) {
-    //     mp_raise_ValueError(MP_ERROR_TEXT("polarity/phase must be 0 or 1"));
-    // }
-    // if (self->bits != 8U) {
-    //     mp_raise_ValueError(MP_ERROR_TEXT("bits must be 8"));
-    // }
-    // if ((self->firstbit != MICROPY_PY_MACHINE_SPI_MSB) &&
-    //     (self->firstbit != MICROPY_PY_MACHINE_SPI_LSB)) {
-    //     mp_raise_ValueError(MP_ERROR_TEXT("invalid firstbit"));
-    // }
+    // Input validation
+    if (self->baudrate == 0) {
+        mp_raise_ValueError(MP_ERROR_TEXT("baudrate must be > 0"));
+    }
+    if ((self->polarity > 1U) || (self->phase > 1U)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("polarity/phase must be 0 or 1"));
+    }
+    if (self->bits != 8U) {
+        mp_raise_ValueError(MP_ERROR_TEXT("bits must be 8"));
+    }
+    if ((self->firstbit != MICROPY_PY_MACHINE_SPI_MSB) &&
+        (self->firstbit != MICROPY_PY_MACHINE_SPI_LSB)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("invalid firstbit"));
+    }
+    if (self->sck == NULL || self->mosi == NULL || self->miso == NULL) {
+        mp_raise_ValueError(MP_ERROR_TEXT("sck, mosi, and miso pins are required"));
+    }
 
     // Pin config → discovers SCB unit
     // CS/SSEL is managed externally by the user via machine.Pin
@@ -238,34 +236,31 @@ static void machine_spi_hw_init(machine_spi_obj_t *self) {
         .masterSlaveIntEnableMask = 0UL,
     };
 
-    // Init + enable [Initialize SPI hardware]
+    // Initialize SPI hardware
     cy_en_scb_spi_status_t result =
         Cy_SCB_SPI_Init(self->scb_obj->scb, &self->cfg, &self->ctx);
 
     if (result != CY_SCB_SPI_SUCCESS) {
-        // Cleanup on failure
         machine_scb_obj_free(self->scb_obj);
         self->scb_obj = NULL;
         mp_raise_msg_varg(&mp_type_ValueError,
             MP_ERROR_TEXT("SPI init failed: 0x%lx"), (uint32_t)result);
     }
-    // Enable interrupts and start SPI
+
     sys_int_init(&self->scb_obj->irq);
     Cy_SCB_SPI_Enable(self->scb_obj->scb);
 }
 
-// Disables the peripheral, resets registers, frees the interrupt,
 static void machine_spi_hw_deinit(machine_spi_obj_t *self) {
-    Cy_SCB_SPI_Disable(self->scb_obj->scb, &self->ctx);     // Disable SPI operation and stop any ongoing transfers
-    Cy_SCB_SPI_DeInit(self->scb_obj->scb);                  // Reset SPI hardware registers to default state
-    sys_int_deinit(&self->scb_obj->irq);                    // Disable and free the SPI interrupt
-    Cy_SysClk_PeriPclkDisableDivider(self->scb_obj->clk, SPI_CLK_DIV_TYPE, self->div_num);  // Disable the peripheral clock divider assigned to this SPI instance
-    machine_scb_obj_free(self->scb_obj);                    // Release the SCB instance back to the pool
-    self->scb_obj = NULL;                                   // Mark SPI object as deinitialized
+    Cy_SCB_SPI_Disable(self->scb_obj->scb, &self->ctx);
+    Cy_SCB_SPI_DeInit(self->scb_obj->scb);
+    sys_int_deinit(&self->scb_obj->irq);
+    Cy_SysClk_PeriPclkDisableDivider(self->scb_obj->clk, SPI_CLK_DIV_TYPE, self->div_num);
+    machine_scb_obj_free(self->scb_obj);
+    self->scb_obj = NULL;
 }
 
-// Initialize or reconfigure an SPI object based on keyword arguments
-// Shared between the constructor (make_new) and SPI.init() method
+// Shared argument parser used by the constructor (make_new).
 static void machine_spi_init_helper(machine_spi_obj_t *self, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_id, ARG_baudrate, ARG_polarity, ARG_phase, ARG_bits,
            ARG_firstbit, ARG_sck, ARG_mosi, ARG_miso };
@@ -388,10 +383,46 @@ static void machine_spi_transfer(mp_obj_base_t *self_in,
     size_t len,
     const uint8_t *src,
     uint8_t *dest) {
-    // TODO: implement hardware-specific SPI transfer
-}
+    machine_spi_obj_t *self = (machine_spi_obj_t *)self_in;
 
-/* SPI protocol table  */
+    if (len == 0) {
+        return;
+    }
+
+    // Prepare TX buffer: if src is NULL (read-only), send 0xFF fill bytes
+    uint8_t tx_fill[len];
+    const uint8_t *tx_buf = src;
+    if (tx_buf == NULL) {
+        memset(tx_fill, 0xFF, len);
+        tx_buf = tx_fill;
+    }
+
+    // Prepare RX buffer: if dest is NULL (write-only), use a dummy buffer
+    uint8_t rx_dummy[len];
+    uint8_t *rx_buf = dest;
+    if (rx_buf == NULL) {
+        rx_buf = rx_dummy;
+    }
+
+    // Start full-duplex transfer (interrupt-driven via ISR)
+    cy_en_scb_spi_status_t status = Cy_SCB_SPI_Transfer(
+        self->scb_obj->scb, (void *)tx_buf, rx_buf, len, &self->ctx);
+
+    if (status != CY_SCB_SPI_SUCCESS) {
+        mp_raise_msg_varg(&mp_type_OSError,
+            MP_ERROR_TEXT("SPI transfer failed: 0x%lx"), (uint32_t)status);
+    }
+
+    // Wait for transfer to complete
+    uint32_t start = mp_hal_ticks_us();
+    while (Cy_SCB_SPI_GetTransferStatus(self->scb_obj->scb, &self->ctx) & CY_SCB_SPI_TRANSFER_ACTIVE) {
+        if (mp_hal_ticks_us() - start > self->timeout) {
+            Cy_SCB_SPI_AbortTransfer(self->scb_obj->scb, &self->ctx);
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("SPI transfer timeout"));
+        }
+        MICROPY_EVENT_POLL_HOOK
+    }
+}
 
 static const mp_machine_spi_p_t machine_spi_p = {
     .init = machine_spi_init,
@@ -399,12 +430,14 @@ static const mp_machine_spi_p_t machine_spi_p = {
     .transfer = machine_spi_transfer,
 };
 
-/* SPi print */
-
 static void machine_spi_print(const mp_print_t *print,
     mp_obj_t self_in,
     mp_print_kind_t kind) {
-    mp_printf(print, "SPI()");
+    machine_spi_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    mp_printf(print, "SPI(baudrate=%u, polarity=%u, phase=%u, bits=%u, firstbit=%s, sck='%q', mosi='%q', miso='%q')",
+        self->baudrate, self->polarity, self->phase, self->bits,
+        self->firstbit == MICROPY_PY_MACHINE_SPI_MSB ? "MSB" : "LSB",
+        self->sck->name, self->mosi->name, self->miso->name);
 }
 
 // Create and initialize a new machine.SPI object from Python
@@ -425,6 +458,9 @@ mp_obj_t mp_machine_spi_make_new(const mp_obj_type_t *type, size_t n_args, size_
     self->firstbit = MICROPY_PY_MACHINE_SPI_MSB;
     self->timeout = DEFAULT_SPI_TIMEOUT;
     self->scb_obj = NULL;
+    self->sck = NULL;
+    self->mosi = NULL;
+    self->miso = NULL;
 
     // Delegate argument parsing and initialization to init_helper
     nlr_buf_t nlr;
@@ -448,3 +484,11 @@ MP_DEFINE_CONST_OBJ_TYPE(
     protocol, &machine_spi_p,
     locals_dict, &mp_machine_spi_locals_dict
     );
+
+void machine_spi_deinit_all(void) {
+    for (uint8_t i = 0; i < MICROPY_PY_MACHINE_SPI_NUM_ENTRIES; i++) {
+        if (machine_hw_spi_obj[i] != NULL) {
+            machine_spi_deinit((mp_obj_base_t *)machine_hw_spi_obj[i]);
+        }
+    }
+}

--- a/ports/psoc-edge/machine_spi.c
+++ b/ports/psoc-edge/machine_spi.c
@@ -4,6 +4,24 @@
  * The MIT License (MIT)
  *
  * Copyright (c) 2022-2026 Infineon Technologies AG
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
  */
 
 #include "py/runtime.h"
@@ -32,8 +50,6 @@
 #define SPI_CLK_DIV_TYPE        CY_SYSCLK_DIV_8_BIT
 #define SPI_CLK_DIV_BASE        (3U)
 
-// Lookup table: maps SCB unit number → PeriGroupSlaveInit arguments.
-// Populated at compile time via the board-generated X-macro.
 typedef struct {
     uint32_t peri_nr;
     uint32_t group_nr;
@@ -41,6 +57,8 @@ typedef struct {
     uint32_t clk_hf_nr;
 } machine_scb_group_info_t;
 
+// The entry is indexed by SCB unit number and later used to enable
+// the correct peripheral group/clock path for that SCB.
 #define SCB_GROUP_ENTRY(n) \
     [n] = { \
         .peri_nr = CY_MMIO_SCB##n##_PERI_NR, \
@@ -73,6 +91,192 @@ typedef struct _machine_spi_obj_t {
     cy_stc_scb_spi_context_t ctx;
 } machine_spi_obj_t;
 
+machine_spi_obj_t *machine_hw_spi_obj[MICROPY_PY_MACHINE_SPI_NUM_ENTRIES] = { NULL };
+
+static inline machine_spi_obj_t *machine_hw_spi_obj_alloc(void) {
+    for (uint8_t i = 0; i < MICROPY_PY_MACHINE_SPI_NUM_ENTRIES; i++) {
+        if (machine_hw_spi_obj[i] == NULL) {
+            machine_hw_spi_obj[i] = mp_obj_malloc(machine_spi_obj_t, &machine_spi_type);
+            machine_hw_spi_obj[i]->div_num = SPI_CLK_DIV_BASE + i;
+            return machine_hw_spi_obj[i];
+        }
+    }
+    return NULL;
+}
+
+static inline void machine_hw_spi_obj_free(machine_spi_obj_t *spi_obj) {
+    for (uint8_t i = 0; i < MICROPY_PY_MACHINE_SPI_NUM_ENTRIES; i++) {
+        if (machine_hw_spi_obj[i] == spi_obj) {
+            machine_hw_spi_obj[i] = NULL;
+        }
+    }
+}
+
+static void machine_spi_scb_isr(mp_obj_t hw_spi_obj) {
+    machine_spi_obj_t *self = MP_OBJ_TO_PTR(hw_spi_obj);
+    Cy_SCB_SPI_Interrupt(self->scb_obj->scb, &self->ctx);
+}
+
+static void machine_spi_hw_init(machine_spi_obj_t *self) {
+    // 1. Validate
+    if ((self->polarity > 1U) || (self->phase > 1U)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("polarity/phase must be 0 or 1"));
+    }
+    if (self->bits != 8U) {
+        mp_raise_ValueError(MP_ERROR_TEXT("bits must be 8"));
+    }
+    if ((self->firstbit != MICROPY_PY_MACHINE_SPI_MSB) &&
+        (self->firstbit != MICROPY_PY_MACHINE_SPI_LSB)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("invalid firstbit"));
+    }
+    if (self->is_slave && !self->has_ssel) {
+        mp_raise_ValueError(MP_ERROR_TEXT("slave mode requires ssel pin"));
+    }
+
+    // 2. Pin config → discovers SCB unit
+    uint8_t scb_unit = 0;
+    if (self->has_ssel) {
+        const mp_hal_pin_af_config_t spi_pins_config[] = {
+            MP_HAL_PIN_AF_CONF(self->sck,
+                self->is_slave ? CY_GPIO_DM_HIGHZ : CY_GPIO_DM_STRONG_IN_OFF,
+                1, MACHINE_PIN_AF_SIGNAL_SPI_CLK),
+            MP_HAL_PIN_AF_CONF(self->mosi,
+                self->is_slave ? CY_GPIO_DM_HIGHZ : CY_GPIO_DM_STRONG_IN_OFF,
+                1, MACHINE_PIN_AF_SIGNAL_SPI_MOSI),
+            MP_HAL_PIN_AF_CONF(self->miso,
+                self->is_slave ? CY_GPIO_DM_STRONG_IN_OFF : CY_GPIO_DM_HIGHZ,
+                0, MACHINE_PIN_AF_SIGNAL_SPI_MISO),
+            MP_HAL_PIN_AF_CONF(self->ssel,
+                CY_GPIO_DM_HIGHZ, 0,
+                MACHINE_PIN_AF_SIGNAL_SPI_SELECT0),
+        };
+        scb_unit = spi_pins_config[0].af->unit;
+        mp_hal_periph_pins_af_config(spi_pins_config, 4);
+    } else {
+        const mp_hal_pin_af_config_t spi_pins_config[] = {
+            MP_HAL_PIN_AF_CONF(self->sck,
+                CY_GPIO_DM_STRONG_IN_OFF, 1,
+                MACHINE_PIN_AF_SIGNAL_SPI_CLK),
+            MP_HAL_PIN_AF_CONF(self->mosi,
+                CY_GPIO_DM_STRONG_IN_OFF, 1,
+                MACHINE_PIN_AF_SIGNAL_SPI_MOSI),
+            MP_HAL_PIN_AF_CONF(self->miso,
+                CY_GPIO_DM_HIGHZ, 0,
+                MACHINE_PIN_AF_SIGNAL_SPI_MISO),
+        };
+        scb_unit = spi_pins_config[0].af->unit;
+        mp_hal_periph_pins_af_config(spi_pins_config, 3);
+    }
+
+    // 3. Power on peripheral group
+    const machine_scb_group_info_t *gi = &scb_group_table[scb_unit];
+    Cy_SysClk_PeriGroupSlaveInit(gi->peri_nr, gi->group_nr,
+        gi->slave_nr, gi->clk_hf_nr);
+
+    // 4. Allocate SCB
+    self->scb_obj = machine_scb_obj_alloc(scb_unit, self,
+        machine_spi_scb_isr);
+
+    // 5. Clock divider (master only)
+    uint32_t actual_clk_scb = 0;
+    if (!self->is_slave) {
+        Cy_SysClk_PeriPclkDisableDivider(self->scb_obj->clk,
+            SPI_CLK_DIV_TYPE, self->div_num);
+        Cy_SysClk_PeriPclkAssignDivider(self->scb_obj->clk,
+            SPI_CLK_DIV_TYPE, self->div_num);
+        Cy_SysClk_PeriPclkSetDivider(self->scb_obj->clk,
+            SPI_CLK_DIV_TYPE, self->div_num, 0U);
+        Cy_SysClk_PeriPclkEnableDivider(self->scb_obj->clk,
+            SPI_CLK_DIV_TYPE, self->div_num);
+
+        uint32_t clk_hf_freq = Cy_SysClk_PeriPclkGetFrequency(
+            self->scb_obj->clk, SPI_CLK_DIV_TYPE, self->div_num);
+
+        uint32_t div_val = clk_hf_freq / (self->baudrate * SPI_OVERSAMPLE);
+        if (div_val > 0U) {
+            div_val--;
+        }
+
+        Cy_SysClk_PeriPclkDisableDivider(self->scb_obj->clk,
+            SPI_CLK_DIV_TYPE, self->div_num);
+        Cy_SysClk_PeriPclkSetDivider(self->scb_obj->clk,
+            SPI_CLK_DIV_TYPE, self->div_num, div_val);
+        Cy_SysClk_PeriPclkEnableDivider(self->scb_obj->clk,
+            SPI_CLK_DIV_TYPE, self->div_num);
+
+        actual_clk_scb = Cy_SysClk_PeriPclkGetFrequency(
+            self->scb_obj->clk, SPI_CLK_DIV_TYPE, self->div_num);
+        mplogger_print("SPI clk_hf=%u, div=%u, clk_scb=%u, baud=%u\n",
+            clk_hf_freq, div_val, actual_clk_scb,
+            actual_clk_scb / SPI_OVERSAMPLE);
+    }
+
+    // 6. PDL config struct
+    cy_en_scb_spi_sclk_mode_t sclk_mode;
+    if (self->polarity == 0 && self->phase == 0) {
+        sclk_mode = CY_SCB_SPI_CPHA0_CPOL0;
+    } else if (self->polarity == 0 && self->phase == 1) {
+        sclk_mode = CY_SCB_SPI_CPHA1_CPOL0;
+    } else if (self->polarity == 1 && self->phase == 0) {
+        sclk_mode = CY_SCB_SPI_CPHA0_CPOL1;
+    } else {
+        sclk_mode = CY_SCB_SPI_CPHA1_CPOL1;
+    }
+
+    self->cfg = (cy_stc_scb_spi_config_t) {
+        .spiMode = self->is_slave ? CY_SCB_SPI_SLAVE : CY_SCB_SPI_MASTER,
+        .subMode = CY_SCB_SPI_MOTOROLA,
+        .sclkMode = sclk_mode,
+        .parity = CY_SCB_SPI_PARITY_NONE,
+        .dropOnParityError = false,
+        .oversample = self->is_slave ? 0U : SPI_OVERSAMPLE,
+        .rxDataWidth = self->bits,
+        .txDataWidth = self->bits,
+        .enableMsbFirst = (self->firstbit == MICROPY_PY_MACHINE_SPI_MSB),
+        .enableInputFilter = false,
+        .enableFreeRunSclk = false,
+        .enableMisoLateSample = self->is_slave ? false : true,
+        .enableTransferSeparation = false,
+        .ssPolarity =
+            ((CY_SCB_SPI_ACTIVE_LOW << CY_SCB_SPI_SLAVE_SELECT0) |
+                (CY_SCB_SPI_ACTIVE_LOW << CY_SCB_SPI_SLAVE_SELECT1) |
+                (CY_SCB_SPI_ACTIVE_LOW << CY_SCB_SPI_SLAVE_SELECT2) |
+                (CY_SCB_SPI_ACTIVE_LOW << CY_SCB_SPI_SLAVE_SELECT3)),
+        .ssSetupDelay = false,
+        .ssHoldDelay = false,
+        .ssInterFrameDelay = false,
+        .enableWakeFromSleep = false,
+        .rxFifoTriggerLevel = 0UL,
+        .rxFifoIntEnableMask = 0UL,
+        .txFifoTriggerLevel = 0UL,
+        .txFifoIntEnableMask = 0UL,
+        .masterSlaveIntEnableMask = 0UL,
+    };
+
+    // 7. Init + enable
+    cy_en_scb_spi_status_t result =
+        Cy_SCB_SPI_Init(self->scb_obj->scb, &self->cfg, &self->ctx);
+    if (result != CY_SCB_SPI_SUCCESS) {
+        machine_scb_obj_free(self->scb_obj);
+        self->scb_obj = NULL;
+        mp_raise_msg_varg(&mp_type_ValueError,
+            MP_ERROR_TEXT("SPI init failed: 0x%lx"), (uint32_t)result);
+    }
+
+    sys_int_init(&self->scb_obj->irq);
+    Cy_SCB_SPI_Enable(self->scb_obj->scb);
+}
+
+// Disables the peripheral, resets registers, frees the interrupt,
+static void machine_spi_hw_deinit(machine_spi_obj_t *self) {
+    Cy_SCB_SPI_Disable(self->scb_obj->scb, &self->ctx);
+    Cy_SCB_SPI_DeInit(self->scb_obj->scb);
+    sys_int_deinit(&self->scb_obj->irq);
+    Cy_SysClk_PeriPclkDisableDivider(self->scb_obj->clk, SPI_CLK_DIV_TYPE, self->div_num);
+    machine_scb_obj_free(self->scb_obj);
+    self->scb_obj = NULL;
+}
+
 /* Port SPI protocol callbacks  */
 
 static void machine_spi_init(mp_obj_base_t *self,
@@ -82,8 +286,12 @@ static void machine_spi_init(mp_obj_base_t *self,
     // hardware-specific init to be implemented by port
 }
 
-static void machine_spi_deinit(mp_obj_base_t *self) {
-    // hardware-specific deinit to be implemented by port
+static void machine_spi_deinit(mp_obj_base_t *self_in) {
+    machine_spi_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    if (self->scb_obj != NULL) {
+        machine_spi_hw_deinit(self);
+    }
+    machine_hw_spi_obj_free(self);
 }
 
 static void machine_spi_transfer(mp_obj_base_t *self,
@@ -93,7 +301,7 @@ static void machine_spi_transfer(mp_obj_base_t *self,
     // hardware-specific transfer to be implemented by port
 }
 
-/* SPI protocol table — REQUIRED BY TEMPLATE */
+/* SPI protocol table  */
 
 static const mp_machine_spi_p_t machine_spi_p = {
     .init = machine_spi_init,
@@ -101,18 +309,7 @@ static const mp_machine_spi_p_t machine_spi_p = {
     .transfer = machine_spi_transfer,
 };
 
-/* SPI object construction */
-
-static mp_obj_t machine_spi_make_new(const mp_obj_type_t *type,
-    size_t n_args,
-    size_t n_kw,
-    const mp_obj_t *all_args) {
-    machine_spi_obj_t *self =
-        mp_obj_malloc(machine_spi_obj_t, type);
-    return MP_OBJ_FROM_PTR(self);
-}
-
-/* SPI print helper */
+/* SPI print  */
 
 static void machine_spi_print(const mp_print_t *print,
     mp_obj_t self_in,
@@ -121,11 +318,74 @@ static void machine_spi_print(const mp_print_t *print,
 }
 
 
+mp_obj_t mp_machine_spi_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
+    mp_arg_check_num(n_args, n_kw, 0, 11, true);
+
+    // Argument definitions: sck/mosi/miso are required, rest have defaults
+    enum { ARG_id, ARG_baudrate, ARG_polarity, ARG_phase, ARG_bits,
+           ARG_firstbit, ARG_sck, ARG_mosi, ARG_miso, ARG_slave, ARG_ssel };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_id,       MP_ARG_INT, {.u_int = -1} },
+        { MP_QSTR_baudrate, MP_ARG_INT, {.u_int = DEFAULT_SPI_BAUDRATE} },
+        { MP_QSTR_polarity, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = DEFAULT_SPI_POLARITY} },
+        { MP_QSTR_phase,    MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = DEFAULT_SPI_PHASE} },
+        { MP_QSTR_bits,     MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = DEFAULT_SPI_BITS} },
+        { MP_QSTR_firstbit, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = MICROPY_PY_MACHINE_SPI_MSB} },
+        { MP_QSTR_sck,      MP_ARG_KW_ONLY | MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
+        { MP_QSTR_mosi,     MP_ARG_KW_ONLY | MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
+        { MP_QSTR_miso,     MP_ARG_KW_ONLY | MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
+        { MP_QSTR_slave,    MP_ARG_KW_ONLY | MP_ARG_BOOL, {.u_bool = false} },
+        { MP_QSTR_ssel,     MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
+    };
+
+    // Parse positional and keyword arguments from Python call
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    // Allocate from static pool (each slot has a unique clock divider index)
+    machine_spi_obj_t *self = machine_hw_spi_obj_alloc();
+    if (self == NULL) {
+        mp_raise_ValueError(MP_ERROR_TEXT("machine.SPI: Maximum number of SPI instances reached"));
+    }
+
+    // Store SPI parameters from parsed args
+    self->baudrate = args[ARG_baudrate].u_int;
+    self->polarity = args[ARG_polarity].u_int;
+    self->phase = args[ARG_phase].u_int;
+    self->bits = args[ARG_bits].u_int;
+    self->firstbit = args[ARG_firstbit].u_int;
+    self->is_slave = args[ARG_slave].u_bool;
+    self->timeout = DEFAULT_SPI_TIMEOUT;
+    self->scb_obj = NULL;
+
+    // Resolve pin name strings (e.g. 'P5_0') to internal pin objects
+    self->sck = mp_hal_get_pin_obj(args[ARG_sck].u_obj);
+    self->mosi = mp_hal_get_pin_obj(args[ARG_mosi].u_obj);
+    self->miso = mp_hal_get_pin_obj(args[ARG_miso].u_obj);
+    self->has_ssel = args[ARG_ssel].u_obj != mp_const_none;
+    if (self->has_ssel) {
+        self->ssel = mp_hal_get_pin_obj(args[ARG_ssel].u_obj);
+    }
+
+    // Initialize hardware with try/except pattern (nlr = non-local return).
+    // If hw_init raises, free the pool slot before re-raising to Python.
+    nlr_buf_t nlr;
+    if (nlr_push(&nlr) == 0) {
+        machine_spi_hw_init(self);
+        nlr_pop();
+    } else {
+        machine_hw_spi_obj_free(self);
+        nlr_jump(nlr.ret_val);
+    }
+
+    return MP_OBJ_FROM_PTR(self);
+}
+
 MP_DEFINE_CONST_OBJ_TYPE(
     machine_spi_type,
     MP_QSTR_SPI,
     MP_TYPE_FLAG_NONE,
-    make_new, machine_spi_make_new,
+    make_new, mp_machine_spi_make_new,
     print, machine_spi_print,
     protocol, &machine_spi_p,
     locals_dict, &mp_machine_spi_locals_dict

--- a/ports/psoc-edge/machine_spi.c
+++ b/ports/psoc-edge/machine_spi.c
@@ -118,20 +118,21 @@ static void machine_spi_scb_isr(mp_obj_t hw_spi_obj) {
 }
 
 static void machine_spi_hw_init(machine_spi_obj_t *self) {
-    // 1. Validate
-    if ((self->polarity > 1U) || (self->phase > 1U)) {
-        mp_raise_ValueError(MP_ERROR_TEXT("polarity/phase must be 0 or 1"));
-    }
-    if (self->bits != 8U) {
-        mp_raise_ValueError(MP_ERROR_TEXT("bits must be 8"));
-    }
-    if ((self->firstbit != MICROPY_PY_MACHINE_SPI_MSB) &&
-        (self->firstbit != MICROPY_PY_MACHINE_SPI_LSB)) {
-        mp_raise_ValueError(MP_ERROR_TEXT("invalid firstbit"));
-    }
-    if (self->is_slave && !self->has_ssel) {
-        mp_raise_ValueError(MP_ERROR_TEXT("slave mode requires ssel pin"));
-    }
+    // Validatition condition
+    // // 1. Validate
+    // if ((self->polarity > 1U) || (self->phase > 1U)) {
+    //     mp_raise_ValueError(MP_ERROR_TEXT("polarity/phase must be 0 or 1"));
+    // }
+    // if (self->bits != 8U) {
+    //     mp_raise_ValueError(MP_ERROR_TEXT("bits must be 8"));
+    // }
+    // if ((self->firstbit != MICROPY_PY_MACHINE_SPI_MSB) &&
+    //     (self->firstbit != MICROPY_PY_MACHINE_SPI_LSB)) {
+    //     mp_raise_ValueError(MP_ERROR_TEXT("invalid firstbit"));
+    // }
+    // if (self->is_slave && !self->has_ssel) {
+    //     mp_raise_ValueError(MP_ERROR_TEXT("slave mode requires ssel pin"));
+    // }
 
     // 2. Pin config → discovers SCB unit
     uint8_t scb_unit = 0;
@@ -283,7 +284,7 @@ static void machine_spi_init(mp_obj_base_t *self,
     size_t n_args,
     const mp_obj_t *pos_args,
     mp_map_t *kw_args) {
-    // hardware-specific init to be implemented by port
+    // hardware-specific init to be implemented
 }
 
 static void machine_spi_deinit(mp_obj_base_t *self_in) {
@@ -294,11 +295,44 @@ static void machine_spi_deinit(mp_obj_base_t *self_in) {
     machine_hw_spi_obj_free(self);
 }
 
-static void machine_spi_transfer(mp_obj_base_t *self,
+static void machine_spi_transfer(mp_obj_base_t *self_in,
     size_t len,
     const uint8_t *src,
     uint8_t *dest) {
-    // hardware-specific transfer to be implemented by port
+    machine_spi_obj_t *self = (machine_spi_obj_t *)self_in;
+    CySCB_Type *base = self->scb_obj->scb;
+
+    if (dest != NULL) {
+        // Full-duplex or read-only (PDL accepts src=NULL, sends default TX byte)
+        Cy_SCB_SPI_Transfer(base, (uint8_t *)src, dest, len, &self->ctx);
+
+        uint32_t start = mp_hal_ticks_ms();
+        while (Cy_SCB_SPI_GetTransferStatus(base, &self->ctx) & CY_SCB_SPI_TRANSFER_ACTIVE) {
+            if ((mp_hal_ticks_ms() - start) > self->timeout) {
+                Cy_SCB_SPI_AbortTransfer(base, &self->ctx);
+                mp_raise_OSError(MP_ETIMEDOUT);
+            }
+            MICROPY_EVENT_POLL_HOOK;
+        }
+    } else {
+        // Write-only: PDL requires a valid RX buffer, use stack chunk
+        uint8_t rx_dummy[64];
+        size_t offset = 0;
+        while (offset < len) {
+            size_t chunk = (len - offset) < 64 ? (len - offset) : 64;
+            Cy_SCB_SPI_Transfer(base, (uint8_t *)&src[offset], rx_dummy, chunk, &self->ctx);
+
+            uint32_t start = mp_hal_ticks_ms();
+            while (Cy_SCB_SPI_GetTransferStatus(base, &self->ctx) & CY_SCB_SPI_TRANSFER_ACTIVE) {
+                if ((mp_hal_ticks_ms() - start) > self->timeout) {
+                    Cy_SCB_SPI_AbortTransfer(base, &self->ctx);
+                    mp_raise_OSError(MP_ETIMEDOUT);
+                }
+                MICROPY_EVENT_POLL_HOOK;
+            }
+            offset += chunk;
+        }
+    }
 }
 
 /* SPI protocol table  */
@@ -309,12 +343,26 @@ static const mp_machine_spi_p_t machine_spi_p = {
     .transfer = machine_spi_transfer,
 };
 
-/* SPI print  */
+/* SPi print */
 
 static void machine_spi_print(const mp_print_t *print,
     mp_obj_t self_in,
     mp_print_kind_t kind) {
-    mp_printf(print, "SPI()");
+    machine_spi_obj_t *self = MP_OBJ_TO_PTR(self_in);
+
+    // print the numeric fields
+    mp_printf(print, "SPI(baudrate=%u, polarity=%u, phase=%u, bits=%u", self->baudrate, self->polarity, self->phase, self->bits);
+    // print the firstbit field as "MSB" or "LSB"
+    mp_printf(print, ", firstbit=%s", (self->firstbit == MICROPY_PY_MACHINE_SPI_MSB) ? "MSB" : "LSB");
+    // print pin names
+    mp_printf(print, ", sck=%s, mosi=%s, miso=%s", mp_hal_pin_name(self->sck), mp_hal_pin_name(self->mosi), mp_hal_pin_name(self->miso));
+
+    // optional ssel pin
+    if (self->has_ssel) {
+        mp_printf(print, ", ssel=%s", mp_hal_pin_name(self->ssel));
+
+        mp_printf(print, ")");
+    }
 }
 
 

--- a/ports/psoc-edge/machine_spi.c
+++ b/ports/psoc-edge/machine_spi.c
@@ -4,57 +4,96 @@
  * The MIT License (MIT)
  *
  * Copyright (c) 2022-2026 Infineon Technologies AG
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
  */
 
-// mpy includes
-#include "extmod/modmachine.h"
 #include "py/runtime.h"
+#include "extmod/modmachine.h"
+#include <stdio.h>
+#include <string.h>
+#include "py/mphal.h"
+#include "py/mperrno.h"
+#include "cybsp.h"
+#include "cy_scb_spi.h"
+#include "cy_sysclk.h"
+#include "genhdr/pins_af.h"
+#include "mplogger.h"
+#include "machine_scb.h"
 
-// port-specific includes
+// Port-specific include
 #include "modmachine.h"
+
+#define DEFAULT_SPI_BAUDRATE    (115200)
+#define DEFAULT_SPI_POLARITY    (0)
+#define DEFAULT_SPI_PHASE       (0)
+#define DEFAULT_SPI_BITS        (8)
+#define DEFAULT_SPI_TIMEOUT     (50000)
+
+#define SPI_OVERSAMPLE          (4U)
+#define SPI_CLK_DIV_TYPE        CY_SYSCLK_DIV_8_BIT
+#define SPI_CLK_DIV_BASE        (3U)
+
+// Lookup table: maps SCB unit number → PeriGroupSlaveInit arguments.
+// Populated at compile time via the board-generated X-macro.
+typedef struct {
+    uint32_t peri_nr;
+    uint32_t group_nr;
+    uint32_t slave_nr;
+    uint32_t clk_hf_nr;
+} machine_scb_group_info_t;
+
+#define SCB_GROUP_ENTRY(n) \
+    [n] = { \
+        .peri_nr = CY_MMIO_SCB##n##_PERI_NR, \
+        .group_nr = CY_MMIO_SCB##n##_GROUP_NR, \
+        .slave_nr = CY_MMIO_SCB##n##_SLAVE_NR, \
+        .clk_hf_nr = CY_MMIO_SCB##n##_CLK_HF_NR, \
+    },
+
+static const machine_scb_group_info_t scb_group_table[] = {
+    MICROPY_PY_MACHINE_FOR_ALL_SCB(SCB_GROUP_ENTRY)
+};
 
 typedef struct _machine_spi_obj_t {
     mp_obj_base_t base;
+    mp_hal_pin_obj_t sck;
+    mp_hal_pin_obj_t mosi;
+    mp_hal_pin_obj_t miso;
+    mp_hal_pin_obj_t ssel;
+    bool has_ssel;
+    bool is_slave;
+    uint32_t baudrate;
+    uint8_t polarity;
+    uint8_t phase;
+    uint8_t bits;
+    uint8_t firstbit;
+    uint32_t timeout;
+    uint8_t div_num;
+    machine_scb_obj_t *scb_obj;
+    cy_stc_scb_spi_config_t cfg;
+    cy_stc_scb_spi_context_t ctx;
 } machine_spi_obj_t;
 
-/******************************************************************************/
-// MicroPython bindings for machine SPI protocol (stubs)
+/* Port SPI protocol callbacks  */
 
-static void machine_spi_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
-    mp_printf(print, "SPI()");
+static void machine_spi_init(mp_obj_base_t *self,
+    size_t n_args,
+    const mp_obj_t *pos_args,
+    mp_map_t *kw_args) {
+    // hardware-specific init to be implemented by port
 }
 
-mp_obj_t mp_machine_spi_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
-    machine_spi_obj_t *self = mp_obj_malloc(machine_spi_obj_t, &machine_spi_type);
-    return MP_OBJ_FROM_PTR(self);
+static void machine_spi_deinit(mp_obj_base_t *self) {
+    // hardware-specific deinit to be implemented by port
 }
 
-static void machine_spi_init(mp_obj_base_t *self_in, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static void machine_spi_transfer(mp_obj_base_t *self,
+    size_t len,
+    const uint8_t *src,
+    uint8_t *dest) {
+    // hardware-specific transfer to be implemented by port
 }
 
-static void machine_spi_deinit(mp_obj_base_t *self_in) {
-}
-
-static void machine_spi_transfer(mp_obj_base_t *self_in, size_t len, const uint8_t *src, uint8_t *dest) {
-}
+/* SPI protocol table — REQUIRED BY TEMPLATE */
 
 static const mp_machine_spi_p_t machine_spi_p = {
     .init = machine_spi_init,
@@ -62,11 +101,31 @@ static const mp_machine_spi_p_t machine_spi_p = {
     .transfer = machine_spi_transfer,
 };
 
+/* SPI object construction */
+
+static mp_obj_t machine_spi_make_new(const mp_obj_type_t *type,
+    size_t n_args,
+    size_t n_kw,
+    const mp_obj_t *all_args) {
+    machine_spi_obj_t *self =
+        mp_obj_malloc(machine_spi_obj_t, type);
+    return MP_OBJ_FROM_PTR(self);
+}
+
+/* SPI print helper */
+
+static void machine_spi_print(const mp_print_t *print,
+    mp_obj_t self_in,
+    mp_print_kind_t kind) {
+    mp_printf(print, "SPI()");
+}
+
+
 MP_DEFINE_CONST_OBJ_TYPE(
     machine_spi_type,
     MP_QSTR_SPI,
     MP_TYPE_FLAG_NONE,
-    make_new, mp_machine_spi_make_new,
+    make_new, machine_spi_make_new,
     print, machine_spi_print,
     protocol, &machine_spi_p,
     locals_dict, &mp_machine_spi_locals_dict

--- a/ports/psoc-edge/machine_spi.c
+++ b/ports/psoc-edge/machine_spi.c
@@ -76,9 +76,6 @@ typedef struct _machine_spi_obj_t {
     mp_hal_pin_obj_t sck;
     mp_hal_pin_obj_t mosi;
     mp_hal_pin_obj_t miso;
-    mp_hal_pin_obj_t ssel;
-    bool has_ssel;
-    bool is_slave;
     uint32_t baudrate;
     uint8_t polarity;
     uint8_t phase;
@@ -119,7 +116,12 @@ static void machine_spi_scb_isr(mp_obj_t hw_spi_obj) {
 
 static void machine_spi_hw_init(machine_spi_obj_t *self) {
     // Validatition condition
-    // // 1. Validate
+    // Disabled for now [testing purpose] – assumes parameters are already validated
+    // polarity/phase: 0 or 1
+    // bits: must be 8
+    // firstbit: MSB or LSB
+
+
     // if ((self->polarity > 1U) || (self->phase > 1U)) {
     //     mp_raise_ValueError(MP_ERROR_TEXT("polarity/phase must be 0 or 1"));
     // }
@@ -130,89 +132,70 @@ static void machine_spi_hw_init(machine_spi_obj_t *self) {
     //     (self->firstbit != MICROPY_PY_MACHINE_SPI_LSB)) {
     //     mp_raise_ValueError(MP_ERROR_TEXT("invalid firstbit"));
     // }
-    // if (self->is_slave && !self->has_ssel) {
-    //     mp_raise_ValueError(MP_ERROR_TEXT("slave mode requires ssel pin"));
-    // }
 
-    // 2. Pin config → discovers SCB unit
-    uint8_t scb_unit = 0;
-    if (self->has_ssel) {
-        const mp_hal_pin_af_config_t spi_pins_config[] = {
-            MP_HAL_PIN_AF_CONF(self->sck,
-                self->is_slave ? CY_GPIO_DM_HIGHZ : CY_GPIO_DM_STRONG_IN_OFF,
-                1, MACHINE_PIN_AF_SIGNAL_SPI_CLK),
-            MP_HAL_PIN_AF_CONF(self->mosi,
-                self->is_slave ? CY_GPIO_DM_HIGHZ : CY_GPIO_DM_STRONG_IN_OFF,
-                1, MACHINE_PIN_AF_SIGNAL_SPI_MOSI),
-            MP_HAL_PIN_AF_CONF(self->miso,
-                self->is_slave ? CY_GPIO_DM_STRONG_IN_OFF : CY_GPIO_DM_HIGHZ,
-                0, MACHINE_PIN_AF_SIGNAL_SPI_MISO),
-            MP_HAL_PIN_AF_CONF(self->ssel,
-                CY_GPIO_DM_HIGHZ, 0,
-                MACHINE_PIN_AF_SIGNAL_SPI_SELECT0),
-        };
-        scb_unit = spi_pins_config[0].af->unit;
-        mp_hal_periph_pins_af_config(spi_pins_config, 4);
-    } else {
-        const mp_hal_pin_af_config_t spi_pins_config[] = {
-            MP_HAL_PIN_AF_CONF(self->sck,
-                CY_GPIO_DM_STRONG_IN_OFF, 1,
-                MACHINE_PIN_AF_SIGNAL_SPI_CLK),
-            MP_HAL_PIN_AF_CONF(self->mosi,
-                CY_GPIO_DM_STRONG_IN_OFF, 1,
-                MACHINE_PIN_AF_SIGNAL_SPI_MOSI),
-            MP_HAL_PIN_AF_CONF(self->miso,
-                CY_GPIO_DM_HIGHZ, 0,
-                MACHINE_PIN_AF_SIGNAL_SPI_MISO),
-        };
-        scb_unit = spi_pins_config[0].af->unit;
-        mp_hal_periph_pins_af_config(spi_pins_config, 3);
-    }
+    // Pin config → discovers SCB unit
+    // CS/SSEL is managed externally by the user via machine.Pin
+    const mp_hal_pin_af_config_t spi_pins_config[] = {
+        MP_HAL_PIN_AF_CONF(self->sck,
+            CY_GPIO_DM_STRONG_IN_OFF, 1,
+            MACHINE_PIN_AF_SIGNAL_SPI_CLK),
+        MP_HAL_PIN_AF_CONF(self->mosi,
+            CY_GPIO_DM_STRONG_IN_OFF, 1,
+            MACHINE_PIN_AF_SIGNAL_SPI_MOSI),
+        MP_HAL_PIN_AF_CONF(self->miso,
+            CY_GPIO_DM_HIGHZ, 0,
+            MACHINE_PIN_AF_SIGNAL_SPI_MISO),
+    };
+    uint8_t scb_unit = spi_pins_config[0].af->unit;
+    mp_hal_periph_pins_af_config(spi_pins_config, 3);
 
-    // 3. Power on peripheral group
+    // Power on the peripheral group that contains this SCB.
+    // Note: "Slave" in PeriGroupSlaveInit refers to the bus architecture
+    // (SCB is a slave on the internal PERI interconnect), not SPI slave mode.
     const machine_scb_group_info_t *gi = &scb_group_table[scb_unit];
     Cy_SysClk_PeriGroupSlaveInit(gi->peri_nr, gi->group_nr,
         gi->slave_nr, gi->clk_hf_nr);
 
-    // 4. Allocate SCB
+    // Allocate SCB
     self->scb_obj = machine_scb_obj_alloc(scb_unit, self,
         machine_spi_scb_isr);
 
-    // 5. Clock divider (master only)
-    uint32_t actual_clk_scb = 0;
-    if (!self->is_slave) {
-        Cy_SysClk_PeriPclkDisableDivider(self->scb_obj->clk,
-            SPI_CLK_DIV_TYPE, self->div_num);
-        Cy_SysClk_PeriPclkAssignDivider(self->scb_obj->clk,
-            SPI_CLK_DIV_TYPE, self->div_num);
-        Cy_SysClk_PeriPclkSetDivider(self->scb_obj->clk,
-            SPI_CLK_DIV_TYPE, self->div_num, 0U);
-        Cy_SysClk_PeriPclkEnableDivider(self->scb_obj->clk,
-            SPI_CLK_DIV_TYPE, self->div_num);
+    // Configure SPI clock divider
+    Cy_SysClk_PeriPclkDisableDivider(self->scb_obj->clk,
+        SPI_CLK_DIV_TYPE, self->div_num);
+    Cy_SysClk_PeriPclkAssignDivider(self->scb_obj->clk,
+        SPI_CLK_DIV_TYPE, self->div_num);
+    Cy_SysClk_PeriPclkSetDivider(self->scb_obj->clk,
+        SPI_CLK_DIV_TYPE, self->div_num, 0U);
+    Cy_SysClk_PeriPclkEnableDivider(self->scb_obj->clk,
+        SPI_CLK_DIV_TYPE, self->div_num);
 
-        uint32_t clk_hf_freq = Cy_SysClk_PeriPclkGetFrequency(
-            self->scb_obj->clk, SPI_CLK_DIV_TYPE, self->div_num);
+    // Get HF clock frequency and calculate divider value for desired baudrate
+    uint32_t clk_hf_freq = Cy_SysClk_PeriPclkGetFrequency(
+        self->scb_obj->clk, SPI_CLK_DIV_TYPE, self->div_num);
 
-        uint32_t div_val = clk_hf_freq / (self->baudrate * SPI_OVERSAMPLE);
-        if (div_val > 0U) {
-            div_val--;
-        }
-
-        Cy_SysClk_PeriPclkDisableDivider(self->scb_obj->clk,
-            SPI_CLK_DIV_TYPE, self->div_num);
-        Cy_SysClk_PeriPclkSetDivider(self->scb_obj->clk,
-            SPI_CLK_DIV_TYPE, self->div_num, div_val);
-        Cy_SysClk_PeriPclkEnableDivider(self->scb_obj->clk,
-            SPI_CLK_DIV_TYPE, self->div_num);
-
-        actual_clk_scb = Cy_SysClk_PeriPclkGetFrequency(
-            self->scb_obj->clk, SPI_CLK_DIV_TYPE, self->div_num);
-        mplogger_print("SPI clk_hf=%u, div=%u, clk_scb=%u, baud=%u\n",
-            clk_hf_freq, div_val, actual_clk_scb,
-            actual_clk_scb / SPI_OVERSAMPLE);
+    // Compute divider value for requested baudrate
+    uint32_t div_val = clk_hf_freq / (self->baudrate * SPI_OVERSAMPLE);
+    if (div_val > 0U) {
+        div_val--;
     }
 
-    // 6. PDL config struct
+    // Apply divider
+    Cy_SysClk_PeriPclkDisableDivider(self->scb_obj->clk,
+        SPI_CLK_DIV_TYPE, self->div_num);
+    Cy_SysClk_PeriPclkSetDivider(self->scb_obj->clk,
+        SPI_CLK_DIV_TYPE, self->div_num, div_val);
+    Cy_SysClk_PeriPclkEnableDivider(self->scb_obj->clk,
+        SPI_CLK_DIV_TYPE, self->div_num);
+
+    // Final SCB clock
+    uint32_t actual_clk_scb = Cy_SysClk_PeriPclkGetFrequency(
+        self->scb_obj->clk, SPI_CLK_DIV_TYPE, self->div_num);
+    mplogger_print("SPI clk_hf=%u, div=%u, clk_scb=%u, baud=%u\n",
+        clk_hf_freq, div_val, actual_clk_scb,
+        actual_clk_scb / SPI_OVERSAMPLE);
+
+    // Select SPI clock polarity and phase
     cy_en_scb_spi_sclk_mode_t sclk_mode;
     if (self->polarity == 0 && self->phase == 0) {
         sclk_mode = CY_SCB_SPI_CPHA0_CPOL0;
@@ -224,19 +207,20 @@ static void machine_spi_hw_init(machine_spi_obj_t *self) {
         sclk_mode = CY_SCB_SPI_CPHA1_CPOL1;
     }
 
+    // Populate PDL SPI configuration
     self->cfg = (cy_stc_scb_spi_config_t) {
-        .spiMode = self->is_slave ? CY_SCB_SPI_SLAVE : CY_SCB_SPI_MASTER,
+        .spiMode = CY_SCB_SPI_MASTER,
         .subMode = CY_SCB_SPI_MOTOROLA,
         .sclkMode = sclk_mode,
         .parity = CY_SCB_SPI_PARITY_NONE,
         .dropOnParityError = false,
-        .oversample = self->is_slave ? 0U : SPI_OVERSAMPLE,
+        .oversample = SPI_OVERSAMPLE,
         .rxDataWidth = self->bits,
         .txDataWidth = self->bits,
         .enableMsbFirst = (self->firstbit == MICROPY_PY_MACHINE_SPI_MSB),
         .enableInputFilter = false,
         .enableFreeRunSclk = false,
-        .enableMisoLateSample = self->is_slave ? false : true,
+        .enableMisoLateSample = true,
         .enableTransferSeparation = false,
         .ssPolarity =
             ((CY_SCB_SPI_ACTIVE_LOW << CY_SCB_SPI_SLAVE_SELECT0) |
@@ -254,37 +238,142 @@ static void machine_spi_hw_init(machine_spi_obj_t *self) {
         .masterSlaveIntEnableMask = 0UL,
     };
 
-    // 7. Init + enable
+    // Init + enable [Initialize SPI hardware]
     cy_en_scb_spi_status_t result =
         Cy_SCB_SPI_Init(self->scb_obj->scb, &self->cfg, &self->ctx);
+
     if (result != CY_SCB_SPI_SUCCESS) {
+        // Cleanup on failure
         machine_scb_obj_free(self->scb_obj);
         self->scb_obj = NULL;
         mp_raise_msg_varg(&mp_type_ValueError,
             MP_ERROR_TEXT("SPI init failed: 0x%lx"), (uint32_t)result);
     }
-
+    // Enable interrupts and start SPI
     sys_int_init(&self->scb_obj->irq);
     Cy_SCB_SPI_Enable(self->scb_obj->scb);
 }
 
 // Disables the peripheral, resets registers, frees the interrupt,
 static void machine_spi_hw_deinit(machine_spi_obj_t *self) {
-    Cy_SCB_SPI_Disable(self->scb_obj->scb, &self->ctx);
-    Cy_SCB_SPI_DeInit(self->scb_obj->scb);
-    sys_int_deinit(&self->scb_obj->irq);
-    Cy_SysClk_PeriPclkDisableDivider(self->scb_obj->clk, SPI_CLK_DIV_TYPE, self->div_num);
-    machine_scb_obj_free(self->scb_obj);
-    self->scb_obj = NULL;
+    Cy_SCB_SPI_Disable(self->scb_obj->scb, &self->ctx);     // Disable SPI operation and stop any ongoing transfers
+    Cy_SCB_SPI_DeInit(self->scb_obj->scb);                  // Reset SPI hardware registers to default state
+    sys_int_deinit(&self->scb_obj->irq);                    // Disable and free the SPI interrupt
+    Cy_SysClk_PeriPclkDisableDivider(self->scb_obj->clk, SPI_CLK_DIV_TYPE, self->div_num);  // Disable the peripheral clock divider assigned to this SPI instance
+    machine_scb_obj_free(self->scb_obj);                    // Release the SCB instance back to the pool
+    self->scb_obj = NULL;                                   // Mark SPI object as deinitialized
 }
 
-/* Port SPI protocol callbacks  */
+// Initialize or reconfigure an SPI object based on keyword arguments
+// Shared between the constructor (make_new) and SPI.init() method
+static void machine_spi_init_helper(machine_spi_obj_t *self, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
+    enum { ARG_id, ARG_baudrate, ARG_polarity, ARG_phase, ARG_bits,
+           ARG_firstbit, ARG_sck, ARG_mosi, ARG_miso };
 
-static void machine_spi_init(mp_obj_base_t *self,
-    size_t n_args,
-    const mp_obj_t *pos_args,
-    mp_map_t *kw_args) {
-    // hardware-specific init to be implemented
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_id,       MP_ARG_INT, {.u_int = -1} },
+        { MP_QSTR_baudrate, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = -1} },
+        { MP_QSTR_polarity, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = -1} },
+        { MP_QSTR_phase,    MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = -1} },
+        { MP_QSTR_bits,     MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = -1} },
+        { MP_QSTR_firstbit, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = -1} },
+        { MP_QSTR_sck,      MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
+        { MP_QSTR_mosi,     MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
+        { MP_QSTR_miso,     MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
+    };
+
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    bool reinit = false;
+
+    if (args[ARG_baudrate].u_int != -1) {
+        self->baudrate = args[ARG_baudrate].u_int;
+        reinit = true;
+    }
+    if (args[ARG_polarity].u_int != -1) {
+        self->polarity = args[ARG_polarity].u_int;
+        reinit = true;
+    }
+    if (args[ARG_phase].u_int != -1) {
+        self->phase = args[ARG_phase].u_int;
+        reinit = true;
+    }
+    if (args[ARG_bits].u_int != -1) {
+        self->bits = args[ARG_bits].u_int;
+        reinit = true;
+    }
+    if (args[ARG_firstbit].u_int != -1) {
+        self->firstbit = args[ARG_firstbit].u_int;
+        reinit = true;
+    }
+    if (args[ARG_sck].u_obj != mp_const_none) {
+        self->sck = mp_hal_get_pin_obj(args[ARG_sck].u_obj);
+        reinit = true;
+    }
+    if (args[ARG_mosi].u_obj != mp_const_none) {
+        self->mosi = mp_hal_get_pin_obj(args[ARG_mosi].u_obj);
+        reinit = true;
+    }
+    if (args[ARG_miso].u_obj != mp_const_none) {
+        self->miso = mp_hal_get_pin_obj(args[ARG_miso].u_obj);
+        reinit = true;
+    }
+
+    // Reinitialize hardware if any config changed
+    if (reinit) {
+        if (self->scb_obj != NULL) {
+            machine_spi_hw_deinit(self);
+        }
+        machine_spi_hw_init(self);
+    }
+}
+
+static void machine_spi_init(mp_obj_base_t *self_in, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    machine_spi_obj_t *self = (machine_spi_obj_t *)self_in;
+
+    enum { ARG_baudrate, ARG_polarity, ARG_phase, ARG_bits, ARG_firstbit };
+
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_baudrate, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = -1} },
+        { MP_QSTR_polarity, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = -1} },
+        { MP_QSTR_phase,    MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = -1} },
+        { MP_QSTR_bits,     MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = -1} },
+        { MP_QSTR_firstbit, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = -1} },
+    };
+
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    bool reinit = false;
+
+    if (args[ARG_baudrate].u_int != -1) {
+        self->baudrate = args[ARG_baudrate].u_int;
+        reinit = true;
+    }
+    if (args[ARG_polarity].u_int != -1) {
+        self->polarity = args[ARG_polarity].u_int;
+        reinit = true;
+    }
+    if (args[ARG_phase].u_int != -1) {
+        self->phase = args[ARG_phase].u_int;
+        reinit = true;
+    }
+    if (args[ARG_bits].u_int != -1) {
+        self->bits = args[ARG_bits].u_int;
+        reinit = true;
+    }
+    if (args[ARG_firstbit].u_int != -1) {
+        self->firstbit = args[ARG_firstbit].u_int;
+        reinit = true;
+    }
+
+    if (reinit) {
+        if (self->scb_obj != NULL) {
+            machine_spi_hw_deinit(self);
+        }
+        machine_spi_hw_init(self);
+    }
 }
 
 static void machine_spi_deinit(mp_obj_base_t *self_in) {
@@ -299,40 +388,7 @@ static void machine_spi_transfer(mp_obj_base_t *self_in,
     size_t len,
     const uint8_t *src,
     uint8_t *dest) {
-    machine_spi_obj_t *self = (machine_spi_obj_t *)self_in;
-    CySCB_Type *base = self->scb_obj->scb;
-
-    if (dest != NULL) {
-        // Full-duplex or read-only (PDL accepts src=NULL, sends default TX byte)
-        Cy_SCB_SPI_Transfer(base, (uint8_t *)src, dest, len, &self->ctx);
-
-        uint32_t start = mp_hal_ticks_ms();
-        while (Cy_SCB_SPI_GetTransferStatus(base, &self->ctx) & CY_SCB_SPI_TRANSFER_ACTIVE) {
-            if ((mp_hal_ticks_ms() - start) > self->timeout) {
-                Cy_SCB_SPI_AbortTransfer(base, &self->ctx);
-                mp_raise_OSError(MP_ETIMEDOUT);
-            }
-            MICROPY_EVENT_POLL_HOOK;
-        }
-    } else {
-        // Write-only: PDL requires a valid RX buffer, use stack chunk
-        uint8_t rx_dummy[64];
-        size_t offset = 0;
-        while (offset < len) {
-            size_t chunk = (len - offset) < 64 ? (len - offset) : 64;
-            Cy_SCB_SPI_Transfer(base, (uint8_t *)&src[offset], rx_dummy, chunk, &self->ctx);
-
-            uint32_t start = mp_hal_ticks_ms();
-            while (Cy_SCB_SPI_GetTransferStatus(base, &self->ctx) & CY_SCB_SPI_TRANSFER_ACTIVE) {
-                if ((mp_hal_ticks_ms() - start) > self->timeout) {
-                    Cy_SCB_SPI_AbortTransfer(base, &self->ctx);
-                    mp_raise_OSError(MP_ETIMEDOUT);
-                }
-                MICROPY_EVENT_POLL_HOOK;
-            }
-            offset += chunk;
-        }
-    }
+    // TODO: implement hardware-specific SPI transfer
 }
 
 /* SPI protocol table  */
@@ -348,78 +404,32 @@ static const mp_machine_spi_p_t machine_spi_p = {
 static void machine_spi_print(const mp_print_t *print,
     mp_obj_t self_in,
     mp_print_kind_t kind) {
-    machine_spi_obj_t *self = MP_OBJ_TO_PTR(self_in);
-
-    // print the numeric fields
-    mp_printf(print, "SPI(baudrate=%u, polarity=%u, phase=%u, bits=%u", self->baudrate, self->polarity, self->phase, self->bits);
-    // print the firstbit field as "MSB" or "LSB"
-    mp_printf(print, ", firstbit=%s", (self->firstbit == MICROPY_PY_MACHINE_SPI_MSB) ? "MSB" : "LSB");
-    // print pin names
-    mp_printf(print, ", sck=%s, mosi=%s, miso=%s", mp_hal_pin_name(self->sck), mp_hal_pin_name(self->mosi), mp_hal_pin_name(self->miso));
-
-    // optional ssel pin
-    if (self->has_ssel) {
-        mp_printf(print, ", ssel=%s", mp_hal_pin_name(self->ssel));
-
-        mp_printf(print, ")");
-    }
+    mp_printf(print, "SPI()");
 }
 
-
+// Create and initialize a new machine.SPI object from Python
 mp_obj_t mp_machine_spi_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
-    mp_arg_check_num(n_args, n_kw, 0, 11, true);
+    mp_arg_check_num(n_args, n_kw, 0, 9, true);
 
-    // Argument definitions: sck/mosi/miso are required, rest have defaults
-    enum { ARG_id, ARG_baudrate, ARG_polarity, ARG_phase, ARG_bits,
-           ARG_firstbit, ARG_sck, ARG_mosi, ARG_miso, ARG_slave, ARG_ssel };
-    static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_id,       MP_ARG_INT, {.u_int = -1} },
-        { MP_QSTR_baudrate, MP_ARG_INT, {.u_int = DEFAULT_SPI_BAUDRATE} },
-        { MP_QSTR_polarity, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = DEFAULT_SPI_POLARITY} },
-        { MP_QSTR_phase,    MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = DEFAULT_SPI_PHASE} },
-        { MP_QSTR_bits,     MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = DEFAULT_SPI_BITS} },
-        { MP_QSTR_firstbit, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = MICROPY_PY_MACHINE_SPI_MSB} },
-        { MP_QSTR_sck,      MP_ARG_KW_ONLY | MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
-        { MP_QSTR_mosi,     MP_ARG_KW_ONLY | MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
-        { MP_QSTR_miso,     MP_ARG_KW_ONLY | MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
-        { MP_QSTR_slave,    MP_ARG_KW_ONLY | MP_ARG_BOOL, {.u_bool = false} },
-        { MP_QSTR_ssel,     MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
-    };
-
-    // Parse positional and keyword arguments from Python call
-    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-
-    // Allocate from static pool (each slot has a unique clock divider index)
+    // Allocate a SPI object from static pool (each slot has a unique clock divider index)
     machine_spi_obj_t *self = machine_hw_spi_obj_alloc();
     if (self == NULL) {
         mp_raise_ValueError(MP_ERROR_TEXT("machine.SPI: Maximum number of SPI instances reached"));
     }
 
-    // Store SPI parameters from parsed args
-    self->baudrate = args[ARG_baudrate].u_int;
-    self->polarity = args[ARG_polarity].u_int;
-    self->phase = args[ARG_phase].u_int;
-    self->bits = args[ARG_bits].u_int;
-    self->firstbit = args[ARG_firstbit].u_int;
-    self->is_slave = args[ARG_slave].u_bool;
+    // Set defaults
+    self->baudrate = DEFAULT_SPI_BAUDRATE;
+    self->polarity = DEFAULT_SPI_POLARITY;
+    self->phase = DEFAULT_SPI_PHASE;
+    self->bits = DEFAULT_SPI_BITS;
+    self->firstbit = MICROPY_PY_MACHINE_SPI_MSB;
     self->timeout = DEFAULT_SPI_TIMEOUT;
     self->scb_obj = NULL;
 
-    // Resolve pin name strings (e.g. 'P5_0') to internal pin objects
-    self->sck = mp_hal_get_pin_obj(args[ARG_sck].u_obj);
-    self->mosi = mp_hal_get_pin_obj(args[ARG_mosi].u_obj);
-    self->miso = mp_hal_get_pin_obj(args[ARG_miso].u_obj);
-    self->has_ssel = args[ARG_ssel].u_obj != mp_const_none;
-    if (self->has_ssel) {
-        self->ssel = mp_hal_get_pin_obj(args[ARG_ssel].u_obj);
-    }
-
-    // Initialize hardware with try/except pattern (nlr = non-local return).
-    // If hw_init raises, free the pool slot before re-raising to Python.
+    // Delegate argument parsing and initialization to init_helper
     nlr_buf_t nlr;
     if (nlr_push(&nlr) == 0) {
-        machine_spi_hw_init(self);
+        machine_spi_init_helper(self, n_args, n_kw, all_args);
         nlr_pop();
     } else {
         machine_hw_spi_obj_free(self);

--- a/ports/psoc-edge/machine_spi_target.c
+++ b/ports/psoc-edge/machine_spi_target.c
@@ -42,15 +42,17 @@
 #define DEFAULT_SPI_TARGET_POLARITY    (0)
 #define DEFAULT_SPI_TARGET_PHASE       (0)
 #define DEFAULT_SPI_TARGET_BITS        (8)
-#define DEFAULT_SPI_TARGET_TIMEOUT_MS  (5000U)   // ms; must be < timer period (15000 ms)
+#define SPI_TARGET_TICKS_WRAP_MS       (15000U) // from mp_hal_ticks_ms source timer period in modtime.c
+#define DEFAULT_SPI_TARGET_TIMEOUT_MS  (5000U)  // must stay below SPI_TARGET_TICKS_WRAP_MS
 
 #define SPI_TARGET_CLK_DIV_TYPE        CY_SYSCLK_DIV_8_BIT
 #define SPI_TARGET_CLK_DIV_BASE        (3U)   // Each SCB lives in its own PERI group with independent dividers
 
-// Returns elapsed milliseconds since start_ms, accounting for the 15s timer wrap.
+// mp_hal_ticks_ms() on this port wraps every SPI_TARGET_TICKS_WRAP_MS.
+// This computes elapsed time across one wrap; caller keeps timeout < wrap period.
 static inline uint32_t spi_target_elapsed_ms(uint32_t start_ms) {
     uint32_t now = mp_hal_ticks_ms();
-    return (now >= start_ms) ? (now - start_ms) : (15000U - start_ms + now);
+    return (now >= start_ms) ? (now - start_ms) : (SPI_TARGET_TICKS_WRAP_MS - start_ms + now);
 }
 
 typedef struct {
@@ -304,8 +306,6 @@ static mp_obj_t machine_spi_target_read(mp_obj_t self_in, mp_obj_t buf_in) {
     machine_spi_target_obj_t *self = MP_OBJ_TO_PTR(self_in);
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(buf_in, &bufinfo, MP_BUFFER_WRITE);
-
-    Cy_SCB_SPI_ClearRxFifo(self->scb_obj->scb);
 
     uint32_t start = mp_hal_ticks_ms();
     size_t received = 0;

--- a/ports/psoc-edge/machine_spi_target.c
+++ b/ports/psoc-edge/machine_spi_target.c
@@ -1,0 +1,408 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022-2026 Infineon Technologies AG
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/runtime.h"
+#include "py/mphal.h"
+#include "py/mperrno.h"
+#include <stdio.h>
+#include <string.h>
+#include "cybsp.h"
+#include "cy_scb_spi.h"
+#include "cy_sysclk.h"
+#include "genhdr/pins_af.h"
+#include "mplogger.h"
+#include "machine_scb.h"
+#include "modmachine.h"
+
+#if MICROPY_PY_MACHINE_SPI_TARGET
+
+#define DEFAULT_SPI_TARGET_POLARITY    (0)
+#define DEFAULT_SPI_TARGET_PHASE       (0)
+#define DEFAULT_SPI_TARGET_BITS        (8)
+#define DEFAULT_SPI_TARGET_TIMEOUT     (50000)
+
+typedef struct {
+    uint32_t peri_nr;
+    uint32_t group_nr;
+    uint32_t slave_nr;
+    uint32_t clk_hf_nr;
+} machine_spi_target_scb_group_info_t;
+
+#define SCB_GROUP_ENTRY(n) \
+    [n] = { \
+        .peri_nr = CY_MMIO_SCB##n##_PERI_NR, \
+        .group_nr = CY_MMIO_SCB##n##_GROUP_NR, \
+        .slave_nr = CY_MMIO_SCB##n##_SLAVE_NR, \
+        .clk_hf_nr = CY_MMIO_SCB##n##_CLK_HF_NR, \
+    },
+
+static const machine_spi_target_scb_group_info_t scb_group_table[] = {
+    MICROPY_PY_MACHINE_FOR_ALL_SCB(SCB_GROUP_ENTRY)
+};
+
+typedef struct _machine_spi_target_obj_t {
+    mp_obj_base_t base;
+    mp_hal_pin_obj_t sck;
+    mp_hal_pin_obj_t mosi;
+    mp_hal_pin_obj_t miso;
+    mp_hal_pin_obj_t ssel;
+    uint8_t polarity;
+    uint8_t phase;
+    uint8_t bits;
+    uint8_t firstbit;
+    uint32_t timeout;
+    machine_scb_obj_t *scb_obj;
+    cy_stc_scb_spi_config_t cfg;
+    cy_stc_scb_spi_context_t ctx;
+} machine_spi_target_obj_t;
+
+machine_spi_target_obj_t *machine_spi_target_obj[MICROPY_PY_MACHINE_SPI_TARGET_MAX] = { NULL };
+
+static inline machine_spi_target_obj_t *machine_spi_target_obj_alloc(void) {
+    for (uint8_t i = 0; i < MICROPY_PY_MACHINE_SPI_TARGET_MAX; i++) {
+        if (machine_spi_target_obj[i] == NULL) {
+            machine_spi_target_obj[i] = mp_obj_malloc(machine_spi_target_obj_t, &machine_spi_target_type);
+            return machine_spi_target_obj[i];
+        }
+    }
+    return NULL;
+}
+
+static inline void machine_spi_target_obj_free(machine_spi_target_obj_t *obj) {
+    for (uint8_t i = 0; i < MICROPY_PY_MACHINE_SPI_TARGET_MAX; i++) {
+        if (machine_spi_target_obj[i] == obj) {
+            machine_spi_target_obj[i] = NULL;
+        }
+    }
+}
+
+static void machine_spi_target_scb_isr(mp_obj_t obj) {
+    machine_spi_target_obj_t *self = MP_OBJ_TO_PTR(obj);
+    Cy_SCB_SPI_Interrupt(self->scb_obj->scb, &self->ctx);
+}
+
+static void machine_spi_target_hw_init(machine_spi_target_obj_t *self) {
+    // Input validation
+    if ((self->polarity > 1U) || (self->phase > 1U)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("polarity/phase must be 0 or 1"));
+    }
+    if (self->bits != 8U) {
+        mp_raise_ValueError(MP_ERROR_TEXT("bits must be 8"));
+    }
+    if ((self->firstbit != MICROPY_PY_MACHINE_SPI_MSB) &&
+        (self->firstbit != MICROPY_PY_MACHINE_SPI_LSB)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("invalid firstbit"));
+    }
+
+    // Pin config: SCK, MOSI, SSEL are inputs; MISO is output
+    const mp_hal_pin_af_config_t spi_pins_config[] = {
+        MP_HAL_PIN_AF_CONF(self->sck,
+            CY_GPIO_DM_HIGHZ, 0,
+            MACHINE_PIN_AF_SIGNAL_SPI_CLK),
+        MP_HAL_PIN_AF_CONF(self->mosi,
+            CY_GPIO_DM_HIGHZ, 0,
+            MACHINE_PIN_AF_SIGNAL_SPI_MOSI),
+        MP_HAL_PIN_AF_CONF(self->miso,
+            CY_GPIO_DM_STRONG_IN_OFF, 1,
+            MACHINE_PIN_AF_SIGNAL_SPI_MISO),
+        MP_HAL_PIN_AF_CONF(self->ssel,
+            CY_GPIO_DM_HIGHZ, 0,
+            MACHINE_PIN_AF_SIGNAL_SPI_SELECT0),
+    };
+    uint8_t scb_unit = spi_pins_config[0].af->unit;
+    mp_hal_periph_pins_af_config(spi_pins_config, 4);
+
+    // Power on the peripheral group that contains this SCB.
+    const machine_spi_target_scb_group_info_t *gi = &scb_group_table[scb_unit];
+    Cy_SysClk_PeriGroupSlaveInit(gi->peri_nr, gi->group_nr,
+        gi->slave_nr, gi->clk_hf_nr);
+
+    // Allocate SCB
+    self->scb_obj = machine_scb_obj_alloc(scb_unit, self,
+        machine_spi_target_scb_isr);
+
+    // Select SPI clock polarity and phase
+    cy_en_scb_spi_sclk_mode_t sclk_mode;
+    if (self->polarity == 0 && self->phase == 0) {
+        sclk_mode = CY_SCB_SPI_CPHA0_CPOL0;
+    } else if (self->polarity == 0 && self->phase == 1) {
+        sclk_mode = CY_SCB_SPI_CPHA1_CPOL0;
+    } else if (self->polarity == 1 && self->phase == 0) {
+        sclk_mode = CY_SCB_SPI_CPHA0_CPOL1;
+    } else {
+        sclk_mode = CY_SCB_SPI_CPHA1_CPOL1;
+    }
+
+    // Populate PDL SPI configuration for slave/target mode
+    self->cfg = (cy_stc_scb_spi_config_t) {
+        .spiMode = CY_SCB_SPI_SLAVE,
+        .subMode = CY_SCB_SPI_MOTOROLA,
+        .sclkMode = sclk_mode,
+        .parity = CY_SCB_SPI_PARITY_NONE,
+        .dropOnParityError = false,
+        .oversample = 0U,
+        .rxDataWidth = self->bits,
+        .txDataWidth = self->bits,
+        .enableMsbFirst = (self->firstbit == MICROPY_PY_MACHINE_SPI_MSB),
+        .enableInputFilter = false,
+        .enableFreeRunSclk = false,
+        .enableMisoLateSample = false,
+        .enableTransferSeparation = false,
+        .ssPolarity =
+            ((CY_SCB_SPI_ACTIVE_LOW << CY_SCB_SPI_SLAVE_SELECT0) |
+                (CY_SCB_SPI_ACTIVE_LOW << CY_SCB_SPI_SLAVE_SELECT1) |
+                (CY_SCB_SPI_ACTIVE_LOW << CY_SCB_SPI_SLAVE_SELECT2) |
+                (CY_SCB_SPI_ACTIVE_LOW << CY_SCB_SPI_SLAVE_SELECT3)),
+        .ssSetupDelay = false,
+        .ssHoldDelay = false,
+        .ssInterFrameDelay = false,
+        .enableWakeFromSleep = false,
+        .rxFifoTriggerLevel = 0UL,
+        .rxFifoIntEnableMask = 0UL,
+        .txFifoTriggerLevel = 0UL,
+        .txFifoIntEnableMask = 0UL,
+        .masterSlaveIntEnableMask = 0UL,
+    };
+
+    // Initialize SPI hardware
+    cy_en_scb_spi_status_t result =
+        Cy_SCB_SPI_Init(self->scb_obj->scb, &self->cfg, &self->ctx);
+
+    if (result != CY_SCB_SPI_SUCCESS) {
+        machine_scb_obj_free(self->scb_obj);
+        self->scb_obj = NULL;
+        mp_raise_msg_varg(&mp_type_ValueError,
+            MP_ERROR_TEXT("SPITarget init failed: 0x%lx"), (uint32_t)result);
+    }
+
+    sys_int_init(&self->scb_obj->irq);
+    Cy_SCB_SPI_Enable(self->scb_obj->scb);
+}
+
+static void machine_spi_target_hw_deinit(machine_spi_target_obj_t *self) {
+    Cy_SCB_SPI_Disable(self->scb_obj->scb, &self->ctx);
+    Cy_SCB_SPI_DeInit(self->scb_obj->scb);
+    sys_int_deinit(&self->scb_obj->irq);
+    machine_scb_obj_free(self->scb_obj);
+    self->scb_obj = NULL;
+}
+
+/******************************************************************************/
+// MicroPython bindings
+
+static void machine_spi_target_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
+    machine_spi_target_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    mp_printf(print, "SPITarget(sck='%q', mosi='%q', miso='%q', ssel='%q', polarity=%u, phase=%u, bits=%u)",
+        self->sck->name, self->mosi->name, self->miso->name, self->ssel->name,
+        self->polarity, self->phase, self->bits);
+}
+
+static mp_obj_t machine_spi_target_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
+    mp_arg_check_num(n_args, n_kw, 0, 8, true);
+
+    enum { ARG_sck, ARG_mosi, ARG_miso, ARG_ssel, ARG_polarity, ARG_phase, ARG_bits, ARG_firstbit };
+
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_sck,      MP_ARG_KW_ONLY | MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
+        { MP_QSTR_mosi,     MP_ARG_KW_ONLY | MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
+        { MP_QSTR_miso,     MP_ARG_KW_ONLY | MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
+        { MP_QSTR_ssel,     MP_ARG_KW_ONLY | MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
+        { MP_QSTR_polarity, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = DEFAULT_SPI_TARGET_POLARITY} },
+        { MP_QSTR_phase,    MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = DEFAULT_SPI_TARGET_PHASE} },
+        { MP_QSTR_bits,     MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = DEFAULT_SPI_TARGET_BITS} },
+        { MP_QSTR_firstbit, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = MICROPY_PY_MACHINE_SPI_MSB} },
+    };
+
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    machine_spi_target_obj_t *self = machine_spi_target_obj_alloc();
+    if (self == NULL) {
+        mp_raise_ValueError(MP_ERROR_TEXT("SPITarget: Maximum number of instances reached"));
+    }
+
+    self->sck = mp_hal_get_pin_obj(args[ARG_sck].u_obj);
+    self->mosi = mp_hal_get_pin_obj(args[ARG_mosi].u_obj);
+    self->miso = mp_hal_get_pin_obj(args[ARG_miso].u_obj);
+    self->ssel = mp_hal_get_pin_obj(args[ARG_ssel].u_obj);
+    self->polarity = args[ARG_polarity].u_int;
+    self->phase = args[ARG_phase].u_int;
+    self->bits = args[ARG_bits].u_int;
+    self->firstbit = args[ARG_firstbit].u_int;
+    self->timeout = DEFAULT_SPI_TARGET_TIMEOUT;
+    self->scb_obj = NULL;
+
+    nlr_buf_t nlr;
+    if (nlr_push(&nlr) == 0) {
+        machine_spi_target_hw_init(self);
+        nlr_pop();
+    } else {
+        machine_spi_target_obj_free(self);
+        nlr_jump(nlr.ret_val);
+    }
+
+    return MP_OBJ_FROM_PTR(self);
+}
+
+static mp_obj_t machine_spi_target_deinit(mp_obj_t self_in) {
+    machine_spi_target_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    if (self->scb_obj != NULL) {
+        machine_spi_target_hw_deinit(self);
+    }
+    machine_spi_target_obj_free(self);
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(machine_spi_target_deinit_obj, machine_spi_target_deinit);
+
+static mp_obj_t machine_spi_target_read(mp_obj_t self_in, mp_obj_t buf_in) {
+    machine_spi_target_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    mp_buffer_info_t bufinfo;
+    mp_get_buffer_raise(buf_in, &bufinfo, MP_BUFFER_WRITE);
+
+    Cy_SCB_SPI_ClearRxFifo(self->scb_obj->scb);
+
+    uint32_t start = mp_hal_ticks_us();
+    size_t received = 0;
+    uint8_t *rx_buf = bufinfo.buf;
+
+    while (received < bufinfo.len) {
+        uint32_t num_available = Cy_SCB_SPI_GetNumInRxFifo(self->scb_obj->scb);
+        while (num_available > 0 && received < bufinfo.len) {
+            rx_buf[received++] = (uint8_t)Cy_SCB_SPI_Read(self->scb_obj->scb);
+            num_available--;
+        }
+
+        if (mp_hal_ticks_us() - start > self->timeout) {
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("SPITarget read timeout"));
+        }
+        MICROPY_EVENT_POLL_HOOK
+    }
+
+    return mp_obj_new_int(received);
+}
+static MP_DEFINE_CONST_FUN_OBJ_2(machine_spi_target_read_obj, machine_spi_target_read);
+
+static mp_obj_t machine_spi_target_write(mp_obj_t self_in, mp_obj_t buf_in) {
+    machine_spi_target_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    mp_buffer_info_t bufinfo;
+    mp_get_buffer_raise(buf_in, &bufinfo, MP_BUFFER_READ);
+
+    Cy_SCB_SPI_ClearTxFifo(self->scb_obj->scb);
+
+    size_t written = 0;
+    uint8_t *tx_buf = bufinfo.buf;
+
+    while (written < bufinfo.len) {
+        if (Cy_SCB_GetNumInTxFifo(self->scb_obj->scb) < Cy_SCB_GetFifoSize(self->scb_obj->scb)) {
+            Cy_SCB_SPI_Write(self->scb_obj->scb, tx_buf[written++]);
+        } else {
+            MICROPY_EVENT_POLL_HOOK
+        }
+    }
+
+    uint32_t start = mp_hal_ticks_us();
+    while (!Cy_SCB_SPI_IsTxComplete(self->scb_obj->scb)) {
+        if (mp_hal_ticks_us() - start > self->timeout) {
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("SPITarget write timeout"));
+        }
+        MICROPY_EVENT_POLL_HOOK
+    }
+
+    return mp_obj_new_int(written);
+}
+static MP_DEFINE_CONST_FUN_OBJ_2(machine_spi_target_write_obj, machine_spi_target_write);
+
+static mp_obj_t machine_spi_target_write_readinto(mp_obj_t self_in, mp_obj_t tx_buf_in, mp_obj_t rx_buf_in) {
+    machine_spi_target_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    mp_buffer_info_t tx_bufinfo;
+    mp_buffer_info_t rx_bufinfo;
+    mp_get_buffer_raise(tx_buf_in, &tx_bufinfo, MP_BUFFER_READ);
+    mp_get_buffer_raise(rx_buf_in, &rx_bufinfo, MP_BUFFER_WRITE);
+
+    if (tx_bufinfo.len != rx_bufinfo.len) {
+        mp_raise_ValueError(MP_ERROR_TEXT("buffers must be the same length"));
+    }
+
+    Cy_SCB_SPI_ClearTxFifo(self->scb_obj->scb);
+    Cy_SCB_SPI_ClearRxFifo(self->scb_obj->scb);
+
+    uint8_t *tx_buf = tx_bufinfo.buf;
+    uint8_t *rx_buf = rx_bufinfo.buf;
+    size_t len = tx_bufinfo.len;
+    size_t tx_idx = 0;
+    size_t rx_idx = 0;
+    uint32_t start = mp_hal_ticks_us();
+
+    while (rx_idx < len) {
+        // Load TX FIFO
+        while (tx_idx < len &&
+               Cy_SCB_GetNumInTxFifo(self->scb_obj->scb) < Cy_SCB_GetFifoSize(self->scb_obj->scb)) {
+            Cy_SCB_SPI_Write(self->scb_obj->scb, tx_buf[tx_idx++]);
+        }
+
+        // Read RX FIFO
+        while (rx_idx < len && Cy_SCB_SPI_GetNumInRxFifo(self->scb_obj->scb) > 0) {
+            rx_buf[rx_idx++] = (uint8_t)Cy_SCB_SPI_Read(self->scb_obj->scb);
+        }
+
+        if (mp_hal_ticks_us() - start > self->timeout) {
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("SPITarget transfer timeout"));
+        }
+        MICROPY_EVENT_POLL_HOOK
+    }
+
+    return mp_obj_new_int(len);
+}
+static MP_DEFINE_CONST_FUN_OBJ_3(machine_spi_target_write_readinto_obj, machine_spi_target_write_readinto);
+
+void machine_spi_target_deinit_all(void) {
+    for (uint8_t i = 0; i < MICROPY_PY_MACHINE_SPI_TARGET_MAX; i++) {
+        if (machine_spi_target_obj[i] != NULL) {
+            machine_spi_target_deinit(MP_OBJ_FROM_PTR(machine_spi_target_obj[i]));
+        }
+    }
+}
+
+static const mp_rom_map_elem_t machine_spi_target_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_read),           MP_ROM_PTR(&machine_spi_target_read_obj) },
+    { MP_ROM_QSTR(MP_QSTR_write),          MP_ROM_PTR(&machine_spi_target_write_obj) },
+    { MP_ROM_QSTR(MP_QSTR_write_readinto), MP_ROM_PTR(&machine_spi_target_write_readinto_obj) },
+    { MP_ROM_QSTR(MP_QSTR_deinit),         MP_ROM_PTR(&machine_spi_target_deinit_obj) },
+    { MP_ROM_QSTR(MP_QSTR_MSB),            MP_ROM_INT(MICROPY_PY_MACHINE_SPI_MSB) },
+    { MP_ROM_QSTR(MP_QSTR_LSB),            MP_ROM_INT(MICROPY_PY_MACHINE_SPI_LSB) },
+};
+static MP_DEFINE_CONST_DICT(machine_spi_target_locals_dict, machine_spi_target_locals_dict_table);
+
+MP_DEFINE_CONST_OBJ_TYPE(
+    machine_spi_target_type,
+    MP_QSTR_SPITarget,
+    MP_TYPE_FLAG_NONE,
+    make_new, machine_spi_target_make_new,
+    print, machine_spi_target_print,
+    locals_dict, &machine_spi_target_locals_dict
+    );
+
+#endif // MICROPY_PY_MACHINE_SPI_TARGET

--- a/ports/psoc-edge/machine_spi_target.c
+++ b/ports/psoc-edge/machine_spi_target.c
@@ -42,7 +42,16 @@
 #define DEFAULT_SPI_TARGET_POLARITY    (0)
 #define DEFAULT_SPI_TARGET_PHASE       (0)
 #define DEFAULT_SPI_TARGET_BITS        (8)
-#define DEFAULT_SPI_TARGET_TIMEOUT     (50000)
+#define DEFAULT_SPI_TARGET_TIMEOUT_MS  (5000U)   // ms; must be < timer period (15000 ms)
+
+#define SPI_TARGET_CLK_DIV_TYPE        CY_SYSCLK_DIV_8_BIT
+#define SPI_TARGET_CLK_DIV_BASE        (3U)   // Each SCB lives in its own PERI group with independent dividers
+
+// Returns elapsed milliseconds since start_ms, accounting for the 15s timer wrap.
+static inline uint32_t spi_target_elapsed_ms(uint32_t start_ms) {
+    uint32_t now = mp_hal_ticks_ms();
+    return (now >= start_ms) ? (now - start_ms) : (15000U - start_ms + now);
+}
 
 typedef struct {
     uint32_t peri_nr;
@@ -74,6 +83,7 @@ typedef struct _machine_spi_target_obj_t {
     uint8_t bits;
     uint8_t firstbit;
     uint32_t timeout;
+    uint8_t div_num;  // Clock divider number for PCLK
     machine_scb_obj_t *scb_obj;
     cy_stc_scb_spi_config_t cfg;
     cy_stc_scb_spi_context_t ctx;
@@ -85,6 +95,7 @@ static inline machine_spi_target_obj_t *machine_spi_target_obj_alloc(void) {
     for (uint8_t i = 0; i < MICROPY_PY_MACHINE_SPI_TARGET_MAX; i++) {
         if (machine_spi_target_obj[i] == NULL) {
             machine_spi_target_obj[i] = mp_obj_malloc(machine_spi_target_obj_t, &machine_spi_target_type);
+            machine_spi_target_obj[i]->div_num = SPI_TARGET_CLK_DIV_BASE + i;
             return machine_spi_target_obj[i];
         }
     }
@@ -143,6 +154,17 @@ static void machine_spi_target_hw_init(machine_spi_target_obj_t *self) {
     // Allocate SCB
     self->scb_obj = machine_scb_obj_alloc(scb_unit, self,
         machine_spi_target_scb_isr);
+
+    // Configure SPI PCLK divider (needed for slave's internal clock even though
+    // the bit clock comes from master's SCK)
+    Cy_SysClk_PeriPclkDisableDivider(self->scb_obj->clk,
+        SPI_TARGET_CLK_DIV_TYPE, self->div_num);
+    Cy_SysClk_PeriPclkAssignDivider(self->scb_obj->clk,
+        SPI_TARGET_CLK_DIV_TYPE, self->div_num);
+    Cy_SysClk_PeriPclkSetDivider(self->scb_obj->clk,
+        SPI_TARGET_CLK_DIV_TYPE, self->div_num, 0U);
+    Cy_SysClk_PeriPclkEnableDivider(self->scb_obj->clk,
+        SPI_TARGET_CLK_DIV_TYPE, self->div_num);
 
     // Select SPI clock polarity and phase
     cy_en_scb_spi_sclk_mode_t sclk_mode;
@@ -206,6 +228,7 @@ static void machine_spi_target_hw_deinit(machine_spi_target_obj_t *self) {
     Cy_SCB_SPI_Disable(self->scb_obj->scb, &self->ctx);
     Cy_SCB_SPI_DeInit(self->scb_obj->scb);
     sys_int_deinit(&self->scb_obj->irq);
+    Cy_SysClk_PeriPclkDisableDivider(self->scb_obj->clk, SPI_TARGET_CLK_DIV_TYPE, self->div_num);
     machine_scb_obj_free(self->scb_obj);
     self->scb_obj = NULL;
 }
@@ -252,7 +275,7 @@ static mp_obj_t machine_spi_target_make_new(const mp_obj_type_t *type, size_t n_
     self->phase = args[ARG_phase].u_int;
     self->bits = args[ARG_bits].u_int;
     self->firstbit = args[ARG_firstbit].u_int;
-    self->timeout = DEFAULT_SPI_TARGET_TIMEOUT;
+    self->timeout = DEFAULT_SPI_TARGET_TIMEOUT_MS;
     self->scb_obj = NULL;
 
     nlr_buf_t nlr;
@@ -284,7 +307,7 @@ static mp_obj_t machine_spi_target_read(mp_obj_t self_in, mp_obj_t buf_in) {
 
     Cy_SCB_SPI_ClearRxFifo(self->scb_obj->scb);
 
-    uint32_t start = mp_hal_ticks_us();
+    uint32_t start = mp_hal_ticks_ms();
     size_t received = 0;
     uint8_t *rx_buf = bufinfo.buf;
 
@@ -295,7 +318,7 @@ static mp_obj_t machine_spi_target_read(mp_obj_t self_in, mp_obj_t buf_in) {
             num_available--;
         }
 
-        if (mp_hal_ticks_us() - start > self->timeout) {
+        if (spi_target_elapsed_ms(start) > self->timeout) {
             mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("SPITarget read timeout"));
         }
         MICROPY_EVENT_POLL_HOOK
@@ -323,9 +346,9 @@ static mp_obj_t machine_spi_target_write(mp_obj_t self_in, mp_obj_t buf_in) {
         }
     }
 
-    uint32_t start = mp_hal_ticks_us();
+    uint32_t start = mp_hal_ticks_ms();
     while (!Cy_SCB_SPI_IsTxComplete(self->scb_obj->scb)) {
-        if (mp_hal_ticks_us() - start > self->timeout) {
+        if (spi_target_elapsed_ms(start) > self->timeout) {
             mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("SPITarget write timeout"));
         }
         MICROPY_EVENT_POLL_HOOK
@@ -354,7 +377,7 @@ static mp_obj_t machine_spi_target_write_readinto(mp_obj_t self_in, mp_obj_t tx_
     size_t len = tx_bufinfo.len;
     size_t tx_idx = 0;
     size_t rx_idx = 0;
-    uint32_t start = mp_hal_ticks_us();
+    uint32_t start = mp_hal_ticks_ms();
 
     while (rx_idx < len) {
         // Load TX FIFO
@@ -368,7 +391,7 @@ static mp_obj_t machine_spi_target_write_readinto(mp_obj_t self_in, mp_obj_t tx_
             rx_buf[rx_idx++] = (uint8_t)Cy_SCB_SPI_Read(self->scb_obj->scb);
         }
 
-        if (mp_hal_ticks_us() - start > self->timeout) {
+        if (spi_target_elapsed_ms(start) > self->timeout) {
             mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("SPITarget transfer timeout"));
         }
         MICROPY_EVENT_POLL_HOOK

--- a/ports/psoc-edge/main.c
+++ b/ports/psoc-edge/main.c
@@ -64,6 +64,8 @@ extern void time_init(void);
 extern void machine_pin_irq_deinit_all(void);
 extern void machine_hw_i2c_deinit_all(void);
 extern void machine_pdm_pcm_deinit_all(void);
+extern void machine_spi_deinit_all(void);
+extern void machine_spi_target_deinit_all(void);
 
 boot_mode_t check_boot_mode(void) {
     boot_mode_t boot_mode;
@@ -168,6 +170,8 @@ soft_reset:
     machine_pin_irq_deinit_all();
     machine_hw_i2c_deinit_all();
     machine_pdm_pcm_deinit_all();
+    machine_spi_deinit_all();
+    machine_spi_target_deinit_all();
 
     #if MICROPY_ENABLE_GC
     gc_sweep_all();

--- a/ports/psoc-edge/modmachine.c
+++ b/ports/psoc-edge/modmachine.c
@@ -77,5 +77,6 @@ static void mp_machine_set_freq(size_t n_args, const mp_obj_t *args) {
     { MP_ROM_QSTR(MP_QSTR_RTC),                 MP_ROM_PTR(&machine_rtc_type) }, \
     { MP_ROM_QSTR(MP_QSTR_IPC),                 MP_ROM_PTR(&machine_ipc_type) }, \
     { MP_ROM_QSTR(MP_QSTR_SPI),                 MP_ROM_PTR(&machine_spi_type) }, \
+    { MP_ROM_QSTR(MP_QSTR_SPITarget),           MP_ROM_PTR(&machine_spi_target_type) }, \
 
 #endif // MICROPY_PY_MACHINE

--- a/ports/psoc-edge/modmachine.h
+++ b/ports/psoc-edge/modmachine.h
@@ -43,6 +43,7 @@ typedef struct _machine_pdm_pcm_obj_t machine_pdm_pcm_obj_t;
 
 extern const mp_obj_type_t machine_i2c_type;
 extern const mp_obj_type_t machine_spi_type;
+extern const mp_obj_type_t machine_spi_target_type;
 extern const mp_obj_type_t machine_pdm_pcm_type;
 extern const mp_obj_type_t machine_rtc_type;
 extern const mp_obj_type_t machine_ipc_type;

--- a/ports/psoc-edge/mpconfigport.h
+++ b/ports/psoc-edge/mpconfigport.h
@@ -115,6 +115,8 @@
 
 #define MICROPY_PY_MACHINE_SPI                  (1)
 #define MICROPY_PY_MACHINE_SOFTSPI              (0)
+#define MICROPY_PY_MACHINE_SPI_TARGET           (1)
+#define MICROPY_PY_MACHINE_SPI_TARGET_MAX       (4)
 
 #define MICROPY_PY_MACHINE_I2C_TARGET           (1)
 #define MICROPY_PY_MACHINE_I2C_TARGET_MAX       (1)

--- a/tests/ports/psoc-edge/BLR-Runner-devs.yml
+++ b/tests/ports/psoc-edge/BLR-Runner-devs.yml
@@ -3,8 +3,10 @@
   features:
     - pin
     - i2c
+    - spi
 
 - name: KIT_PSE84_AI
   uid: 111B1698012D2400
   features:
     - i2c
+    - spi

--- a/tests/ports/psoc-edge/board_ext_hw/multi/spi_basic.py
+++ b/tests/ports/psoc-edge/board_ext_hw/multi/spi_basic.py
@@ -1,0 +1,166 @@
+# SPI multi-device test
+# Tests SPI master and target communication between two boards
+#
+# KIT_PSE84_AI board Hardware connections:
+#   Board 0 (Target)    Board 1 (Master)
+#   P16_0 (SCK)    <->  P16_0 (SCK)
+#   P16_1 (MOSI)   <->  P16_1 (MOSI)
+#   P16_2 (MISO)   <->  P16_2 (MISO)
+#   P16_3 (SSEL)   <->  P16_3 (CS out)
+#   GND            <->  GND
+
+import time
+
+
+def instance0():
+    # SPI Target (Slave)
+    from machine import SPITarget
+
+    print("\n***** SPI Target Test *****\n")
+
+    target = SPITarget(
+        polarity=0,
+        phase=0,
+        bits=8,
+        firstbit=SPITarget.MSB,
+        sck="P16_0",
+        mosi="P16_1",
+        miso="P16_2",
+        ssel="P16_3",
+    )
+
+    # Signal to master that target is ready
+    multitest.next()
+
+    # Test 1: Read from master
+    print("***** Test 1: Read *****\n")
+    rx = bytearray(4)
+    n = target.read(rx)
+    print("Received:", rx[:n])
+    read_pass = rx[:n] == b"\x01\x02\x03\x04"
+    print("Status:", "PASS" if read_pass else "FAIL")
+
+    # Signal master that read is done
+    multitest.next()
+
+    # Wait for master to be ready for write test
+    multitest.next()
+
+    # Test 2: Write to master
+    print("\n***** Test 2: Write *****\n")
+    tx = b"\xaa\xbb\xcc\xdd"
+    n = target.write(tx)
+    print("Wrote:", n, "bytes")
+    print("Status:", "PASS" if n == 4 else "FAIL")
+
+    # Signal master that write is done
+    multitest.next()
+
+    # Wait for master to be ready for write_readinto test
+    multitest.next()
+
+    # Test 3: Write and read simultaneously
+    print("\n***** Test 3: Write+Read *****\n")
+    tx = b"\x11\x22\x33\x44"
+    rx = bytearray(4)
+    n = target.write_readinto(tx, rx)
+    print("Sent:", tx)
+    print("Received:", rx[:n])
+    readinto_pass = rx[:n] == b"\xde\xad\xbe\xef"
+    print("Status:", "PASS" if readinto_pass else "FAIL")
+
+    multitest.next()
+
+    target.deinit()
+
+    # Summary
+    print("\n***** Target Summary *****")
+    all_pass = read_pass and readinto_pass
+    print("Overall:", "PASS" if all_pass else "FAIL")
+
+
+def instance1():
+    # SPI Master (Controller)
+    from machine import SPI, Pin
+
+    print("\n***** SPI Master Test *****\n")
+
+    spi = SPI(
+        baudrate=1_000_000,
+        polarity=0,
+        phase=0,
+        bits=8,
+        firstbit=SPI.MSB,
+        sck="P16_0",
+        mosi="P16_1",
+        miso="P16_2",
+    )
+    cs = Pin("P16_3", Pin.OUT, value=1)
+
+    # Wait for target to be ready
+    print("Waiting for target...")
+    multitest.next()
+    print("Target ready\n")
+    time.sleep_ms(50)
+
+    # Test 1: Write to target
+    print("***** Test 1: Write *****\n")
+    tx = b"\x01\x02\x03\x04"
+    rx = bytearray(4)
+    cs(0)
+    time.sleep_us(10)
+    spi.write_readinto(tx, rx)
+    time.sleep_us(10)
+    cs(1)
+    print("Sent:", tx)
+    print("Status: PASS")
+
+    # Wait for target to finish reading
+    multitest.next()
+
+    # Test 2: Read from target
+    print("\n***** Test 2: Read *****\n")
+    # Signal target to start writing
+    multitest.next()
+    time.sleep_ms(50)
+
+    tx = b"\x00\x00\x00\x00"
+    rx = bytearray(4)
+    cs(0)
+    time.sleep_us(10)
+    spi.write_readinto(tx, rx)
+    time.sleep_us(10)
+    cs(1)
+    print("Received:", rx)
+    read_pass = rx == b"\xaa\xbb\xcc\xdd"
+    print("Status:", "PASS" if read_pass else "FAIL")
+
+    # Wait for target to finish write
+    multitest.next()
+
+    # Test 3: Simultaneous write and read
+    print("\n***** Test 3: Transfer *****\n")
+    # Signal target to start write_readinto
+    multitest.next()
+    time.sleep_ms(50)
+
+    tx = b"\xde\xad\xbe\xef"
+    rx = bytearray(4)
+    cs(0)
+    time.sleep_us(10)
+    spi.write_readinto(tx, rx)
+    time.sleep_us(10)
+    cs(1)
+    print("Sent:", tx)
+    print("Received:", rx)
+    transfer_pass = rx == b"\x11\x22\x33\x44"
+    print("Status:", "PASS" if transfer_pass else "FAIL")
+
+    multitest.next()
+
+    spi.deinit()
+
+    # Summary
+    print("\n***** Master Summary *****")
+    all_pass = read_pass and transfer_pass
+    print("Overall:", "PASS" if all_pass else "FAIL")

--- a/tests/ports/psoc-edge/board_ext_hw/multi/spi_basic.py.exp
+++ b/tests/ports/psoc-edge/board_ext_hw/multi/spi_basic.py.exp
@@ -1,0 +1,57 @@
+--- instance0 ---
+
+***** SPI Target Test *****
+
+***** Test 1: Read *****
+
+Received: bytearray(b'\x01\x02\x03\x04')
+Status: PASS
+NEXT
+NEXT
+
+***** Test 2: Write *****
+
+Wrote: 4 bytes
+Status: PASS
+NEXT
+NEXT
+
+***** Test 3: Write+Read *****
+
+Sent: b'\x11"3D'
+Received: bytearray(b'\xde\xad\xbe\xef')
+Status: PASS
+NEXT
+
+***** Target Summary *****
+Overall: PASS
+--- instance1 ---
+
+***** SPI Master Test *****
+
+Waiting for target...
+Target ready
+
+***** Test 1: Write *****
+
+Sent: b'\x01\x02\x03\x04'
+Status: PASS
+NEXT
+
+***** Test 2: Read *****
+
+NEXT
+Received: bytearray(b'\xaa\xbb\xcc\xdd')
+Status: PASS
+NEXT
+
+***** Test 3: Transfer *****
+
+NEXT
+Sent: b'\xde\xad\xbe\xef'
+Received: bytearray(b'\x11"3D')
+Status: PASS
+NEXT
+
+***** Master Summary *****
+Overall: PASS

--- a/tests/ports/psoc-edge/board_ext_hw/single/spi.py
+++ b/tests/ports/psoc-edge/board_ext_hw/single/spi.py
@@ -1,0 +1,99 @@
+# SPI single-board loopback test
+# Hardware: short MOSI (P16_1) to MISO (P16_2)
+#
+# Tests SPI master basic functionality using loopback.
+
+from machine import SPI, Pin
+
+# Test 1: Create SPI instance
+spi = SPI(
+    baudrate=1_000_000,
+    polarity=0,
+    phase=0,
+    bits=8,
+    firstbit=SPI.MSB,
+    sck="P16_0",
+    mosi="P16_1",
+    miso="P16_2",
+)
+print(spi)
+
+# Test 2: write_readinto loopback
+tx = b"\xa5\x5a\xff\x00"
+rx = bytearray(4)
+spi.write_readinto(tx, rx)
+print("write_readinto loopback: ", rx == b"\xa5\x5a\xff\x00")
+
+# Test 3: write_readinto loopback (different data)
+tx = b"\xde\xad\xbe\xef"
+rx = bytearray(4)
+spi.write_readinto(tx, rx)
+print("transfer loopback: ", rx == b"\xde\xad\xbe\xef")
+
+# Test 4: write (no read, just verify no crash)
+spi.write(b"\x01\x02\x03")
+print("write ok: ", True)
+
+# Test 5: readinto (MISO reads what MOSI sends, but MOSI is idle so expect 0s)
+rx = bytearray(4)
+spi.readinto(rx)
+print("readinto ok: ", True)
+
+# Test 6: Different polarity/phase modes
+spi.deinit()
+for pol in (0, 1):
+    for pha in (0, 1):
+        s = SPI(
+            baudrate=1_000_000,
+            polarity=pol,
+            phase=pha,
+            bits=8,
+            firstbit=SPI.MSB,
+            sck="P16_0",
+            mosi="P16_1",
+            miso="P16_2",
+        )
+        tx = b"\xaa\x55"
+        rx = bytearray(2)
+        s.write_readinto(tx, rx)
+        print("mode({},{}): ".format(pol, pha), rx == b"\xaa\x55")
+        s.deinit()
+
+# Test 7: LSB first
+spi = SPI(
+    baudrate=1_000_000,
+    polarity=0,
+    phase=0,
+    bits=8,
+    firstbit=SPI.LSB,
+    sck="P16_0",
+    mosi="P16_1",
+    miso="P16_2",
+)
+tx = b"\xf0\x0f"
+rx = bytearray(2)
+spi.write_readinto(tx, rx)
+print("LSB first loopback: ", rx == b"\xf0\x0f")
+spi.deinit()
+
+# Test 8: CS pin toggling with transfer
+spi = SPI(
+    baudrate=1_000_000,
+    polarity=0,
+    phase=0,
+    bits=8,
+    firstbit=SPI.MSB,
+    sck="P16_0",
+    mosi="P16_1",
+    miso="P16_2",
+)
+cs = Pin("P16_3", Pin.OUT, value=1)
+cs(0)
+tx = b"\x9f\x00\x00\x00"
+rx = bytearray(4)
+spi.write_readinto(tx, rx)
+cs(1)
+print("CS toggled transfer: ", rx == b"\x9f\x00\x00\x00")
+spi.deinit()
+
+print("done")

--- a/tests/ports/psoc-edge/board_ext_hw/single/spi.py.exp
+++ b/tests/ports/psoc-edge/board_ext_hw/single/spi.py.exp
@@ -1,0 +1,12 @@
+SPI(baudrate=1000000, polarity=0, phase=0, bits=8, firstbit=MSB, sck='P16_0', mosi='P16_1', miso='P16_2')
+write_readinto loopback:  True
+transfer loopback:  True
+write ok:  True
+readinto ok:  True
+mode(0,0):  True
+mode(0,1):  True
+mode(1,0):  True
+mode(1,1):  True
+LSB first loopback:  True
+CS toggled transfer:  True
+done

--- a/tests/ports/psoc-edge/test-plan.yml
+++ b/tests/ports/psoc-edge/test-plan.yml
@@ -58,3 +58,12 @@
       - board: KIT_PSE84_AI
         features:
           - i2c
+
+- name: spi
+  type: multi
+  test:
+    script: ports/psoc-edge/board_ext_hw/multi/spi_basic.py
+    device:
+      - board: KIT_PSE84_AI
+        features:
+          - spi


### PR DESCRIPTION
### Summary

Add `SPI.transfer()` and a new `machine.SPITarget` class for the PSoC Edge port.

- `SPI.transfer()`: interrupt-driven simultaneous read/write via `Cy_SCB_SPI_Transfer`
- `machine.SPITarget`: slave-mode SPI with `read()`, `write()`, `write_readinto()`
- Shared `init_helper`, input validation, and cleanup (addresses prior PR review comments)

### Testing

Hardware testing pending.

### Generative AI

I did not use generative AI tools when creating this PR.