### PR TITLE
Fix/pin irq scheduler extended

### DIFF
--- a/ports/psoc-edge/machine_pin_irq.c
+++ b/ports/psoc-edge/machine_pin_irq.c
@@ -154,11 +154,17 @@ static void machine_pin_irq_port_handler(uint8_t port) {
             Cy_GPIO_ClearInterrupt(Cy_GPIO_PortToAddr(port), pin);
 
             uint32_t idx = machine_pin_irq_obj_find_index(port, pin);
-            machine_pin_irq_obj_t *irq = (idx < MICROPY_PY_MACHINE_PIN_CPU_NUM_ENTRIES) ? machine_pin_irq_obj[idx] : NULL;
+            machine_pin_irq_obj_t *irq = machine_pin_irq_obj[idx];
 
-            /* Call handler via mp_irq_handler for deferred execution in scheduler context. */
-            if (irq != NULL && irq->base.handler != mp_const_none) {
-                irq->flags = 1; /* Mark that an IRQ was triggered. */
+            /**
+             * Update the flags with the current trigger that caused the IRQ.
+             * There is not a PDL function to get the current trigger,
+             * so we use the configured trigger as the source of truth.
+             * This means that if both edges are enabled, the flags will
+             * indicate both edges even if only one of them caused the IRQ.
+             */
+            irq->flags = irq->trigger;
+            if (irq->base.handler != mp_const_none) {
                 mp_irq_handler(&irq->base);
             }
         }
@@ -203,9 +209,17 @@ static void machine_pin_irq_set_priority(sys_int_cfg_t *port_cfg, uint32_t port,
     }
 }
 
+#define MP_PIN_IRQ_ALLOWED_FLAGS (CY_GPIO_INTR_RISING | CY_GPIO_INTR_FALLING)
+
 static mp_uint_t machine_pin_irq_trigger(mp_obj_t self_in, mp_uint_t new_trigger) {
     machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
     machine_pin_irq_obj_t *irq = machine_pin_irq_obj[machine_pin_irq_obj_find_index(self->port, self->pin)];
+
+    /* Check the trigger */
+    mp_uint_t not_supported = new_trigger & ~MP_PIN_IRQ_ALLOWED_FLAGS;
+    if (new_trigger != 0 && not_supported) {
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("trigger 0x%08x unsupported"), not_supported);
+    }
 
     irq->flags = 0;
     irq->trigger = new_trigger;
@@ -267,6 +281,12 @@ mp_obj_t machine_pin_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_a
     machine_pin_irq_obj_t *irq = machine_pin_irq_get_irq(self);
 
     if (n_args > 1 || kw_args->used != 0) {
+
+        /* Check the handler */
+        mp_obj_t handler = args[ARG_handler].u_obj;
+        if (handler != mp_const_none && !mp_obj_is_callable(handler)) {
+            mp_raise_ValueError(MP_ERROR_TEXT("handler must be None or callable"));
+        }
         irq->base.handler = args[ARG_handler].u_obj;
         irq->base.ishard = args[ARG_hard].u_bool;
         machine_pin_irq_set_priority(irq->port_cfg, self->port, args[ARG_priority].u_int);

--- a/ports/psoc-edge/machine_pin_irq.c
+++ b/ports/psoc-edge/machine_pin_irq.c
@@ -96,6 +96,43 @@ typedef struct _machine_pin_irq_obj_t {
 
 machine_pin_irq_obj_t *machine_pin_irq_obj[MICROPY_PY_MACHINE_PIN_CPU_NUM_ENTRIES];
 
+static machine_pin_irq_obj_t *machine_pin_get_irq_obj(machine_pin_obj_t *pin_obj) {
+    uint32_t idx = 0;
+    for (idx = 0; idx < MICROPY_PY_MACHINE_PIN_CPU_NUM_ENTRIES; idx++) {
+        machine_pin_irq_obj_t *irq = machine_pin_irq_obj[idx];
+        if (irq != NULL) {
+            machine_pin_obj_t *irq_parent = MP_OBJ_TO_PTR(irq->base.parent);
+            if (irq_parent == pin_obj) {
+                return irq;
+            }
+        }
+    }
+    return NULL;
+}
+
+static machine_pin_irq_obj_t *machine_pin_irq_obj_allocate(void) {
+    for (uint32_t idx = 0; idx < MICROPY_PY_MACHINE_PIN_CPU_NUM_ENTRIES; idx++) {
+        machine_pin_irq_obj_t *irq = machine_pin_irq_obj[idx];
+        if (irq == NULL) {
+            irq = m_new_obj(machine_pin_irq_obj_t);
+            machine_pin_irq_obj[idx] = irq;
+            return irq;
+        }
+    }
+
+    mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("no more Pin IRQ objects available"));
+}
+
+static void machine_pin_irq_obj_dealloc(machine_pin_irq_obj_t *irq) {
+    for (uint32_t idx = 0; idx < MICROPY_PY_MACHINE_PIN_CPU_NUM_ENTRIES; idx++) {
+        if (machine_pin_irq_obj[idx] == irq) {
+            m_del_obj(machine_pin_irq_obj_t, irq);
+            machine_pin_irq_obj[idx] = NULL;
+            return;
+        }
+    }
+}
+
 static uint32_t machine_pin_irq_obj_find_index(uint8_t port, uint8_t pin) {
     uint32_t idx = 0;
     for (idx = 0; idx < MICROPY_PY_MACHINE_PIN_CPU_NUM_ENTRIES; idx++) {
@@ -108,38 +145,6 @@ static uint32_t machine_pin_irq_obj_find_index(uint8_t port, uint8_t pin) {
         }
     }
     return idx;
-}
-
-static uint32_t machine_pin_irq_obj_allocate_index(uint8_t port, uint8_t pin) {
-    uint32_t idx = 0;
-    for (idx = 0; idx < MICROPY_PY_MACHINE_PIN_CPU_NUM_ENTRIES; idx++) {
-        machine_pin_irq_obj_t *irq = machine_pin_irq_obj[idx];
-        if (irq == NULL) {
-            return idx;
-        }
-    }
-
-    return idx;
-}
-
-/**
- * Get the index of the Pin IRQ object if already registered
- * in the array. If not registered, allocate a new index.
- * If no more indexes are available, raise RuntimeError.
- */
-static int machine_pin_irq_obj_get_index(uint8_t port, uint8_t pin) {
-    int irq_index = machine_pin_irq_obj_find_index(port, pin);
-    if (irq_index < MICROPY_PY_MACHINE_PIN_CPU_NUM_ENTRIES) {
-        return irq_index;
-    }
-    irq_index = machine_pin_irq_obj_allocate_index(port, pin);
-    if (irq_index < MICROPY_PY_MACHINE_PIN_CPU_NUM_ENTRIES) {
-        return irq_index;
-    }
-
-    mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("no more Pin IRQ objects available"));
-
-    return -1;
 }
 
 static void machine_pin_irq_port_handler(uint8_t port) {
@@ -209,32 +214,45 @@ static void machine_pin_irq_set_priority(sys_int_cfg_t *port_cfg, uint32_t port,
     }
 }
 
-#define MP_PIN_IRQ_ALLOWED_FLAGS (CY_GPIO_INTR_RISING | CY_GPIO_INTR_FALLING)
+#define MP_PIN_IRQ_TRIGGER_DISABLE  0x00UL
+#define MP_PIN_IRQ_ALLOWED_FLAGS    (CY_GPIO_INTR_RISING | CY_GPIO_INTR_FALLING)
 
-static mp_uint_t machine_pin_irq_trigger(mp_obj_t self_in, mp_uint_t new_trigger) {
+static void machine_pin_irq_config(machine_pin_irq_obj_t *irq, uint32_t trigger) {
+    machine_pin_obj_t *self = MP_OBJ_TO_PTR(irq->base.parent);
+    if (trigger == MP_PIN_IRQ_TRIGGER_DISABLE) {
+        sys_int_deinit(irq->port_cfg);
+        Cy_GPIO_ClearInterrupt(Cy_GPIO_PortToAddr(self->port), self->pin);
+        Cy_GPIO_SetInterruptMask(Cy_GPIO_PortToAddr(self->port), self->pin, 0u);
+        return;
+    } else {
+        Cy_GPIO_ClearInterrupt(Cy_GPIO_PortToAddr(self->port), self->pin);
+        Cy_GPIO_SetInterruptEdge(Cy_GPIO_PortToAddr(self->port), self->pin, trigger);
+        Cy_GPIO_SetInterruptMask(Cy_GPIO_PortToAddr(self->port), self->pin, 1u);
+        sys_int_init(irq->port_cfg);
+    }
+}
+
+static mp_uint_t machine_pin_irq_trigger(mp_obj_t self_in, mp_uint_t trigger) {
     machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    machine_pin_irq_obj_t *irq = machine_pin_irq_obj[machine_pin_irq_obj_find_index(self->port, self->pin)];
+    machine_pin_irq_obj_t *irq = machine_pin_get_irq_obj(self);
 
     /* Check the trigger */
-    mp_uint_t not_supported = new_trigger & ~MP_PIN_IRQ_ALLOWED_FLAGS;
-    if (new_trigger != 0 && not_supported) {
+    mp_uint_t not_supported = trigger & ~MP_PIN_IRQ_ALLOWED_FLAGS;
+    if (trigger != 0 && not_supported) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("trigger 0x%08x unsupported"), not_supported);
     }
 
     irq->flags = 0;
-    irq->trigger = new_trigger;
+    irq->trigger = trigger;
 
-    Cy_GPIO_ClearInterrupt(Cy_GPIO_PortToAddr(self->port), self->pin);
-    Cy_GPIO_SetInterruptEdge(Cy_GPIO_PortToAddr(self->port), self->pin, new_trigger);
-    Cy_GPIO_SetInterruptMask(Cy_GPIO_PortToAddr(self->port), self->pin, 1u);
+    machine_pin_irq_config(irq, trigger);
 
-    sys_int_init(irq->port_cfg);
     return 0;
 }
 
 static mp_uint_t machine_pin_irq_info(mp_obj_t self_in, mp_uint_t info_type) {
     machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    machine_pin_irq_obj_t *irq = machine_pin_irq_obj[machine_pin_irq_obj_find_index(self->port, self->pin)];
+    machine_pin_irq_obj_t *irq = machine_pin_get_irq_obj(self);
 
     if (info_type == MP_IRQ_INFO_FLAGS) {
         return irq->flags;
@@ -249,20 +267,19 @@ static const mp_irq_methods_t machine_pin_irq_methods = {
     .info = machine_pin_irq_info,
 };
 
-machine_pin_irq_obj_t *machine_pin_irq_get_irq(const machine_pin_obj_t *self) {
-    int idx = machine_pin_irq_obj_get_index(self->port, self->pin);
-    machine_pin_irq_obj_t *irq = machine_pin_irq_obj[idx];
+static void machine_pin_irq_obj_init(machine_pin_irq_obj_t *irq, machine_pin_obj_t *parent_pin) {
+    mp_irq_init(&irq->base, &machine_pin_irq_methods, MP_OBJ_FROM_PTR(parent_pin));
+    irq->flags = 0;
+    irq->trigger = 0;
+    irq->port_cfg = &port_irq_cfg[parent_pin->port];
+}
 
-    if (irq == NULL) {
-        irq = m_new_obj(machine_pin_irq_obj_t);
-        mp_irq_init(&irq->base, &machine_pin_irq_methods, MP_OBJ_FROM_PTR(self));
-        irq->flags = 0;
-        irq->trigger = 0;
-        irq->port_cfg = &port_irq_cfg[self->port];
-        machine_pin_irq_obj[idx] = irq;
-    }
-
-    return irq;
+static void machine_pin_irq_obj_deinit(machine_pin_irq_obj_t *irq) {
+    irq->base.handler = mp_const_none;
+    irq->base.ishard = false;
+    irq->trigger = 0;
+    irq->flags = 0;
+    irq->port_cfg = NULL;
 }
 
 mp_obj_t machine_pin_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
@@ -278,15 +295,23 @@ mp_obj_t machine_pin_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_a
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    machine_pin_irq_obj_t *irq = machine_pin_irq_get_irq(self);
+    machine_pin_irq_obj_t *irq = machine_pin_get_irq_obj(self);
+    if (irq == NULL) {
+        irq = machine_pin_irq_obj_allocate();
+        machine_pin_irq_obj_init(irq, self);
+    }
 
     if (n_args > 1 || kw_args->used != 0) {
-
         /* Check the handler */
         mp_obj_t handler = args[ARG_handler].u_obj;
         if (handler != mp_const_none && !mp_obj_is_callable(handler)) {
             mp_raise_ValueError(MP_ERROR_TEXT("handler must be None or callable"));
+            /* If handler is None, disable the IRQ */
+        } else if (handler == mp_const_none) {
+            machine_pin_irq_trigger(self, MP_PIN_IRQ_TRIGGER_DISABLE);
+            return MP_OBJ_FROM_PTR(irq);
         }
+
         irq->base.handler = args[ARG_handler].u_obj;
         irq->base.ishard = args[ARG_hard].u_bool;
         machine_pin_irq_set_priority(irq->port_cfg, self->port, args[ARG_priority].u_int);
@@ -300,14 +325,9 @@ void machine_pin_irq_deinit_all(void) {
     for (uint32_t i = 0; i < MICROPY_PY_MACHINE_PIN_CPU_NUM_ENTRIES; i++) {
         machine_pin_irq_obj_t *irq = machine_pin_irq_obj[i];
         if (irq != NULL) {
-            sys_int_deinit(irq->port_cfg);
-
-            machine_pin_obj_t *self = MP_OBJ_TO_PTR(irq->base.parent);
-            Cy_GPIO_ClearInterrupt(Cy_GPIO_PortToAddr(self->port), self->pin);
-            Cy_GPIO_SetInterruptMask(Cy_GPIO_PortToAddr(self->port), self->pin, 0u);
-
-            m_del_obj(machine_pin_irq_obj_t, irq);
-            machine_pin_irq_obj[i] = NULL;
+            machine_pin_irq_config(irq, MP_PIN_IRQ_TRIGGER_DISABLE);
+            machine_pin_irq_obj_deinit(irq);
+            machine_pin_irq_obj_dealloc(irq);
         }
     }
 }

--- a/tests/ports/psoc-edge/board_ext_hw/single/pin_irq.py
+++ b/tests/ports/psoc-edge/board_ext_hw/single/pin_irq.py
@@ -44,6 +44,14 @@ irq = pin_irq.irq(irq_handler_hard, trigger=Pin.IRQ_FALLING, hard=True)
 pin_trigger(0)
 
 
+# Trigger set to None, should not trigger any interrupt.
+pin_irq.irq(None)
+pin_trigger(1)
+pin_trigger(0)
+pin_trigger(1)
+pin_trigger(0)
+
+
 # Invalid trigger
 try:
     irq.trigger(0x35)

--- a/tests/ports/psoc-edge/board_ext_hw/single/pin_irq.py
+++ b/tests/ports/psoc-edge/board_ext_hw/single/pin_irq.py
@@ -1,4 +1,5 @@
 from machine import Pin
+import time
 
 # Two pins are connected together.
 # An output pin triggers the interrupt.
@@ -13,23 +14,38 @@ def irq_handler(pin):
 
 # Configure the IRQ handler to trigger on falling edge
 # The handler should be called twice
-pin_irq.irq(irq_handler, trigger=Pin.IRQ_FALLING)
+irq = pin_irq.irq(irq_handler, trigger=Pin.IRQ_FALLING)
 pin_trigger(0)
 pin_trigger(1)
 pin_trigger(0)
+# Wait for the interrupts to be processed
+time.sleep_ms(50)
+print("irq flag falling:", irq.flags() == Pin.IRQ_FALLING)
+
 
 # Now it is configured to trigger on rising edge.
 # The handler should be called twice
-pin_irq.irq(irq_handler, trigger=Pin.IRQ_RISING)
+irq.trigger(Pin.IRQ_RISING)
 pin_trigger(0)
 pin_trigger(1)
+time.sleep_ms(50)
 pin_trigger(0)
 pin_trigger(1)
+time.sleep_ms(50)
+print("irq flag rising:", irq.flags() == Pin.IRQ_RISING)
 
-# TODO: The priority and ishard parameters are not tested.
-# These might be added in the future if we find a suitable HIL functional test.
 
-# Wait for the interrupts to be processed
-import time
+# Test hard IRQ
+def irq_handler_hard(pin):
+    print("irq hard")
 
-time.sleep_ms(500)
+
+irq = pin_irq.irq(irq_handler_hard, trigger=Pin.IRQ_FALLING, hard=True)
+pin_trigger(0)
+
+
+# Invalid trigger
+try:
+    irq.trigger(0x35)
+except ValueError as e:
+    print("error:", e)

--- a/tests/ports/psoc-edge/board_ext_hw/single/pin_irq.py.exp
+++ b/tests/ports/psoc-edge/board_ext_hw/single/pin_irq.py.exp
@@ -1,4 +1,8 @@
 irq
 irq
+irq flag falling: True
 irq
 irq
+irq flag rising: True
+irq hard
+error: trigger 0x00000034 unsupported


### PR DESCRIPTION
@IFX-Anusha All very good with the existing fix. I just wanted to complete the tickets that were pending  for Pin IRQ topic to be completed with the respect to the official merge PR 😊. 

I added 3 things:

1. In `machine_pin_irq_port_handler()` :
 * I removed the irq `idx `out of bound verification as no invalid `(port, pin)` should be passed here. That validation should have happened already in the `Pin()` constructor. And we have as many Pin IRQ objects as MICROPY_PY_MACHINE_PIN_CPU_NUM_ENTRIES`. The verification does not harm, but it makes the code a bit less simple/readable. 
 * The `irq->flags`are taking the `irq->trigger` instead of just 1. Ideallly we could say which edge has triggered the interrupt, but I think that isn't available in the PDL API.
 
 2. The verification of the `trigger` and `handler` parameters. 
 3. I needed to add `machine.Pin.irq(None)` disable the interrupt. So that invited to some refactoring of the alloc/dealloc and init/deinit of the irq objects.
