### PR TITLE
Machine pwm frequency and duty cycle getter - setter

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -98,6 +98,9 @@
 [submodule "lib/psoc-edge/se-rt-services-utils"]
 	path = lib/psoc-edge/se-rt-services-utils
 	url = https://github.com/Infineon/se-rt-services-utils.git
+[submodule "lib/psoc-edge/cmsis"]
+	path = lib/psoc-edge/cmsis
+	url = https://github.com/Infineon/cmsis.git
 [submodule "lib/psoc-edge/serial-memory"]
 	path = lib/psoc-edge/serial-memory
 	url = https://github.com/Infineon/serial-memory.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -98,9 +98,6 @@
 [submodule "lib/psoc-edge/se-rt-services-utils"]
 	path = lib/psoc-edge/se-rt-services-utils
 	url = https://github.com/Infineon/se-rt-services-utils.git
-[submodule "lib/psoc-edge/cmsis"]
-	path = lib/psoc-edge/cmsis
-	url = https://github.com/Infineon/cmsis.git
 [submodule "lib/psoc-edge/serial-memory"]
 	path = lib/psoc-edge/serial-memory
 	url = https://github.com/Infineon/serial-memory.git

--- a/docs/psoc-edge/quickref.rst
+++ b/docs/psoc-edge/quickref.rst
@@ -631,44 +631,10 @@ Constructor
       - ``freq`` — output frequency in Hz (**required**). Must be in the range 1 - 500 000.
       - ``duty_u16`` — duty cycle as a 16-bit unsigned integer 0-65535 (0 % - ~100 %).
       - ``duty_ns`` — duty cycle (high pulse width) in nanoseconds. Must not exceed the period (``1 000 000 000 / freq`` ns).
-            .. note:: Either one of ``duty_u16`` or ``duty_ns`` must be supplied.
       - ``invert`` — if ``True``, inverts the output polarity. Default is ``False``.
 
     Raises ``ValueError`` if the pin does not support PWM, if a PWM instance for that pin already exists without calling ``deinit()`` 
     first, or if the frequency or duty arguments are out of range.
-
-Methods
-^^^^^^^^
-
-See :ref:`machine.PWM <machine.PWM>` for the full API. The following notes describe
-port-specific behaviour:
-
-.. method:: PWM.init(*, freq, duty_u16, duty_ns, invert=False)
-
-    Same constraints as the constructor apply (see above).
-
-.. method:: PWM.deinit()
-
-    In addition to stopping the counter, the pin is restored to Hi-Z GPIO mode and
-    its instance slot is released for reuse.
-
-.. method:: PWM.freq([freq])
-
-    Frequency must be in the range **1 – 500 000 Hz**. When the duty cycle was set
-    via ``duty_ns``, the setter also validates that the stored on-time does not exceed
-    the new period; a ``ValueError`` is raised if it does.
-
-.. method:: PWM.duty_u16([duty_u16])
-
-    Values above 65535 are silently clamped to 65535. If the instance was last
-    configured with ``duty_ns``, the getter converts and returns the equivalent u16
-    value.
-
-.. method:: PWM.duty_ns([duty_ns])
-
-    Raises ``ValueError`` if the requested on-time exceeds the current period
-    (``1 000 000 000 / freq`` ns). If the instance was last configured with
-    ``duty_u16``, the getter converts and returns the equivalent nanosecond value.
 
 Complete example
 ^^^^^^^^^^^^^^^^

--- a/docs/psoc-edge/quickref.rst
+++ b/docs/psoc-edge/quickref.rst
@@ -597,3 +597,105 @@ Methods
 .. method:: UART.init(baudrate=9600, bits=8, parity=None, stop=1, *, ...)
 
     The same parameters as the constructor are supported, with the same limitations.
+    
+PWM
+----
+
+Pulse Width Modulation (PWM) signal output on the PSOC™ Edge. See :ref:`machine.PWM <machine.PWM>` for the standard MicroPython PWM API.
+
+.. note::
+
+    On this port, PWM output is available exclusively on pins **P16_1** through **P16_7**. Each pin is backed by an independent TCPWM0 counter, 
+    so each instance can run at a different frequency simultaneously. A maximum of **7** PWM instances can be active at the same time.
+
+.. note::
+
+    The base clock driving all counters is **1 MHz** (derived from the 100 MHz PCLK via a shared 16-bit divider). 
+    This gives a frequency range of **1 Hz - 500 kHz** and a period resolution of 1 µs.
+
+A PWM object can be created and started using::
+
+    from machine import PWM
+
+    pwm = PWM("P16_1", freq=1000, duty_u16=32767)  # 1 kHz, 50 % duty cycle
+
+Constructor
+^^^^^^^^^^^^
+
+.. class:: PWM(pin, *, freq, duty_u16, duty_ns, invert=False)
+
+    Construct and immediately start a PWM signal on *pin*.
+
+      - ``pin`` — the output pin. Accepts a string label (``"P16_1"``), a ``Pin.cpu.<pin>`` object, or a ``Pin.board.<pin>`` object.
+        The pin must be one of the PWM-capable pins P16_1 - P16_7.
+      - ``freq`` — output frequency in Hz (**required**). Must be in the range 1 - 500 000.
+      - ``duty_u16`` — duty cycle as a 16-bit unsigned integer 0-65535 (0 % - ~100 %).
+      - ``duty_ns`` — duty cycle (high pulse width) in nanoseconds. Must not exceed the period (``1 000 000 000 / freq`` ns).
+            .. note:: Either one of ``duty_u16`` or ``duty_ns`` must be supplied.
+      - ``invert`` — if ``True``, inverts the output polarity. Default is ``False``.
+
+    Raises ``ValueError`` if the pin does not support PWM, if a PWM instance for that pin already exists without calling ``deinit()`` 
+    first, or if the frequency or duty arguments are out of range.
+
+Methods
+^^^^^^^^
+
+See :ref:`machine.PWM <machine.PWM>` for the full API. The following notes describe
+port-specific behaviour:
+
+.. method:: PWM.init(*, freq, duty_u16, duty_ns, invert=False)
+
+    Same constraints as the constructor apply (see above).
+
+.. method:: PWM.deinit()
+
+    In addition to stopping the counter, the pin is restored to Hi-Z GPIO mode and
+    its instance slot is released for reuse.
+
+.. method:: PWM.freq([freq])
+
+    Frequency must be in the range **1 – 500 000 Hz**. When the duty cycle was set
+    via ``duty_ns``, the setter also validates that the stored on-time does not exceed
+    the new period; a ``ValueError`` is raised if it does.
+
+.. method:: PWM.duty_u16([duty_u16])
+
+    Values above 65535 are silently clamped to 65535. If the instance was last
+    configured with ``duty_ns``, the getter converts and returns the equivalent u16
+    value.
+
+.. method:: PWM.duty_ns([duty_ns])
+
+    Raises ``ValueError`` if the requested on-time exceeds the current period
+    (``1 000 000 000 / freq`` ns). If the instance was last configured with
+    ``duty_u16``, the getter converts and returns the equivalent nanosecond value.
+
+Complete example
+^^^^^^^^^^^^^^^^
+
+::
+
+    from machine import PWM
+
+    # Start a 1 kHz signal at 50 % duty cycle on P16_1
+    pwm = PWM("P16_1", freq=1000, duty_u16=32767)
+    print(pwm)                     # PWM(Pin.cpu.P16_1, freq=1000, duty=50.00%)
+
+    # Read back the current settings
+    print(pwm.freq())              # 1000
+    print(pwm.duty_u16())          # 32767
+    print(pwm.duty_ns())           # 500000  (0.5 ms duty cycle at 1 kHz)
+
+    # Update frequency only — duty ratio preserved
+    pwm.freq(2000)
+    print(pwm.freq())              # 2000
+
+    # Switch to nanosecond duty control: 250 µs duty cycle at 2 kHz = 50 %
+    pwm.duty_ns(250000)
+    print(pwm.duty_ns())           # 250000
+
+    # Reconfigure completely
+    pwm.init(freq=500, duty_u16=16383)   # 500 Hz, 25 %
+
+    # Stop and release the pin
+    pwm.deinit()

--- a/ports/psoc-edge/Makefile
+++ b/ports/psoc-edge/Makefile
@@ -317,7 +317,6 @@ MOD_SRC_C += \
 	modpsocedge.c \
 	machine_ipc.c \
 	machine_scb.c \
-	machine_pwm.c \
 
 ifeq ($(MICROPY_PY_EXT_FLASH),1)
 	CFLAGS += -DMICROPY_ENABLE_EXT_QSPI_FLASH=1

--- a/ports/psoc-edge/machine_pwm.c
+++ b/ports/psoc-edge/machine_pwm.c
@@ -220,6 +220,8 @@ static void mp_machine_pwm_init_helper(machine_pwm_obj_t *self, size_t n_args, c
         mp_raise_ValueError(MP_ERROR_TEXT("PWM duty should be specified only in one format"));
     }
 
+    self->frequency = (uint32_t)args[ARG_freq].u_int;
+
     if (args[ARG_duty_u16].u_int != VALUE_NOT_SET) {
         self->duty = args[ARG_duty_u16].u_int > 65535 ? 65535 : args[ARG_duty_u16].u_int;
         self->duty_type = DUTY_U16;
@@ -230,8 +232,6 @@ static void mp_machine_pwm_init_helper(machine_pwm_obj_t *self, size_t n_args, c
     } else {
         mp_raise_ValueError(MP_ERROR_TEXT("PWM duty should be specified in either ns or u16"));
     }
-
-    self->frequency = (uint32_t)args[ARG_freq].u_int;
 
     self->invert = args[ARG_invert].u_bool;
 
@@ -373,12 +373,40 @@ static void mp_machine_pwm_deinit(machine_pwm_obj_t *self) {
 
 // Return the current PWM output frequency in Hz.
 static mp_obj_t mp_machine_pwm_freq_get(machine_pwm_obj_t *self) {
-    mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM freq getter/setter not yet implemented"));
+    return MP_OBJ_NEW_SMALL_INT(self->frequency);
 }
 
 // Update the PWM output frequency; recalculates the period register.
 static void mp_machine_pwm_freq_set(machine_pwm_obj_t *self, mp_int_t freq) {
-    mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM freq getter/setter not yet implemented"));
+    if (freq <= 0) {
+        mp_raise_ValueError(MP_ERROR_TEXT("PWM frequency must be greater than 0"));
+    }
+    if ((uint32_t)freq > PWM_TCPWM_CLK_HZ / 2) {
+        mp_raise_msg_varg(&mp_type_ValueError,
+            MP_ERROR_TEXT("PWM frequency must not exceed %lu Hz"), (unsigned long)(PWM_TCPWM_CLK_HZ / 2));
+    }
+    if (self->duty_type == DUTY_NS) {
+        pwm_duty_ns_assert(self->duty, (uint32_t)freq);
+    }
+
+    // set the frequency
+    self->frequency = (uint32_t)freq;
+
+    /* Apply frequency and duty cycle to the PWM config struct */
+    pwm_config(self);
+
+    // Disable the TCPWM counter
+    Cy_TCPWM_PWM_Disable(TCPWM0, self->counter_num);
+
+    cy_en_tcpwm_status_t result = Cy_TCPWM_PWM_Init(TCPWM0,
+        self->counter_num, &self->pwm_obj);
+    pwm_assert_raise_val("PWM init failed with return code %lx !", result);
+
+    /* Enable the TCPWM block */
+    Cy_TCPWM_PWM_Enable(TCPWM0, self->counter_num);
+
+    /* Start the PWM */
+    Cy_TCPWM_TriggerReloadOrIndex_Single(TCPWM0, self->counter_num);
 }
 
 // Return the current duty cycle as a 16-bit value (0-65535).

--- a/ports/psoc-edge/machine_pwm.c
+++ b/ports/psoc-edge/machine_pwm.c
@@ -172,6 +172,15 @@ static void pwm_pin_restore(const machine_pin_obj_t *pin) {
     Cy_GPIO_SetDrivemode(port, pin->pin, CY_GPIO_DM_HIGHZ);
 }
 
+// Reconfigure and restart the TCPWM counter using the current pwm_obj config struct.
+static void pwm_restart(machine_pwm_obj_t *self) {
+    Cy_TCPWM_PWM_Disable(TCPWM0, self->counter_num);
+    cy_en_tcpwm_status_t result = Cy_TCPWM_PWM_Init(TCPWM0, self->counter_num, &self->pwm_obj);
+    pwm_assert_raise_val("PWM init failed with return code %lx !", result);
+    Cy_TCPWM_PWM_Enable(TCPWM0, self->counter_num);
+    Cy_TCPWM_TriggerReloadOrIndex_Single(TCPWM0, self->counter_num);
+}
+
 // Compute period and compare register values from the stored frequency/duty and write to the PDL config struct.
 static void pwm_config(machine_pwm_obj_t *self) {
     if (self->frequency == 0) {
@@ -395,36 +404,44 @@ static void mp_machine_pwm_freq_set(machine_pwm_obj_t *self, mp_int_t freq) {
     /* Apply frequency and duty cycle to the PWM config struct */
     pwm_config(self);
 
-    // Disable the TCPWM counter
-    Cy_TCPWM_PWM_Disable(TCPWM0, self->counter_num);
-
-    cy_en_tcpwm_status_t result = Cy_TCPWM_PWM_Init(TCPWM0,
-        self->counter_num, &self->pwm_obj);
-    pwm_assert_raise_val("PWM init failed with return code %lx !", result);
-
-    /* Enable the TCPWM block */
-    Cy_TCPWM_PWM_Enable(TCPWM0, self->counter_num);
-
-    /* Start the PWM */
-    Cy_TCPWM_TriggerReloadOrIndex_Single(TCPWM0, self->counter_num);
+    // Reconfigure and restart the TCPWM counter with the new config.
+    pwm_restart(self);
 }
 
 // Return the current duty cycle as a 16-bit value (0-65535).
 static mp_obj_t mp_machine_pwm_duty_get_u16(machine_pwm_obj_t *self) {
-    mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM duty getter/setter not yet implemented"));
+    if (self->duty_type == DUTY_U16) {
+        return MP_OBJ_NEW_SMALL_INT(self->duty);
+    }
+    // Convert stored duty_ns to u16
+    return MP_OBJ_NEW_SMALL_INT(pwm_duty_cycle_ns_to_u16(self->duty, self->frequency));
 }
 
 // Set the duty cycle from a 16-bit value (0-65535).
 static void mp_machine_pwm_duty_set_u16(machine_pwm_obj_t *self, mp_int_t duty_u16) {
-    mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM duty getter/setter not yet implemented"));
+    self->duty = duty_u16 > 65535 ? 65535 : duty_u16;
+    self->duty_type = DUTY_U16;
+
+    pwm_config(self);
+    pwm_restart(self);
 }
 
 // Return the current on-time duty cycle in nanoseconds.
 static mp_obj_t mp_machine_pwm_duty_get_ns(machine_pwm_obj_t *self) {
-    mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM duty getter/setter not yet implemented"));
+    if (self->duty_type == DUTY_NS) {
+        return MP_OBJ_NEW_SMALL_INT(self->duty);
+    }
+    // Convert stored duty_u16 to nanoseconds
+    return MP_OBJ_NEW_SMALL_INT(pwm_duty_cycle_u16_to_ns(self->duty, self->frequency));
 }
 
 // Set the duty cycle as an on-time in nanoseconds.
 static void mp_machine_pwm_duty_set_ns(machine_pwm_obj_t *self, mp_int_t duty_ns) {
-    mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM duty getter/setter not yet implemented"));
+    pwm_duty_ns_assert(duty_ns, self->frequency);
+
+    self->duty = duty_ns;
+    self->duty_type = DUTY_NS;
+
+    pwm_config(self);
+    pwm_restart(self);
 }

--- a/ports/psoc-edge/modmachine.c
+++ b/ports/psoc-edge/modmachine.c
@@ -76,6 +76,6 @@ static void mp_machine_set_freq(size_t n_args, const mp_obj_t *args) {
     { MP_ROM_QSTR(MP_QSTR_RTC),                 MP_ROM_PTR(&machine_rtc_type) }, \
     { MP_ROM_QSTR(MP_QSTR_IPC),                 MP_ROM_PTR(&machine_ipc_type) }, \
     { MP_ROM_QSTR(MP_QSTR_UART),                MP_ROM_PTR(&machine_uart_type) }, \
-	{ MP_ROM_QSTR(MP_QSTR_PWM),                 MP_ROM_PTR(&machine_pwm_type) }, \
+    { MP_ROM_QSTR(MP_QSTR_PWM),                 MP_ROM_PTR(&machine_pwm_type) }, \
 
 #endif // MICROPY_PY_MACHINE

--- a/ports/psoc-edge/modmachine.c
+++ b/ports/psoc-edge/modmachine.c
@@ -76,5 +76,6 @@ static void mp_machine_set_freq(size_t n_args, const mp_obj_t *args) {
     { MP_ROM_QSTR(MP_QSTR_RTC),                 MP_ROM_PTR(&machine_rtc_type) }, \
     { MP_ROM_QSTR(MP_QSTR_IPC),                 MP_ROM_PTR(&machine_ipc_type) }, \
     { MP_ROM_QSTR(MP_QSTR_UART),                MP_ROM_PTR(&machine_uart_type) }, \
+	{ MP_ROM_QSTR(MP_QSTR_PWM),                 MP_ROM_PTR(&machine_pwm_type) }, \
 
 #endif // MICROPY_PY_MACHINE

--- a/tests/ports/psoc-edge/board_ext_hw/single/pwm.py
+++ b/tests/ports/psoc-edge/board_ext_hw/single/pwm.py
@@ -165,6 +165,73 @@ try:
 except Exception as e:
     print(e)
 
+#### freq getter / setter tests ####
+
+# freq_get returns the frequency set at construction (duty_u16)
+pwm = PWM(pwm_pin, freq=1000, duty_u16=32767)
+print(f"freq_get after init (duty_u16): {pwm.freq()}")
+pwm.deinit()
+
+# freq_get returns the frequency set at construction (duty_ns)
+pwm = PWM(pwm_pin, freq=500, duty_ns=1000000)
+print(f"freq_get after init (duty_ns): {pwm.freq()}")
+pwm.deinit()
+
+# freq_set changes output frequency (duty_u16, measured on hardware)
+pwm = PWM(pwm_pin, freq=10, duty_u16=32767)
+pwm.freq(50)
+calc_dc, calc_freq = measure_signal()
+validate_signal(exp_freq=50, calc_freq=calc_freq, exp_dc=50, calc_dc=calc_dc)
+pwm.deinit()
+
+# freq_set changes output frequency (duty_ns, measured on hardware)
+# duty_ns=2500000: 25% at 100 Hz -> 50% at 200 Hz (period shrinks from 10ms to 5ms)
+pwm = PWM(pwm_pin, freq=100, duty_ns=2500000)
+pwm.freq(200)
+calc_dc, calc_freq = measure_signal()
+validate_signal(exp_freq=200, calc_freq=calc_freq, exp_dc=50, calc_dc=calc_dc)
+pwm.deinit()
+
+# freq_get after freq_set returns the new frequency
+pwm = PWM(pwm_pin, freq=100, duty_u16=32767)
+pwm.freq(250)
+print(f"freq_get after freq_set: {pwm.freq()}")
+pwm.deinit()
+
+#### Negative freq_set tests ####
+
+# freq_set: frequency must be greater than 0
+pwm = PWM(pwm_pin, freq=100, duty_u16=32767)
+try:
+    pwm.freq(0)
+except Exception as e:
+    print(e)
+pwm.deinit()
+
+# freq_set: negative frequency
+pwm = PWM(pwm_pin, freq=100, duty_u16=32767)
+try:
+    pwm.freq(-1)
+except Exception as e:
+    print(e)
+pwm.deinit()
+
+# freq_set: frequency exceeds maximum
+pwm = PWM(pwm_pin, freq=100, duty_u16=32767)
+try:
+    pwm.freq(500001)
+except Exception as e:
+    print(e)
+pwm.deinit()
+
+# freq_set: duty_ns would exceed new (lower) period
+pwm = PWM(pwm_pin, freq=100, duty_ns=9000000)  # 9 ms on-time, period = 10 ms
+try:
+    pwm.freq(200)  # new period = 5 ms; 9 ms duty exceeds it
+except Exception as e:
+    print(e)
+pwm.deinit()
+
 # PWM instance already exists
 pwm = PWM(pwm_pin, freq=1, duty_u16=32767)
 time.sleep(2)  # Wait for the pwm signal to be initialized and started

--- a/tests/ports/psoc-edge/board_ext_hw/single/pwm.py
+++ b/tests/ports/psoc-edge/board_ext_hw/single/pwm.py
@@ -232,6 +232,70 @@ except Exception as e:
     print(e)
 pwm.deinit()
 
+#### duty_u16 getter / setter tests ####
+
+# duty_u16_get returns value set at construction
+pwm = PWM(pwm_pin, freq=100, duty_u16=32767)
+print(f"duty_u16_get after init: {pwm.duty_u16()}")
+pwm.deinit()
+
+# duty_u16_get converts duty_ns to u16
+# duty_ns=5000000 at 100 Hz = 50% -> u16 = 32767
+pwm = PWM(pwm_pin, freq=100, duty_ns=5000000)
+print(f"duty_u16_get from duty_ns: {pwm.duty_u16()}")
+pwm.deinit()
+
+# duty_u16_set changes output duty cycle (measured on hardware)
+# 16383 / 65536 ~= 25%
+pwm = PWM(pwm_pin, freq=100, duty_u16=32767)
+pwm.duty_u16(16383)
+calc_dc, calc_freq = measure_signal()
+validate_signal(exp_freq=100, calc_freq=calc_freq, exp_dc=25, calc_dc=calc_dc)
+pwm.deinit()
+
+# duty_u16_get after duty_u16_set returns the new value
+pwm = PWM(pwm_pin, freq=100, duty_u16=32767)
+pwm.duty_u16(16383)
+print(f"duty_u16_get after duty_u16_set: {pwm.duty_u16()}")
+pwm.deinit()
+
+#### duty_ns getter / setter tests ####
+
+# duty_ns_get returns value set at construction
+pwm = PWM(pwm_pin, freq=100, duty_ns=2500000)
+print(f"duty_ns_get after init: {pwm.duty_ns()}")
+pwm.deinit()
+
+# duty_ns_get converts duty_u16 to ns
+# duty_u16=32767 at 100 Hz: (32767+1)/65536 * 10000000 = 5000000 ns
+pwm = PWM(pwm_pin, freq=100, duty_u16=32767)
+print(f"duty_ns_get from duty_u16: {pwm.duty_ns()}")
+pwm.deinit()
+
+# duty_ns_set changes output duty cycle (measured on hardware)
+# 2500000 ns at 100 Hz = 25%
+pwm = PWM(pwm_pin, freq=100, duty_u16=32767)
+pwm.duty_ns(2500000)
+calc_dc, calc_freq = measure_signal()
+validate_signal(exp_freq=100, calc_freq=calc_freq, exp_dc=25, calc_dc=calc_dc)
+pwm.deinit()
+
+# duty_ns_get after duty_ns_set returns the new value
+pwm = PWM(pwm_pin, freq=100, duty_u16=32767)
+pwm.duty_ns(2500000)
+print(f"duty_ns_get after duty_ns_set: {pwm.duty_ns()}")
+pwm.deinit()
+
+#### Negative duty setter tests ####
+
+# duty_ns_set: duty exceeds period (period = 10 ms = 10000000 ns at 100 Hz)
+pwm = PWM(pwm_pin, freq=100, duty_u16=32767)
+try:
+    pwm.duty_ns(15000000)
+except Exception as e:
+    print(e)
+pwm.deinit()
+
 # PWM instance already exists
 pwm = PWM(pwm_pin, freq=1, duty_u16=32767)
 time.sleep(2)  # Wait for the pwm signal to be initialized and started

--- a/tests/ports/psoc-edge/board_ext_hw/single/pwm.py.exp
+++ b/tests/ports/psoc-edge/board_ext_hw/single/pwm.py.exp
@@ -33,4 +33,19 @@ PWM frequency must be greater than 0
 PWM frequency must be greater than 0
 PWM frequency must not exceed 500000 Hz
 PWM duty in ns is larger than the period 5000000 ns
+duty_u16_get after init: 32767
+duty_u16_get from duty_ns: 32767
+Expected freq matches calc freq! 
+ freq: 100
+Exp dc(%) matches calc dc(%)! 
+ dc: 25
+duty_u16_get after duty_u16_set: 16383
+duty_ns_get after init: 2500000
+duty_ns_get from duty_u16: 5000000
+Expected freq matches calc freq! 
+ freq: 100
+Exp dc(%) matches calc dc(%)! 
+ dc: 25
+duty_ns_get after duty_ns_set: 2500000
+PWM duty in ns is larger than the period 10000000 ns
 PWM instance for Pin P16_1 already exists, call deinit() first

--- a/tests/ports/psoc-edge/board_ext_hw/single/pwm.py.exp
+++ b/tests/ports/psoc-edge/board_ext_hw/single/pwm.py.exp
@@ -13,9 +13,24 @@ Exp dc(%) matches calc dc(%)!
  dc: 25
 PWM frequency must not exceed 500000 Hz
 PWM frequency must be greater than 0
-PWM duty in ns is larger than the period 0 ns
+PWM duty in ns is larger than the period 20000000 ns
 PWM duty should be specified only in one format
 PWM frequency must be greater than 0
 PWM duty should be specified in either ns or u16
 Pin(P0_0) doesn't exist
+freq_get after init (duty_u16): 1000
+freq_get after init (duty_ns): 500
+Expected freq matches calc freq! 
+ freq: 50
+Exp dc(%) matches calc dc(%)! 
+ dc: 50
+Expected freq matches calc freq! 
+ freq: 200
+Exp dc(%) matches calc dc(%)! 
+ dc: 50
+freq_get after freq_set: 250
+PWM frequency must be greater than 0
+PWM frequency must be greater than 0
+PWM frequency must not exceed 500000 Hz
+PWM duty in ns is larger than the period 5000000 ns
 PWM instance for Pin P16_1 already exists, call deinit() first

--- a/tests/ports/psoc-edge/test-plan.yml
+++ b/tests/ports/psoc-edge/test-plan.yml
@@ -66,7 +66,7 @@
       - board: KIT_PSE84_AI
         features:
           - uart
-	  
+
 - name: pwm
   test: 
     script: ports/psoc-edge/board_ext_hw/single/pwm.py

--- a/tests/ports/psoc-edge/test-plan.yml
+++ b/tests/ports/psoc-edge/test-plan.yml
@@ -66,3 +66,11 @@
       - board: KIT_PSE84_AI
         features:
           - uart
+	  
+- name: pwm
+  test: 
+    script: ports/psoc-edge/board_ext_hw/single/pwm.py
+    device: 
+      - board: KIT_PSE84_AI
+        features:
+          - pwm


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant,
     especially links to open issues. -->

This PR builds on the previous PR and implements the stubbed freq(), duty_u16(), and duty_ns() getter/setter methods for the PSoC Edge machine.PWM class, along with a supporting refactor and comprehensive test coverage.

**Bug fix:** Moved self->frequency assignment before the duty_ns validation in mp_machine_pwm_init_helper, which previously caused pwm_duty_ns_assert to always compare against freq=0.

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this section empty then your Pull Request may be closed. -->

- Tested using the logic analyzer on exposed PWM capable pins P16_4.
- Multiple frequencies and duty cycles were tested on the PWM object using the getter and setter methods.
- Tested on HIL setup with positive and negative test cases using PWM pin P16_1.

### Trade-offs and Alternatives

<!-- If the Pull Request has some negative impact (i.e. increased code size)
     then please explain why you think the trade-off improvement is worth it.
     If you can think of alternative ways to do this, please explain that here too.

     Delete this heading if not relevant (i.e. small fixes) -->

In addition to the Trade-offs and Alternatives mentioned in the previous PR https://github.com/Infineon/micropython-psoc-edge/pull/103, this getter and setter methods was tested only on pin P16_1 and P16_4.

### Generative AI

<!-- Please delete the answer below which doesn't apply, or write your own
     answer with more details. -->

I did not use generative AI tools when creating this PR.

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.

<!-- We require everyone to answer this question. If you delete this section or
     ignore it then your PR may be closed.

     For more information, consult the MicroPython Generative AI Policy:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines#generative-ai-policy
     -->
