### PR TITLE
Enable Machine PWM

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -98,6 +98,9 @@
 [submodule "lib/psoc-edge/se-rt-services-utils"]
 	path = lib/psoc-edge/se-rt-services-utils
 	url = https://github.com/Infineon/se-rt-services-utils.git
+[submodule "lib/psoc-edge/cmsis"]
+	path = lib/psoc-edge/cmsis
+	url = https://github.com/Infineon/cmsis.git
 [submodule "lib/psoc-edge/serial-memory"]
 	path = lib/psoc-edge/serial-memory
 	url = https://github.com/Infineon/serial-memory.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -98,9 +98,6 @@
 [submodule "lib/psoc-edge/se-rt-services-utils"]
 	path = lib/psoc-edge/se-rt-services-utils
 	url = https://github.com/Infineon/se-rt-services-utils.git
-[submodule "lib/psoc-edge/cmsis"]
-	path = lib/psoc-edge/cmsis
-	url = https://github.com/Infineon/cmsis.git
 [submodule "lib/psoc-edge/serial-memory"]
 	path = lib/psoc-edge/serial-memory
 	url = https://github.com/Infineon/serial-memory.git

--- a/docs/psoc-edge/quickref.rst
+++ b/docs/psoc-edge/quickref.rst
@@ -631,44 +631,10 @@ Constructor
       - ``freq`` — output frequency in Hz (**required**). Must be in the range 1 - 500 000.
       - ``duty_u16`` — duty cycle as a 16-bit unsigned integer 0-65535 (0 % - ~100 %).
       - ``duty_ns`` — duty cycle (high pulse width) in nanoseconds. Must not exceed the period (``1 000 000 000 / freq`` ns).
-            .. note:: Either one of ``duty_u16`` or ``duty_ns`` must be supplied.
       - ``invert`` — if ``True``, inverts the output polarity. Default is ``False``.
 
     Raises ``ValueError`` if the pin does not support PWM, if a PWM instance for that pin already exists without calling ``deinit()`` 
     first, or if the frequency or duty arguments are out of range.
-
-Methods
-^^^^^^^^
-
-See :ref:`machine.PWM <machine.PWM>` for the full API. The following notes describe
-port-specific behaviour:
-
-.. method:: PWM.init(*, freq, duty_u16, duty_ns, invert=False)
-
-    Same constraints as the constructor apply (see above).
-
-.. method:: PWM.deinit()
-
-    In addition to stopping the counter, the pin is restored to Hi-Z GPIO mode and
-    its instance slot is released for reuse.
-
-.. method:: PWM.freq([freq])
-
-    Frequency must be in the range **1 – 500 000 Hz**. When the duty cycle was set
-    via ``duty_ns``, the setter also validates that the stored on-time does not exceed
-    the new period; a ``ValueError`` is raised if it does.
-
-.. method:: PWM.duty_u16([duty_u16])
-
-    Values above 65535 are silently clamped to 65535. If the instance was last
-    configured with ``duty_ns``, the getter converts and returns the equivalent u16
-    value.
-
-.. method:: PWM.duty_ns([duty_ns])
-
-    Raises ``ValueError`` if the requested on-time exceeds the current period
-    (``1 000 000 000 / freq`` ns). If the instance was last configured with
-    ``duty_u16``, the getter converts and returns the equivalent nanosecond value.
 
 Complete example
 ^^^^^^^^^^^^^^^^

--- a/docs/psoc-edge/quickref.rst
+++ b/docs/psoc-edge/quickref.rst
@@ -597,3 +597,105 @@ Methods
 .. method:: UART.init(baudrate=9600, bits=8, parity=None, stop=1, *, ...)
 
     The same parameters as the constructor are supported, with the same limitations.
+    
+PWM
+----
+
+Pulse Width Modulation (PWM) signal output on the PSOC™ Edge. See :ref:`machine.PWM <machine.PWM>` for the standard MicroPython PWM API.
+
+.. note::
+
+    On this port, PWM output is available exclusively on pins **P16_1** through **P16_7**. Each pin is backed by an independent TCPWM0 counter, 
+    so each instance can run at a different frequency simultaneously. A maximum of **7** PWM instances can be active at the same time.
+
+.. note::
+
+    The base clock driving all counters is **1 MHz** (derived from the 100 MHz PCLK via a shared 16-bit divider). 
+    This gives a frequency range of **1 Hz - 500 kHz** and a period resolution of 1 µs.
+
+A PWM object can be created and started using::
+
+    from machine import PWM
+
+    pwm = PWM("P16_1", freq=1000, duty_u16=32767)  # 1 kHz, 50 % duty cycle
+
+Constructor
+^^^^^^^^^^^^
+
+.. class:: PWM(pin, *, freq, duty_u16, duty_ns, invert=False)
+
+    Construct and immediately start a PWM signal on *pin*.
+
+      - ``pin`` — the output pin. Accepts a string label (``"P16_1"``), a ``Pin.cpu.<pin>`` object, or a ``Pin.board.<pin>`` object.
+        The pin must be one of the PWM-capable pins P16_1 - P16_7.
+      - ``freq`` — output frequency in Hz (**required**). Must be in the range 1 - 500 000.
+      - ``duty_u16`` — duty cycle as a 16-bit unsigned integer 0-65535 (0 % - ~100 %).
+      - ``duty_ns`` — duty cycle (high pulse width) in nanoseconds. Must not exceed the period (``1 000 000 000 / freq`` ns).
+            .. note:: Either one of ``duty_u16`` or ``duty_ns`` must be supplied.
+      - ``invert`` — if ``True``, inverts the output polarity. Default is ``False``.
+
+    Raises ``ValueError`` if the pin does not support PWM, if a PWM instance for that pin already exists without calling ``deinit()`` 
+    first, or if the frequency or duty arguments are out of range.
+
+Methods
+^^^^^^^^
+
+See :ref:`machine.PWM <machine.PWM>` for the full API. The following notes describe
+port-specific behaviour:
+
+.. method:: PWM.init(*, freq, duty_u16, duty_ns, invert=False)
+
+    Same constraints as the constructor apply (see above).
+
+.. method:: PWM.deinit()
+
+    In addition to stopping the counter, the pin is restored to Hi-Z GPIO mode and
+    its instance slot is released for reuse.
+
+.. method:: PWM.freq([freq])
+
+    Frequency must be in the range **1 – 500 000 Hz**. When the duty cycle was set
+    via ``duty_ns``, the setter also validates that the stored on-time does not exceed
+    the new period; a ``ValueError`` is raised if it does.
+
+.. method:: PWM.duty_u16([duty_u16])
+
+    Values above 65535 are silently clamped to 65535. If the instance was last
+    configured with ``duty_ns``, the getter converts and returns the equivalent u16
+    value.
+
+.. method:: PWM.duty_ns([duty_ns])
+
+    Raises ``ValueError`` if the requested on-time exceeds the current period
+    (``1 000 000 000 / freq`` ns). If the instance was last configured with
+    ``duty_u16``, the getter converts and returns the equivalent nanosecond value.
+
+Complete example
+^^^^^^^^^^^^^^^^
+
+::
+
+    from machine import PWM
+
+    # Start a 1 kHz signal at 50 % duty cycle on P16_1
+    pwm = PWM("P16_1", freq=1000, duty_u16=32767)
+    print(pwm)                     # PWM(Pin.cpu.P16_1, freq=1000, duty=50.00%)
+
+    # Read back the current settings
+    print(pwm.freq())              # 1000
+    print(pwm.duty_u16())          # 32767
+    print(pwm.duty_ns())           # 500000  (0.5 ms duty cycle at 1 kHz)
+
+    # Update frequency only — duty ratio preserved
+    pwm.freq(2000)
+    print(pwm.freq())              # 2000
+
+    # Switch to nanosecond duty control: 250 µs duty cycle at 2 kHz = 50 %
+    pwm.duty_ns(250000)
+    print(pwm.duty_ns())           # 250000
+
+    # Reconfigure completely
+    pwm.init(freq=500, duty_u16=16383)   # 500 Hz, 25 %
+
+    # Stop and release the pin
+    pwm.deinit()

--- a/ports/psoc-edge/Makefile
+++ b/ports/psoc-edge/Makefile
@@ -317,7 +317,6 @@ MOD_SRC_C += \
 	modpsocedge.c \
 	machine_ipc.c \
 	machine_scb.c \
-	machine_pwm.c \
 
 ifeq ($(MICROPY_PY_EXT_FLASH),1)
 	CFLAGS += -DMICROPY_ENABLE_EXT_QSPI_FLASH=1

--- a/ports/psoc-edge/Makefile
+++ b/ports/psoc-edge/Makefile
@@ -233,6 +233,7 @@ PSE_LIB_SRC_C += $(addprefix $(PSE_LIB_TOP_DIR)/, \
 	mtb-dsl-pse8xxgp/pdl/drivers/source/cy_syspm_ppu.c \
 	mtb-dsl-pse8xxgp/pdl/drivers/source/cy_syspm_v4.c \
 	mtb-dsl-pse8xxgp/pdl/drivers/source/cy_tcpwm_counter.c \
+	mtb-dsl-pse8xxgp/pdl/drivers/source/cy_tcpwm_pwm.c \
 	mtb-dsl-pse8xxgp/pdl/drivers/source/ppu_v1.c \
 	\
 	mtb-dsl-pse8xxgp/support/source/mtb_stdlib_stubs.c \
@@ -316,6 +317,7 @@ MOD_SRC_C += \
 	modpsocedge.c \
 	machine_ipc.c \
 	machine_scb.c \
+	machine_pwm.c \
 
 ifeq ($(MICROPY_PY_EXT_FLASH),1)
 	CFLAGS += -DMICROPY_ENABLE_EXT_QSPI_FLASH=1

--- a/ports/psoc-edge/machine_pwm.c
+++ b/ports/psoc-edge/machine_pwm.c
@@ -27,8 +27,10 @@
 #include "py/runtime.h"
 #include "py/mphal.h"
 #include "modmachine.h"
+#include "cy_gpio.h"
 #include "cy_tcpwm_pwm.h"
 #include "cycfg_peripherals.h"
+#include "machine_pin.h"
 
 typedef enum {
     VALUE_NOT_SET = -1,
@@ -40,7 +42,7 @@ typedef enum {
 typedef struct _machine_pwm_obj_t {
     mp_obj_base_t base;                     /**< MicroPython base object */
     cy_stc_tcpwm_pwm_config_t pwm_obj;      /**< PDL PWM configuration struct */
-    mp_obj_t dest;                          /**< PWM output destination: Pin object or integer pin number */
+    const machine_pin_obj_t *pin;           /**< Resolved GPIO pin object for PWM output */
     uint32_t frequency;                     /**< PWM output frequency in Hz */
     duty_type_t duty_type;                  /**< Indicates whether duty is set as DUTY_U16 or DUTY_NS */
     mp_int_t duty;                          /**< Duty cycle value: 0-65535 if DUTY_U16, nanoseconds if DUTY_NS */
@@ -52,6 +54,8 @@ typedef struct _machine_pwm_obj_t {
 
 // TCPWM clock = PCLK (100 MHz) / (divider+1) = 100,000,000 / 50,000 = 2000 Hz
 #define CYBSP_PWM_LED_CTRL_CLK_HZ   2000UL
+
+#define TCPWM_PWM_CTRL_NUM   (0UL)
 
 #define pwm_assert_raise_val(msg, ret)   if (ret != CY_RSLT_SUCCESS) { \
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT(msg), ret); \
@@ -91,6 +95,20 @@ static void pwm_duty_ns_assert(mp_int_t duty_ns, uint32_t freq) {
     if (duty_ns > (int)(1000000000 / freq)) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("PWM duty in ns is larger than the period %d ns"), (int)(1000000000 / freq));
     }
+}
+
+// Configure the GPIO pin to route the TCPWM output via HSIOM (HSIOM_SEL_ACT_1 = 9 for all TCPWM0 outputs)
+static void pwm_pin_config(const machine_pin_obj_t *pin) {
+    GPIO_PRT_Type *port = Cy_GPIO_PortToAddr(pin->port);
+    Cy_GPIO_SetHSIOM(port, pin->pin, HSIOM_SEL_ACT_1);
+    Cy_GPIO_SetDrivemode(port, pin->pin, CY_GPIO_DM_STRONG_IN_OFF);
+}
+
+// Restore the GPIO pin to plain GPIO mode (Hi-Z, no peripheral routing)
+static void pwm_pin_restore(const machine_pin_obj_t *pin) {
+    GPIO_PRT_Type *port = Cy_GPIO_PortToAddr(pin->port);
+    Cy_GPIO_SetHSIOM(port, pin->pin, HSIOM_SEL_GPIO);    
+    Cy_GPIO_SetDrivemode(port, pin->pin, CY_GPIO_DM_HIGHZ);
 }
 
 // methods for machine.PWM
@@ -155,21 +173,25 @@ static void mp_machine_pwm_init_helper(machine_pwm_obj_t *self, size_t n_args, c
     /* Apply frequency and duty cycle to the PWM config struct */
     pwm_config(self);
 
-    cy_rslt_t result = Cy_TCPWM_PWM_Init(CYBSP_PWM_LED_CTRL_HW,
-            CYBSP_PWM_LED_CTRL_NUM, &self->pwm_obj);
+    /* Route the TCPWM output to the configured GPIO pin */
+    pwm_pin_config(self->pin);
+
+    cy_rslt_t result = Cy_TCPWM_PWM_Init(TCPWM0,
+            TCPWM_PWM_CTRL_NUM, &self->pwm_obj);
     pwm_assert_raise_val("PWM init failed with return code %lx !", result);
 
     /* Enable the TCPWM block */
-    Cy_TCPWM_PWM_Enable(CYBSP_PWM_LED_CTRL_HW, CYBSP_PWM_LED_CTRL_NUM);
+    Cy_TCPWM_PWM_Enable(TCPWM0, TCPWM_PWM_CTRL_NUM);
 
     /* Start the PWM */
-    Cy_TCPWM_TriggerReloadOrIndex_Single(CYBSP_PWM_LED_CTRL_HW, CYBSP_PWM_LED_CTRL_NUM);
+    Cy_TCPWM_TriggerReloadOrIndex_Single(TCPWM0, TCPWM_PWM_CTRL_NUM);
 }
 
 static void mp_machine_pwm_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     machine_pwm_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_printf(print, "PWM(freq=%u, duty=%.2f%%)", 
-        self->frequency, 
+    mp_printf(print, "PWM(Pin.cpu.%q, freq=%u, duty=%.2f%%)",
+        self->pin->name,
+        self->frequency,
         self->duty_type == DUTY_U16 ? pwm_duty_cycle_u16_to_percent(self->duty) : pwm_duty_cycle_ns_to_percent(self->duty, self->frequency));
 }
 
@@ -181,8 +203,8 @@ static mp_obj_t mp_machine_pwm_make_new(const mp_obj_type_t *type, size_t n_args
     // Get static peripheral object.
     machine_pwm_obj_t *self = pwm_obj_alloc();
 
-    // Store dest (Pin object or integer pin number)
-    self->dest = args[0];
+    // Resolve dest to a pin object (accepts Pin object, board name string, or CPU name string)
+    self->pin = machine_pin_get_pin_obj(args[0]);
 
     // Default config parameters for the PWM object.
     self->pwm_obj.pwmMode = CY_TCPWM_PWM_MODE_PWM;
@@ -236,7 +258,8 @@ static mp_obj_t mp_machine_pwm_make_new(const mp_obj_type_t *type, size_t n_args
 }
 
 static void mp_machine_pwm_deinit(machine_pwm_obj_t *self) {
-    Cy_TCPWM_PWM_Disable(CYBSP_PWM_LED_CTRL_HW, CYBSP_PWM_LED_CTRL_NUM);
+    Cy_TCPWM_PWM_Disable(TCPWM0, TCPWM_PWM_CTRL_NUM);
+    pwm_pin_restore(self->pin);
     pwm_obj_free(self);
 }
 

--- a/ports/psoc-edge/machine_pwm.c
+++ b/ports/psoc-edge/machine_pwm.c
@@ -38,35 +38,206 @@ typedef enum {
 } duty_type_t;
 
 typedef struct _machine_pwm_obj_t {
-    mp_obj_base_t base;
-    cy_stc_tcpwm_pwm_config_t pwm_obj;
-    uint32_t pin;
-    uint32_t frequency;
-    duty_type_t duty_type;
-    mp_int_t duty;
-    bool invert;
+    mp_obj_base_t base;                     /**< MicroPython base object */
+    cy_stc_tcpwm_pwm_config_t pwm_obj;      /**< PDL PWM configuration struct */
+    mp_obj_t dest;                          /**< PWM output destination: Pin object or integer pin number */
+    uint32_t frequency;                     /**< PWM output frequency in Hz */
+    duty_type_t duty_type;                  /**< Indicates whether duty is set as DUTY_U16 or DUTY_NS */
+    mp_int_t duty;                          /**< Duty cycle value: 0-65535 if DUTY_U16, nanoseconds if DUTY_NS */
+    bool invert;                            /**< If true, inverts the PWM output signal polarity */
 } machine_pwm_obj_t;
 
+/** Input trigger mode value meaning "disabled" - passed to inputMode fields (masked with 0x3U to extract the 2-bit mode) */
+#define CYBSP_PWM_LED_CTRL_INPUT_DISABLED 0x7U
+
+// TCPWM clock = PCLK (100 MHz) / (divider+1) = 100,000,000 / 50,000 = 2000 Hz
+#define CYBSP_PWM_LED_CTRL_CLK_HZ   2000UL
+
+#define pwm_assert_raise_val(msg, ret)   if (ret != CY_RSLT_SUCCESS) { \
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT(msg), ret); \
+}
+
+/* Unit conversion macros */
+ #define pwm_duty_cycle_ns_to_u16(duty_ns, freq)        ((int)(((float)(duty_ns * freq) / (float)1000000000) * (float)65536) - 1)
+ #define pwm_duty_cycle_u16_to_ns(duty_u16, freq)       ((int)(((float)(duty_u16 + 1) / (float)65536) * ((float)1000000000 / (float)freq)))
+ #define pwm_duty_cycle_u16_to_percent(duty_u16)        ((float)(duty_u16 + 1) * 100 / (float)65536)
+ #define pwm_duty_cycle_ns_to_percent(duty_ns, freq)    ((float)((duty_ns) * 100) / (float)(1000000000 / freq))
+ #define pwm_duty_cycle_percent_to_compare(duty_percent, period) ((int)(((float)duty_percent / (float)100) * (float)period))
+ #define pwm_freq_to_period_us(freq)                    ((uint32_t)(1000000 / freq))
+ #define pwm_period_ns_to_us(period_ns)                 ((uint32_t)(period_ns / 1000))
+ #define pwm_duty_cycle_u16_to_compare(duty_u16, period) ((int)(((float)(duty_u16 + 1) / (float)65536) * (float)period))
+
+static machine_pwm_obj_t *pwm_obj[MICROPY_PY_MACHINE_PWM_MAX_OBJS] = { NULL };
+
+static inline machine_pwm_obj_t *pwm_obj_alloc() {
+    for (uint8_t i = 0; i < MICROPY_PY_MACHINE_PWM_MAX_OBJS; i++) {
+        if (pwm_obj[i] == NULL) {
+            pwm_obj[i] = mp_obj_malloc(machine_pwm_obj_t, &machine_pwm_type);
+            return pwm_obj[i];
+        }
+    }
+    return NULL;
+}
+
+static inline void pwm_obj_free(machine_pwm_obj_t *pwm_obj_ptr) {
+    for (uint8_t i = 0; i < MICROPY_PY_MACHINE_PWM_MAX_OBJS; i++) {
+        if (pwm_obj[i] == pwm_obj_ptr) {
+            pwm_obj[i] = NULL;
+        }
+    }
+}
+
+static void pwm_duty_ns_assert(mp_int_t duty_ns, uint32_t freq) {
+    if (duty_ns > (int)(1000000000 / freq)) {
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("PWM duty in ns is larger than the period %d ns"), (int)(1000000000 / freq));
+    }
+}
+
+// methods for machine.PWM
+static void pwm_config(machine_pwm_obj_t *self) {
+
+    if (self->frequency == 0) {
+        mp_raise_ValueError(MP_ERROR_TEXT("PWM frequency must be greater than 0"));
+    }
+    self->pwm_obj.period0 = CYBSP_PWM_LED_CTRL_CLK_HZ / self->frequency;
+    self->pwm_obj.period1 = CYBSP_PWM_LED_CTRL_CLK_HZ / self->frequency;
+    
+    if (self->duty_type == DUTY_U16) {
+        self->pwm_obj.compare0 = pwm_duty_cycle_u16_to_compare(self->duty, self->pwm_obj.period0);
+        self->pwm_obj.compare1 = pwm_duty_cycle_u16_to_compare(self->duty, self->pwm_obj.period1);
+    } else if (self->duty_type == DUTY_NS) {
+        self->pwm_obj.compare0 = pwm_duty_cycle_ns_to_u16(self->duty, self->frequency);
+        self->pwm_obj.compare1 = pwm_duty_cycle_ns_to_u16(self->duty, self->frequency);
+    }
+
+    self->pwm_obj.invertPWMOut = self->invert;
+}
+
+static void mp_machine_pwm_init_helper(machine_pwm_obj_t *self, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    enum { ARG_freq, ARG_duty_u16, ARG_duty_ns, ARG_invert};
+
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_freq,     MP_ARG_KW_ONLY | MP_ARG_INT,  {.u_int = VALUE_NOT_SET} },
+        { MP_QSTR_duty_u16, MP_ARG_KW_ONLY | MP_ARG_INT,  {.u_int = VALUE_NOT_SET} },
+        { MP_QSTR_duty_ns,  MP_ARG_KW_ONLY | MP_ARG_INT,  {.u_int = VALUE_NOT_SET} },
+        { MP_QSTR_invert,   MP_ARG_KW_ONLY | MP_ARG_BOOL, {.u_bool = false} },
+    };
+
+    // Parse the arguments.
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args, pos_args, kw_args,
+        MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    if (args[ARG_freq].u_int != VALUE_NOT_SET) {
+        self->frequency = args[ARG_freq].u_int;
+    }
+
+    if (args[ARG_invert].u_bool) {
+        self->invert = true;
+    }
+
+    if (args[ARG_duty_u16].u_int != VALUE_NOT_SET &&
+        args[ARG_duty_ns].u_int != VALUE_NOT_SET) {
+        mp_raise_ValueError(MP_ERROR_TEXT("PWM duty should be specified only in one format"));
+    }
+
+    if (args[ARG_duty_u16].u_int != VALUE_NOT_SET) {
+        self->duty = args[ARG_duty_u16].u_int > 65535 ? 65535 : args[ARG_duty_u16].u_int;
+        self->duty_type = DUTY_U16;
+    } else if (args[ARG_duty_ns].u_int != VALUE_NOT_SET) {
+        pwm_duty_ns_assert(args[ARG_duty_ns].u_int, self->frequency);
+        self->duty = args[ARG_duty_ns].u_int;
+        self->duty_type = DUTY_NS;
+    } else {
+        mp_raise_ValueError(MP_ERROR_TEXT("PWM duty should be specified in either ns or u16"));
+    } 
+    
+    /* Apply frequency and duty cycle to the PWM config struct */
+    pwm_config(self);
+
+    cy_rslt_t result = Cy_TCPWM_PWM_Init(CYBSP_PWM_LED_CTRL_HW,
+            CYBSP_PWM_LED_CTRL_NUM, &self->pwm_obj);
+    pwm_assert_raise_val("PWM init failed with return code %lx !", result);
+
+    /* Enable the TCPWM block */
+    Cy_TCPWM_PWM_Enable(CYBSP_PWM_LED_CTRL_HW, CYBSP_PWM_LED_CTRL_NUM);
+
+    /* Start the PWM */
+    Cy_TCPWM_TriggerReloadOrIndex_Single(CYBSP_PWM_LED_CTRL_HW, CYBSP_PWM_LED_CTRL_NUM);
+}
+
 static void mp_machine_pwm_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
-    mp_printf(print, "PWM() - not implemented");
+    machine_pwm_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    mp_printf(print, "PWM(freq=%u, duty=%.2f%%)", 
+        self->frequency, 
+        self->duty_type == DUTY_U16 ? pwm_duty_cycle_u16_to_percent(self->duty) : pwm_duty_cycle_ns_to_percent(self->duty, self->frequency));
 }
 
 static mp_obj_t mp_machine_pwm_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
 
-    // Check number of arguments
+    // Check number of arguments: dest is required
     mp_arg_check_num(n_args, n_kw, 1, MP_OBJ_FUN_ARGS_MAX, true);
 
-    mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM not implemented"));   
+    // Get static peripheral object.
+    machine_pwm_obj_t *self = pwm_obj_alloc();
 
-}
+    // Store dest (Pin object or integer pin number)
+    self->dest = args[0];
 
-static void mp_machine_pwm_init_helper(machine_pwm_obj_t *self, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
-    
-    mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM partially implemented"));
+    // Default config parameters for the PWM object.
+    self->pwm_obj.pwmMode = CY_TCPWM_PWM_MODE_PWM;
+    self->pwm_obj.clockPrescaler = CY_TCPWM_PWM_PRESCALER_DIVBY_1;
+    self->pwm_obj.pwmAlignment = CY_TCPWM_PWM_LEFT_ALIGN;  
+    self->pwm_obj.deadTimeClocks = 0;
+    self->pwm_obj.runMode = CY_TCPWM_PWM_CONTINUOUS;
+    self->pwm_obj.enablePeriodSwap = false;
+    self->pwm_obj.enableCompareSwap = false;
+    self->pwm_obj.interruptSources = (CY_TCPWM_INT_ON_TC & 0U) | (CY_TCPWM_INT_ON_CC0 & 0U) | (CY_TCPWM_INT_ON_CC1 & 0U);    
+    self->pwm_obj.invertPWMOutN = CY_TCPWM_PWM_INVERT_ENABLE;
+    self->pwm_obj.killMode = CY_TCPWM_PWM_ASYNC_KILL;
+    self->pwm_obj.swapInputMode = CYBSP_PWM_LED_CTRL_INPUT_DISABLED & 0x3U;
+    self->pwm_obj.swapInput = CY_TCPWM_INPUT_0;
+    self->pwm_obj.reloadInputMode = CYBSP_PWM_LED_CTRL_INPUT_DISABLED & 0x3U;
+    self->pwm_obj.reloadInput = CY_TCPWM_INPUT_0;
+    self->pwm_obj.startInputMode = CYBSP_PWM_LED_CTRL_INPUT_DISABLED & 0x3U;
+    self->pwm_obj.startInput = CY_TCPWM_INPUT_0;
+    self->pwm_obj.killInputMode = CYBSP_PWM_LED_CTRL_INPUT_DISABLED & 0x3U;
+    self->pwm_obj.killInput = CY_TCPWM_INPUT_0;
+    self->pwm_obj.countInputMode = CYBSP_PWM_LED_CTRL_INPUT_DISABLED & 0x3U;
+    self->pwm_obj.countInput = CY_TCPWM_INPUT_1;
+    self->pwm_obj.swapOverflowUnderflow = false;
+    self->pwm_obj.immediateKill = false;
+    self->pwm_obj.tapsEnabled = 45;
+    self->pwm_obj.compare2 = CY_TCPWM_GRP_CNT_CC0_DEFAULT;
+    self->pwm_obj.compare3 = CY_TCPWM_GRP_CNT_CC0_BUFF_DEFAULT;
+    self->pwm_obj.enableCompare1Swap = false;
+    self->pwm_obj.compare0MatchUp = true;
+    self->pwm_obj.compare0MatchDown = false;
+    self->pwm_obj.compare1MatchUp = true;
+    self->pwm_obj.compare1MatchDown = false;
+    self->pwm_obj.kill1InputMode = CYBSP_PWM_LED_CTRL_INPUT_DISABLED & 0x3U;
+    self->pwm_obj.kill1Input = CY_TCPWM_INPUT_0;
+    self->pwm_obj.pwmOnDisable = CY_TCPWM_PWM_OUTPUT_HIGHZ;
+    self->pwm_obj.trigger0Event = CY_TCPWM_CNT_TRIGGER_ON_DISABLED;
+    self->pwm_obj.trigger1Event = CY_TCPWM_CNT_TRIGGER_ON_DISABLED;
+    self->pwm_obj.reloadLineSelect = false;
+    self->pwm_obj.line_out_sel = CY_TCPWM_OUTPUT_PWM_SIGNAL;
+    self->pwm_obj.linecompl_out_sel = CY_TCPWM_OUTPUT_INVERTED_PWM_SIGNAL;
+    self->pwm_obj.line_out_sel_buff = CY_TCPWM_OUTPUT_PWM_SIGNAL;
+    self->pwm_obj.linecompl_out_sel_buff = CY_TCPWM_OUTPUT_INVERTED_PWM_SIGNAL;
+    self->pwm_obj.deadTimeClocks_linecompl_out = 0;
+
+    // Process the remaining parameters (skip dest at args[0]).
+    mp_map_t kw_args;
+    mp_map_init_fixed_table(&kw_args, n_kw, args + n_args);
+    mp_machine_pwm_init_helper(self, n_args - 1, args + 1, &kw_args);
+
+    return MP_OBJ_FROM_PTR(self);
 }
 
 static void mp_machine_pwm_deinit(machine_pwm_obj_t *self) {
-    mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM not implemented"));
+    Cy_TCPWM_PWM_Disable(CYBSP_PWM_LED_CTRL_HW, CYBSP_PWM_LED_CTRL_NUM);
+    pwm_obj_free(self);
 }
 
 static mp_obj_t mp_machine_pwm_freq_get(machine_pwm_obj_t *self) {

--- a/ports/psoc-edge/machine_pwm.c
+++ b/ports/psoc-edge/machine_pwm.c
@@ -68,8 +68,6 @@ typedef struct _machine_pwm_obj_t {
 // PWM frequency.
 //
 // PWM-capable pins on KIT_PSE84_AI:
-//     P16_0 : counter 0  (shared — P9_1, P9_3, P14_3, P14_4, P17_0, P20_5 also route to counter 0;
-//           :              enabling any of those pins simultaneously will conflict with P16_0)
 //     P16_1 : counter 1
 //     P16_2 : counter 2
 //     P16_3 : counter 3
@@ -84,7 +82,6 @@ static const struct {
     uint32_t counter_num;
     en_clk_dst_t pclk_dst;     // PCLK clock destination for Cy_SysClk_PeriPclkAssignDivider
 } pwm_pin_map[] = {
-    {16, 0, 0, PCLK_TCPWM0_CLOCK_COUNTER_EN0},  // P16_0
     {16, 1, 1, PCLK_TCPWM0_CLOCK_COUNTER_EN1},  // P16_1
     {16, 2, 2, PCLK_TCPWM0_CLOCK_COUNTER_EN2},  // P16_2
     {16, 3, 3, PCLK_TCPWM0_CLOCK_COUNTER_EN3},  // P16_3

--- a/ports/psoc-edge/machine_pwm.c
+++ b/ports/psoc-edge/machine_pwm.c
@@ -220,6 +220,8 @@ static void mp_machine_pwm_init_helper(machine_pwm_obj_t *self, size_t n_args, c
         mp_raise_ValueError(MP_ERROR_TEXT("PWM duty should be specified only in one format"));
     }
 
+    self->frequency = (uint32_t)args[ARG_freq].u_int;
+
     if (args[ARG_duty_u16].u_int != VALUE_NOT_SET) {
         self->duty = args[ARG_duty_u16].u_int > 65535 ? 65535 : args[ARG_duty_u16].u_int;
         self->duty_type = DUTY_U16;
@@ -230,8 +232,6 @@ static void mp_machine_pwm_init_helper(machine_pwm_obj_t *self, size_t n_args, c
     } else {
         mp_raise_ValueError(MP_ERROR_TEXT("PWM duty should be specified in either ns or u16"));
     }
-
-    self->frequency = (uint32_t)args[ARG_freq].u_int;
 
     self->invert = args[ARG_invert].u_bool;
 
@@ -373,12 +373,40 @@ static void mp_machine_pwm_deinit(machine_pwm_obj_t *self) {
 
 // Return the current PWM output frequency in Hz.
 static mp_obj_t mp_machine_pwm_freq_get(machine_pwm_obj_t *self) {
-    mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM freq getter/setter not yet implemented"));
+    return MP_OBJ_NEW_SMALL_INT(self->frequency);
 }
 
 // Update the PWM output frequency; recalculates the period register.
 static void mp_machine_pwm_freq_set(machine_pwm_obj_t *self, mp_int_t freq) {
-    mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM freq getter/setter not yet implemented"));
+    if (freq <= 0) {
+        mp_raise_ValueError(MP_ERROR_TEXT("PWM frequency must be greater than 0"));
+    }
+    if ((uint32_t)freq > PWM_TCPWM_CLK_HZ / 2) {
+        mp_raise_msg_varg(&mp_type_ValueError,
+            MP_ERROR_TEXT("PWM frequency must not exceed %lu Hz"), (unsigned long)(PWM_TCPWM_CLK_HZ / 2));
+    }
+    if (self->duty_type == DUTY_NS) {
+        pwm_duty_ns_assert(self->duty, (uint32_t)freq);
+    }
+
+    // set the frequency
+    self->frequency = (uint32_t)freq;
+
+    /* Apply frequency and duty cycle to the PWM config struct */
+    pwm_config(self);
+
+    // Disable the TCPWM counter
+    Cy_TCPWM_PWM_Disable(TCPWM0, self->counter_num);
+
+    cy_en_tcpwm_status_t result = Cy_TCPWM_PWM_Init(TCPWM0,
+        self->counter_num, &self->pwm_obj);
+    pwm_assert_raise_val("PWM init failed with return code %lx !", result);
+
+    /* Enable the TCPWM block */
+    Cy_TCPWM_PWM_Enable(TCPWM0, self->counter_num);
+
+    /* Start the PWM */
+    Cy_TCPWM_TriggerReloadOrIndex_Single(TCPWM0, self->counter_num);
 }
 
 // Return the current duty cycle as a 16-bit value (0-65535).

--- a/ports/psoc-edge/machine_pwm.c
+++ b/ports/psoc-edge/machine_pwm.c
@@ -68,14 +68,10 @@ static const struct {
     uint32_t counter_num;
     en_clk_dst_t pclk_dst;     // PCLK clock destination for Cy_SysClk_PeriPclkAssignDivider
 } pwm_pin_map[] = {
-    {0,  0, 0, PCLK_TCPWM0_CLOCK_COUNTER_EN0},  // P0_0  - LINE0
-    {0,  1, 0, PCLK_TCPWM0_CLOCK_COUNTER_EN0},  // P0_1  - LINE_COMPL0
-    {7,  3, 0, PCLK_TCPWM0_CLOCK_COUNTER_EN0},  // P7_3  - LINE_COMPL0
-    {9,  1, 0, PCLK_TCPWM0_CLOCK_COUNTER_EN0},  // P9_1  - LINE0
-    {9,  3, 0, PCLK_TCPWM0_CLOCK_COUNTER_EN0},  // P9_3  - LINE_COMPL0
-    {11, 6, 0, PCLK_TCPWM0_CLOCK_COUNTER_EN0},  // P11_6 - LINE0
-    {14, 3, 0, PCLK_TCPWM0_CLOCK_COUNTER_EN0},  // P14_3 - LINE0
-    {14, 4, 0, PCLK_TCPWM0_CLOCK_COUNTER_EN0},  // P14_4 - LINE_COMPL0
+    // {9,  1, 0, PCLK_TCPWM0_CLOCK_COUNTER_EN0},  // P9_1  - LINE0       (shares counter 0)
+    // {9,  3, 0, PCLK_TCPWM0_CLOCK_COUNTER_EN0},  // P9_3  - LINE_COMPL0 (shares counter 0)
+    // {14, 3, 0, PCLK_TCPWM0_CLOCK_COUNTER_EN0},  // P14_3 - LINE0       (shares counter 0)
+    // {14, 4, 0, PCLK_TCPWM0_CLOCK_COUNTER_EN0},  // P14_4 - LINE_COMPL0 (shares counter 0)
     {16, 0, 0, PCLK_TCPWM0_CLOCK_COUNTER_EN0},  // P16_0 - LINE0  (counter 0)
     {16, 1, 1, PCLK_TCPWM0_CLOCK_COUNTER_EN1},  // P16_1 - LINE1  (counter 1)
     {16, 2, 2, PCLK_TCPWM0_CLOCK_COUNTER_EN2},  // P16_2 - LINE2  (counter 2)
@@ -84,8 +80,8 @@ static const struct {
     {16, 5, 5, PCLK_TCPWM0_CLOCK_COUNTER_EN5},  // P16_5 - LINE5  (counter 5)
     {16, 6, 6, PCLK_TCPWM0_CLOCK_COUNTER_EN6},  // P16_6 - LINE6  (counter 6)
     {16, 7, 7, PCLK_TCPWM0_CLOCK_COUNTER_EN7},  // P16_7 - LINE7  (counter 7)
-    {17, 0, 0, PCLK_TCPWM0_CLOCK_COUNTER_EN0},  // P17_0 - LINE_COMPL0
-    {20, 5, 0, PCLK_TCPWM0_CLOCK_COUNTER_EN0},  // P20_5 - LINE_COMPL0
+    // {17, 0, 0, PCLK_TCPWM0_CLOCK_COUNTER_EN0},  // P17_0 - LINE_COMPL0 (shares counter 0)
+    // {20, 5, 0, PCLK_TCPWM0_CLOCK_COUNTER_EN0},  // P20_5 - LINE_COMPL0 (shares counter 0)
 };
 
 // Look up the pin→counter mapping. Returns false if the pin is not PWM-capable.

--- a/ports/psoc-edge/machine_pwm.c
+++ b/ports/psoc-edge/machine_pwm.c
@@ -97,7 +97,7 @@ static bool pwm_pin_get_counter(uint8_t port, uint8_t pin, uint32_t *counter_num
 }
 
 #define pwm_assert_raise_val(msg, ret)   if (ret != CY_RSLT_SUCCESS) { \
-        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT(msg), ret); \
+            mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT(msg), ret); \
 }
 
 /* Unit conversion macros */
@@ -155,7 +155,7 @@ static void pwm_pin_config(const machine_pin_obj_t *pin) {
 // Restore the GPIO pin to plain GPIO mode (Hi-Z, no peripheral routing)
 static void pwm_pin_restore(const machine_pin_obj_t *pin) {
     GPIO_PRT_Type *port = Cy_GPIO_PortToAddr(pin->port);
-    Cy_GPIO_SetHSIOM(port, pin->pin, HSIOM_SEL_GPIO);    
+    Cy_GPIO_SetHSIOM(port, pin->pin, HSIOM_SEL_GPIO);
     Cy_GPIO_SetDrivemode(port, pin->pin, CY_GPIO_DM_HIGHZ);
 }
 
@@ -167,7 +167,7 @@ static void pwm_config(machine_pwm_obj_t *self) {
     }
     self->pwm_obj.period0 = CYBSP_PWM_LED_CTRL_CLK_HZ / self->frequency;
     self->pwm_obj.period1 = CYBSP_PWM_LED_CTRL_CLK_HZ / self->frequency;
-    
+
     if (self->duty_type == DUTY_U16) {
         self->pwm_obj.compare0 = pwm_duty_cycle_u16_to_compare(self->duty, self->pwm_obj.period0);
         self->pwm_obj.compare1 = pwm_duty_cycle_u16_to_compare(self->duty, self->pwm_obj.period1);
@@ -216,8 +216,8 @@ static void mp_machine_pwm_init_helper(machine_pwm_obj_t *self, size_t n_args, c
         self->duty_type = DUTY_NS;
     } else {
         mp_raise_ValueError(MP_ERROR_TEXT("PWM duty should be specified in either ns or u16"));
-    } 
-    
+    }
+
     /* Apply frequency and duty cycle to the PWM config struct */
     pwm_config(self);
 
@@ -229,7 +229,7 @@ static void mp_machine_pwm_init_helper(machine_pwm_obj_t *self, size_t n_args, c
     Cy_SysClk_PeriPclkAssignDivider(self->pclk_dst, CY_SYSCLK_DIV_16_BIT, CYBSP_PWM_LED_CTRL_CLK_DIV_NUM);
 
     cy_rslt_t result = Cy_TCPWM_PWM_Init(TCPWM0,
-            self->counter_num, &self->pwm_obj);
+        self->counter_num, &self->pwm_obj);
     pwm_assert_raise_val("PWM init failed with return code %lx !", result);
 
     /* Enable the TCPWM block */
@@ -278,12 +278,12 @@ static mp_obj_t mp_machine_pwm_make_new(const mp_obj_type_t *type, size_t n_args
     // Default config parameters for the PWM object.
     self->pwm_obj.pwmMode = CY_TCPWM_PWM_MODE_PWM;
     self->pwm_obj.clockPrescaler = CY_TCPWM_PWM_PRESCALER_DIVBY_1;
-    self->pwm_obj.pwmAlignment = CY_TCPWM_PWM_LEFT_ALIGN;  
+    self->pwm_obj.pwmAlignment = CY_TCPWM_PWM_LEFT_ALIGN;
     self->pwm_obj.deadTimeClocks = 0;
     self->pwm_obj.runMode = CY_TCPWM_PWM_CONTINUOUS;
     self->pwm_obj.enablePeriodSwap = false;
     self->pwm_obj.enableCompareSwap = false;
-    self->pwm_obj.interruptSources = (CY_TCPWM_INT_ON_TC & 0U) | (CY_TCPWM_INT_ON_CC0 & 0U) | (CY_TCPWM_INT_ON_CC1 & 0U);    
+    self->pwm_obj.interruptSources = (CY_TCPWM_INT_ON_TC & 0U) | (CY_TCPWM_INT_ON_CC0 & 0U) | (CY_TCPWM_INT_ON_CC1 & 0U);
     self->pwm_obj.invertPWMOutN = CY_TCPWM_PWM_INVERT_ENABLE;
     self->pwm_obj.killMode = CY_TCPWM_PWM_ASYNC_KILL;
     self->pwm_obj.swapInputMode = CYBSP_PWM_LED_CTRL_INPUT_DISABLED & 0x3U;
@@ -355,5 +355,3 @@ static mp_obj_t mp_machine_pwm_duty_get_ns(machine_pwm_obj_t *self) {
 static void mp_machine_pwm_duty_set_ns(machine_pwm_obj_t *self, mp_int_t duty_ns) {
     mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM not implemented"));
 }
-
-

--- a/ports/psoc-edge/machine_pwm.c
+++ b/ports/psoc-edge/machine_pwm.c
@@ -112,6 +112,15 @@ static bool pwm_pin_get_counter(uint8_t port, uint8_t pin, uint32_t *counter_num
 
 static machine_pwm_obj_t *pwm_obj[MICROPY_PY_MACHINE_PWM_MAX_OBJS] = { NULL };
 
+static inline machine_pwm_obj_t *pwm_obj_find_by_pin(uint8_t port, uint8_t pin) {
+    for (uint8_t i = 0; i < MICROPY_PY_MACHINE_PWM_MAX_OBJS; i++) {
+        if (pwm_obj[i] != NULL && pwm_obj[i]->pin->port == port && pwm_obj[i]->pin->pin == pin) {
+            return pwm_obj[i];
+        }
+    }
+    return NULL;
+}
+
 static inline machine_pwm_obj_t *pwm_obj_alloc() {
     for (uint8_t i = 0; i < MICROPY_PY_MACHINE_PWM_MAX_OBJS; i++) {
         if (pwm_obj[i] == NULL) {
@@ -243,14 +252,22 @@ static mp_obj_t mp_machine_pwm_make_new(const mp_obj_type_t *type, size_t n_args
     // Check number of arguments: dest is required
     mp_arg_check_num(n_args, n_kw, 1, MP_OBJ_FUN_ARGS_MAX, true);
 
+    // Resolve dest to a pin object (accepts Pin object, board name string, or CPU name string)
+    const machine_pin_obj_t *pin = machine_pin_get_pin_obj(args[0]);
+
+    // Reject if a PWM instance already exists for this pin
+    if (pwm_obj_find_by_pin(pin->port, pin->pin) != NULL) {
+        mp_raise_msg_varg(&mp_type_ValueError,
+            MP_ERROR_TEXT("PWM instance for Pin %q already exists, call deinit() first"), pin->name);
+    }
+
     // Get static peripheral object.
     machine_pwm_obj_t *self = pwm_obj_alloc();
     if (self == NULL) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("PWM: maximum number of instances (%d) reached"), MICROPY_PY_MACHINE_PWM_MAX_OBJS);
     }
 
-    // Resolve dest to a pin object (accepts Pin object, board name string, or CPU name string)
-    self->pin = machine_pin_get_pin_obj(args[0]);
+    self->pin = pin;
 
     // Look up the TCPWM counter and PCLK destination for this pin
     if (!pwm_pin_get_counter(self->pin->port, self->pin->pin, &self->counter_num, &self->pclk_dst)) {

--- a/ports/psoc-edge/machine_pwm.c
+++ b/ports/psoc-edge/machine_pwm.c
@@ -118,6 +118,7 @@ static bool pwm_pin_get_counter(uint8_t port, uint8_t pin, uint32_t *counter_num
 
 static machine_pwm_obj_t *pwm_obj[MICROPY_PY_MACHINE_PWM_MAX_OBJS] = { NULL };
 
+// Search the instance pool for an existing PWM object on the given port/pin; returns NULL if not found.
 static inline machine_pwm_obj_t *pwm_obj_find_by_pin(uint8_t port, uint8_t pin) {
     for (uint8_t i = 0; i < MICROPY_PY_MACHINE_PWM_MAX_OBJS; i++) {
         if (pwm_obj[i] != NULL && pwm_obj[i]->pin->port == port && pwm_obj[i]->pin->pin == pin) {
@@ -127,6 +128,7 @@ static inline machine_pwm_obj_t *pwm_obj_find_by_pin(uint8_t port, uint8_t pin) 
     return NULL;
 }
 
+// Allocate and return a new PWM object from the instance pool; returns NULL if the pool is full.
 static inline machine_pwm_obj_t *pwm_obj_alloc() {
     for (uint8_t i = 0; i < MICROPY_PY_MACHINE_PWM_MAX_OBJS; i++) {
         if (pwm_obj[i] == NULL) {
@@ -137,6 +139,7 @@ static inline machine_pwm_obj_t *pwm_obj_alloc() {
     return NULL;
 }
 
+// Release a PWM object slot back to the instance pool.
 static inline void pwm_obj_free(machine_pwm_obj_t *pwm_obj_ptr) {
     for (uint8_t i = 0; i < MICROPY_PY_MACHINE_PWM_MAX_OBJS; i++) {
         if (pwm_obj[i] == pwm_obj_ptr) {
@@ -145,6 +148,7 @@ static inline void pwm_obj_free(machine_pwm_obj_t *pwm_obj_ptr) {
     }
 }
 
+// Raise ValueError if duty_ns exceeds the period length for the given frequency.
 static void pwm_duty_ns_assert(mp_int_t duty_ns, uint32_t freq) {
     if (duty_ns > (int)(1000000000 / freq)) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("PWM duty in ns is larger than the period %d ns"), (int)(1000000000 / freq));
@@ -165,8 +169,7 @@ static void pwm_pin_restore(const machine_pin_obj_t *pin) {
     Cy_GPIO_SetDrivemode(port, pin->pin, CY_GPIO_DM_HIGHZ);
 }
 
-// Compute the period and compare register values from the stored frequency and duty cycle,
-// and write them into the PDL PWM config struct.
+// Compute period and compare register values from the stored frequency/duty and write to the PDL config struct.
 static void pwm_config(machine_pwm_obj_t *self) {
     if (self->frequency == 0) {
         mp_raise_ValueError(MP_ERROR_TEXT("PWM frequency must be greater than 0"));
@@ -185,6 +188,7 @@ static void pwm_config(machine_pwm_obj_t *self) {
     self->pwm_obj.invertPWMOut = self->invert;
 }
 
+// Parse freq/duty_u16/duty_ns/invert args, configure the hardware, and start the PWM counter.
 static void mp_machine_pwm_init_helper(machine_pwm_obj_t *self, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_freq, ARG_duty_u16, ARG_duty_ns, ARG_invert};
 
@@ -243,6 +247,7 @@ static void mp_machine_pwm_init_helper(machine_pwm_obj_t *self, size_t n_args, c
     Cy_TCPWM_TriggerReloadOrIndex_Single(TCPWM0, self->counter_num);
 }
 
+// Print a human-readable representation: pin name, frequency, and duty cycle percentage.
 static void mp_machine_pwm_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     machine_pwm_obj_t *self = MP_OBJ_TO_PTR(self_in);
     mp_printf(print, "PWM(Pin.cpu.%q, freq=%u, duty=%.2f%%)",
@@ -251,6 +256,7 @@ static void mp_machine_pwm_print(const mp_print_t *print, mp_obj_t self_in, mp_p
         self->duty_type == DUTY_U16 ? pwm_duty_cycle_u16_to_percent(self->duty) : pwm_duty_cycle_ns_to_percent(self->duty, self->frequency));
 }
 
+// Constructor: resolve the pin, allocate an instance, apply the default PDL config, then call init_helper.
 static mp_obj_t mp_machine_pwm_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
 
     // Check number of arguments: dest is required
@@ -330,32 +336,39 @@ static mp_obj_t mp_machine_pwm_make_new(const mp_obj_type_t *type, size_t n_args
     return MP_OBJ_FROM_PTR(self);
 }
 
+// Disable the TCPWM counter, restore the GPIO pin to Hi-Z, and free the instance slot.
 static void mp_machine_pwm_deinit(machine_pwm_obj_t *self) {
     Cy_TCPWM_PWM_Disable(TCPWM0, self->counter_num);
     pwm_pin_restore(self->pin);
     pwm_obj_free(self);
 }
 
+// Return the current PWM output frequency in Hz.
 static mp_obj_t mp_machine_pwm_freq_get(machine_pwm_obj_t *self) {
     mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM not implemented"));
 }
 
+// Update the PWM output frequency; recalculates the period register.
 static void mp_machine_pwm_freq_set(machine_pwm_obj_t *self, mp_int_t freq) {
     mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM not implemented"));
 }
 
+// Return the current duty cycle as a 16-bit value (0-65535).
 static mp_obj_t mp_machine_pwm_duty_get_u16(machine_pwm_obj_t *self) {
     mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM not implemented"));
 }
 
+// Set the duty cycle from a 16-bit value (0-65535).
 static void mp_machine_pwm_duty_set_u16(machine_pwm_obj_t *self, mp_int_t duty_u16) {
     mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM not implemented"));
 }
 
+// Return the current on-time duty cycle in nanoseconds.
 static mp_obj_t mp_machine_pwm_duty_get_ns(machine_pwm_obj_t *self) {
     mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM not implemented"));
 }
 
+// Set the duty cycle as an on-time in nanoseconds.
 static void mp_machine_pwm_duty_set_ns(machine_pwm_obj_t *self, mp_int_t duty_ns) {
     mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM not implemented"));
 }

--- a/ports/psoc-edge/machine_pwm.c
+++ b/ports/psoc-edge/machine_pwm.c
@@ -172,6 +172,15 @@ static void pwm_pin_restore(const machine_pin_obj_t *pin) {
     Cy_GPIO_SetDrivemode(port, pin->pin, CY_GPIO_DM_HIGHZ);
 }
 
+// Reconfigure and restart the TCPWM counter using the current pwm_obj config struct.
+static void pwm_restart(machine_pwm_obj_t *self) {
+    Cy_TCPWM_PWM_Disable(TCPWM0, self->counter_num);
+    cy_en_tcpwm_status_t result = Cy_TCPWM_PWM_Init(TCPWM0, self->counter_num, &self->pwm_obj);
+    pwm_assert_raise_val("PWM init failed with return code %lx !", result);
+    Cy_TCPWM_PWM_Enable(TCPWM0, self->counter_num);
+    Cy_TCPWM_TriggerReloadOrIndex_Single(TCPWM0, self->counter_num);
+}
+
 // Compute period and compare register values from the stored frequency/duty and write to the PDL config struct.
 static void pwm_config(machine_pwm_obj_t *self) {
     if (self->frequency == 0) {
@@ -395,36 +404,44 @@ static void mp_machine_pwm_freq_set(machine_pwm_obj_t *self, mp_int_t freq) {
     /* Apply frequency and duty cycle to the PWM config struct */
     pwm_config(self);
 
-    // Disable the TCPWM counter
-    Cy_TCPWM_PWM_Disable(TCPWM0, self->counter_num);
-
-    cy_en_tcpwm_status_t result = Cy_TCPWM_PWM_Init(TCPWM0,
-        self->counter_num, &self->pwm_obj);
-    pwm_assert_raise_val("PWM init failed with return code %lx !", result);
-
-    /* Enable the TCPWM block */
-    Cy_TCPWM_PWM_Enable(TCPWM0, self->counter_num);
-
-    /* Start the PWM */
-    Cy_TCPWM_TriggerReloadOrIndex_Single(TCPWM0, self->counter_num);
+    // Reconfigure and restart the TCPWM counter with the new config.
+    pwm_restart(self);
 }
 
 // Return the current duty cycle as a 16-bit value (0-65535).
 static mp_obj_t mp_machine_pwm_duty_get_u16(machine_pwm_obj_t *self) {
-    mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM duty getter/setter not yet implemented"));
+    if (self->duty_type == DUTY_U16) {
+        return MP_OBJ_NEW_SMALL_INT(self->duty);
+    }
+    // Convert stored duty_ns to u16
+    return MP_OBJ_NEW_SMALL_INT(pwm_duty_cycle_ns_to_u16(self->duty, self->frequency));
 }
 
 // Set the duty cycle from a 16-bit value (0-65535).
 static void mp_machine_pwm_duty_set_u16(machine_pwm_obj_t *self, mp_int_t duty_u16) {
-    mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM duty getter/setter not yet implemented"));
+    self->duty = duty_u16 > 65535 ? 65535 : duty_u16;
+    self->duty_type = DUTY_U16;
+
+    pwm_config(self);
+    pwm_restart(self);
 }
 
 // Return the current on-time duty cycle in nanoseconds.
 static mp_obj_t mp_machine_pwm_duty_get_ns(machine_pwm_obj_t *self) {
-    mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM duty getter/setter not yet implemented"));
+    if (self->duty_type == DUTY_NS) {
+        return MP_OBJ_NEW_SMALL_INT(self->duty);
+    }
+    // Convert stored duty_u16 to nanoseconds
+    return MP_OBJ_NEW_SMALL_INT(pwm_duty_cycle_u16_to_ns(self->duty, self->frequency));
 }
 
 // Set the duty cycle as an on-time in nanoseconds.
 static void mp_machine_pwm_duty_set_ns(machine_pwm_obj_t *self, mp_int_t duty_ns) {
-    mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM duty getter/setter not yet implemented"));
+    pwm_duty_ns_assert(duty_ns, self->frequency);
+
+    self->duty = duty_ns;
+    self->duty_type = DUTY_NS;
+
+    pwm_config(self);
+    pwm_restart(self);
 }

--- a/ports/psoc-edge/machine_pwm.c
+++ b/ports/psoc-edge/machine_pwm.c
@@ -97,7 +97,7 @@ static bool pwm_pin_get_counter(uint8_t port, uint8_t pin, uint32_t *counter_num
 }
 
 #define pwm_assert_raise_val(msg, ret)   if (ret != CY_RSLT_SUCCESS) { \
-            mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT(msg), ret); \
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT(msg), ret); \
 }
 
 /* Unit conversion macros */

--- a/ports/psoc-edge/machine_pwm.c
+++ b/ports/psoc-edge/machine_pwm.c
@@ -28,8 +28,10 @@
 #include "py/mphal.h"
 #include "modmachine.h"
 #include "cy_gpio.h"
+#include "cy_sysclk.h"
 #include "cy_tcpwm_pwm.h"
 #include "cycfg_peripherals.h"
+#include "cycfg_peripheral_clocks.h"
 #include "machine_pin.h"
 
 typedef enum {
@@ -43,6 +45,8 @@ typedef struct _machine_pwm_obj_t {
     mp_obj_base_t base;                     /**< MicroPython base object */
     cy_stc_tcpwm_pwm_config_t pwm_obj;      /**< PDL PWM configuration struct */
     const machine_pin_obj_t *pin;           /**< Resolved GPIO pin object for PWM output */
+    uint32_t counter_num;                   /**< TCPWM0 counter index assigned to this PWM instance */
+    en_clk_dst_t pclk_dst;                 /**< PCLK clock destination for this counter's clock assignment */
     uint32_t frequency;                     /**< PWM output frequency in Hz */
     duty_type_t duty_type;                  /**< Indicates whether duty is set as DUTY_U16 or DUTY_NS */
     mp_int_t duty;                          /**< Duty cycle value: 0-65535 if DUTY_U16, nanoseconds if DUTY_NS */
@@ -55,7 +59,46 @@ typedef struct _machine_pwm_obj_t {
 // TCPWM clock = PCLK (100 MHz) / (divider+1) = 100,000,000 / 50,000 = 2000 Hz
 #define CYBSP_PWM_LED_CTRL_CLK_HZ   2000UL
 
-#define TCPWM_PWM_CTRL_NUM   (0UL)
+// Maps (port, pin) → TCPWM0 counter number for pins that support HSIOM_SEL_ACT_1 routing.
+// Only pins with a unique counter number can generate an independent PWM frequency.
+// Pins sharing counter 0 (e.g. P20_5, P17_0, P16_0) cannot have different frequencies simultaneously.
+static const struct {
+    uint8_t port;
+    uint8_t pin;
+    uint32_t counter_num;
+    en_clk_dst_t pclk_dst;     // PCLK clock destination for Cy_SysClk_PeriPclkAssignDivider
+} pwm_pin_map[] = {
+    {0,  0, 0, PCLK_TCPWM0_CLOCK_COUNTER_EN0},  // P0_0  - LINE0
+    {0,  1, 0, PCLK_TCPWM0_CLOCK_COUNTER_EN0},  // P0_1  - LINE_COMPL0
+    {7,  3, 0, PCLK_TCPWM0_CLOCK_COUNTER_EN0},  // P7_3  - LINE_COMPL0
+    {9,  1, 0, PCLK_TCPWM0_CLOCK_COUNTER_EN0},  // P9_1  - LINE0
+    {9,  3, 0, PCLK_TCPWM0_CLOCK_COUNTER_EN0},  // P9_3  - LINE_COMPL0
+    {11, 6, 0, PCLK_TCPWM0_CLOCK_COUNTER_EN0},  // P11_6 - LINE0
+    {14, 3, 0, PCLK_TCPWM0_CLOCK_COUNTER_EN0},  // P14_3 - LINE0
+    {14, 4, 0, PCLK_TCPWM0_CLOCK_COUNTER_EN0},  // P14_4 - LINE_COMPL0
+    {16, 0, 0, PCLK_TCPWM0_CLOCK_COUNTER_EN0},  // P16_0 - LINE0  (counter 0)
+    {16, 1, 1, PCLK_TCPWM0_CLOCK_COUNTER_EN1},  // P16_1 - LINE1  (counter 1)
+    {16, 2, 2, PCLK_TCPWM0_CLOCK_COUNTER_EN2},  // P16_2 - LINE2  (counter 2)
+    {16, 3, 3, PCLK_TCPWM0_CLOCK_COUNTER_EN3},  // P16_3 - LINE3  (counter 3)
+    {16, 4, 4, PCLK_TCPWM0_CLOCK_COUNTER_EN4},  // P16_4 - LINE4  (counter 4)
+    {16, 5, 5, PCLK_TCPWM0_CLOCK_COUNTER_EN5},  // P16_5 - LINE5  (counter 5)
+    {16, 6, 6, PCLK_TCPWM0_CLOCK_COUNTER_EN6},  // P16_6 - LINE6  (counter 6)
+    {16, 7, 7, PCLK_TCPWM0_CLOCK_COUNTER_EN7},  // P16_7 - LINE7  (counter 7)
+    {17, 0, 0, PCLK_TCPWM0_CLOCK_COUNTER_EN0},  // P17_0 - LINE_COMPL0
+    {20, 5, 0, PCLK_TCPWM0_CLOCK_COUNTER_EN0},  // P20_5 - LINE_COMPL0
+};
+
+// Look up the pin→counter mapping. Returns false if the pin is not PWM-capable.
+static bool pwm_pin_get_counter(uint8_t port, uint8_t pin, uint32_t *counter_num, en_clk_dst_t *pclk_dst) {
+    for (uint8_t i = 0; i < MP_ARRAY_SIZE(pwm_pin_map); i++) {
+        if (pwm_pin_map[i].port == port && pwm_pin_map[i].pin == pin) {
+            *counter_num = pwm_pin_map[i].counter_num;
+            *pclk_dst = pwm_pin_map[i].pclk_dst;
+            return true;
+        }
+    }
+    return false;
+}
 
 #define pwm_assert_raise_val(msg, ret)   if (ret != CY_RSLT_SUCCESS) { \
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT(msg), ret); \
@@ -176,15 +219,19 @@ static void mp_machine_pwm_init_helper(machine_pwm_obj_t *self, size_t n_args, c
     /* Route the TCPWM output to the configured GPIO pin */
     pwm_pin_config(self->pin);
 
+    /* Assign the pre-configured 2000 Hz clock divider (16-bit div #3, peri group 1)
+     * to this counter's PCLK destination so it runs at the same clock as counter 0 */
+    Cy_SysClk_PeriPclkAssignDivider(self->pclk_dst, CY_SYSCLK_DIV_16_BIT, CYBSP_PWM_LED_CTRL_CLK_DIV_NUM);
+
     cy_rslt_t result = Cy_TCPWM_PWM_Init(TCPWM0,
-            TCPWM_PWM_CTRL_NUM, &self->pwm_obj);
+            self->counter_num, &self->pwm_obj);
     pwm_assert_raise_val("PWM init failed with return code %lx !", result);
 
     /* Enable the TCPWM block */
-    Cy_TCPWM_PWM_Enable(TCPWM0, TCPWM_PWM_CTRL_NUM);
+    Cy_TCPWM_PWM_Enable(TCPWM0, self->counter_num);
 
     /* Start the PWM */
-    Cy_TCPWM_TriggerReloadOrIndex_Single(TCPWM0, TCPWM_PWM_CTRL_NUM);
+    Cy_TCPWM_TriggerReloadOrIndex_Single(TCPWM0, self->counter_num);
 }
 
 static void mp_machine_pwm_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
@@ -202,9 +249,18 @@ static mp_obj_t mp_machine_pwm_make_new(const mp_obj_type_t *type, size_t n_args
 
     // Get static peripheral object.
     machine_pwm_obj_t *self = pwm_obj_alloc();
+    if (self == NULL) {
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("PWM: maximum number of instances (%d) reached"), MICROPY_PY_MACHINE_PWM_MAX_OBJS);
+    }
 
     // Resolve dest to a pin object (accepts Pin object, board name string, or CPU name string)
     self->pin = machine_pin_get_pin_obj(args[0]);
+
+    // Look up the TCPWM counter and PCLK destination for this pin
+    if (!pwm_pin_get_counter(self->pin->port, self->pin->pin, &self->counter_num, &self->pclk_dst)) {
+        pwm_obj_free(self);
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("Pin %q does not support PWM output"), self->pin->name);
+    }
 
     // Default config parameters for the PWM object.
     self->pwm_obj.pwmMode = CY_TCPWM_PWM_MODE_PWM;
@@ -258,7 +314,7 @@ static mp_obj_t mp_machine_pwm_make_new(const mp_obj_type_t *type, size_t n_args
 }
 
 static void mp_machine_pwm_deinit(machine_pwm_obj_t *self) {
-    Cy_TCPWM_PWM_Disable(TCPWM0, TCPWM_PWM_CTRL_NUM);
+    Cy_TCPWM_PWM_Disable(TCPWM0, self->counter_num);
     pwm_pin_restore(self->pin);
     pwm_obj_free(self);
 }

--- a/ports/psoc-edge/machine_pwm.c
+++ b/ports/psoc-edge/machine_pwm.c
@@ -1,0 +1,96 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2026 Infineon Technologies AG
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/runtime.h"
+#include "py/mphal.h"
+#include "modmachine.h"
+#include "cy_tcpwm_pwm.h"
+#include "cycfg_peripherals.h"
+
+typedef enum {
+    VALUE_NOT_SET = -1,
+    DUTY_NOT_SET = 0,
+    DUTY_U16,
+    DUTY_NS
+} duty_type_t;
+
+typedef struct _machine_pwm_obj_t {
+    mp_obj_base_t base;
+    cy_stc_tcpwm_pwm_config_t pwm_obj;
+    uint32_t pin;
+    uint32_t frequency;
+    duty_type_t duty_type;
+    mp_int_t duty;
+    bool invert;
+} machine_pwm_obj_t;
+
+static void mp_machine_pwm_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
+    mp_printf(print, "PWM() - not implemented");
+}
+
+static mp_obj_t mp_machine_pwm_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+
+    // Check number of arguments
+    mp_arg_check_num(n_args, n_kw, 1, MP_OBJ_FUN_ARGS_MAX, true);
+
+    mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM not implemented"));   
+
+}
+
+static void mp_machine_pwm_init_helper(machine_pwm_obj_t *self, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    
+    mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM partially implemented"));
+}
+
+static void mp_machine_pwm_deinit(machine_pwm_obj_t *self) {
+    mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM not implemented"));
+}
+
+static mp_obj_t mp_machine_pwm_freq_get(machine_pwm_obj_t *self) {
+    mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM not implemented"));
+}
+
+static void mp_machine_pwm_freq_set(machine_pwm_obj_t *self, mp_int_t freq) {
+    mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM not implemented"));
+}
+
+static mp_obj_t mp_machine_pwm_duty_get_u16(machine_pwm_obj_t *self) {
+    mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM not implemented"));
+}
+
+static void mp_machine_pwm_duty_set_u16(machine_pwm_obj_t *self, mp_int_t duty_u16) {
+    mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM not implemented"));
+}
+
+static mp_obj_t mp_machine_pwm_duty_get_ns(machine_pwm_obj_t *self) {
+    mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM not implemented"));
+}
+
+static void mp_machine_pwm_duty_set_ns(machine_pwm_obj_t *self, mp_int_t duty_ns) {
+    mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM not implemented"));
+}
+
+

--- a/ports/psoc-edge/machine_pwm.c
+++ b/ports/psoc-edge/machine_pwm.c
@@ -217,9 +217,6 @@ static void mp_machine_pwm_init_helper(machine_pwm_obj_t *self, size_t n_args, c
         mp_raise_msg_varg(&mp_type_ValueError,
             MP_ERROR_TEXT("PWM frequency must not exceed %lu Hz"), (unsigned long)(PWM_TCPWM_CLK_HZ / 2));
     }
-    self->frequency = (uint32_t)args[ARG_freq].u_int;
-
-    self->invert = args[ARG_invert].u_bool;
 
     if (args[ARG_duty_u16].u_int != VALUE_NOT_SET &&
         args[ARG_duty_ns].u_int != VALUE_NOT_SET) {
@@ -236,6 +233,10 @@ static void mp_machine_pwm_init_helper(machine_pwm_obj_t *self, size_t n_args, c
     } else {
         mp_raise_ValueError(MP_ERROR_TEXT("PWM duty should be specified in either ns or u16"));
     }
+
+    self->frequency = (uint32_t)args[ARG_freq].u_int;
+
+    self->invert = args[ARG_invert].u_bool;
 
     /* Apply frequency and duty cycle to the PWM config struct */
     pwm_config(self);
@@ -352,7 +353,16 @@ static mp_obj_t mp_machine_pwm_make_new(const mp_obj_type_t *type, size_t n_args
     // Process the remaining parameters (skip dest at args[0]).
     mp_map_t kw_args;
     mp_map_init_fixed_table(&kw_args, n_kw, args + n_args);
-    mp_machine_pwm_init_helper(self, n_args - 1, args + 1, &kw_args);
+
+    // If pwm_init_helper raises, free the pool slot so the pin can be reused.
+    nlr_buf_t nl;
+    if (nlr_push(&nl) == 0) {
+        mp_machine_pwm_init_helper(self, n_args - 1, args + 1, &kw_args);
+        nlr_pop();
+    } else {
+        pwm_obj_free(self);
+        nlr_jump(nl.ret_val);
+    }
 
     return MP_OBJ_FROM_PTR(self);
 }

--- a/ports/psoc-edge/machine_pwm.c
+++ b/ports/psoc-edge/machine_pwm.c
@@ -53,35 +53,41 @@ typedef struct _machine_pwm_obj_t {
     bool invert;                            /**< If true, inverts the PWM output signal polarity */
 } machine_pwm_obj_t;
 
-/** Input trigger mode value meaning "disabled" - passed to inputMode fields (masked with 0x3U to extract the 2-bit mode) */
+// Sentinel value meaning "no trigger"; masked with 0x3U when assigned to 2-bit inputMode fields.
 #define CYBSP_PWM_LED_CTRL_INPUT_DISABLED 0x7U
 
 // TCPWM clock = PCLK (100 MHz) / (divider+1) = 100,000,000 / 50,000 = 2000 Hz
 #define CYBSP_PWM_LED_CTRL_CLK_HZ   2000UL
 
-// Maps (port, pin) → TCPWM0 counter number for pins that support HSIOM_SEL_ACT_1 routing.
-// Only pins with a unique counter number can generate an independent PWM frequency.
-// Pins sharing counter 0 (e.g. P20_5, P17_0, P16_0) cannot have different frequencies simultaneously.
+// Maps (port, pin) → TCPWM0 counter index and PCLK destination for pins that support PWM via
+// HSIOM_SEL_ACT_1 routing. Each entry has a unique counter, so each pin can carry an independent
+// PWM frequency.
+//
+// PWM-capable pins on KIT_PSE84_AI:
+//     P16_0 → counter 0  (shared — P9_1, P9_3, P14_3, P14_4, P17_0, P20_5 also route to counter 0;
+//                          enabling any of those pins simultaneously will conflict with P16_0)
+//     P16_1 → counter 1
+//     P16_2 → counter 2
+//     P16_3 → counter 3
+//     P16_4 → counter 4
+//     P16_5 → counter 5
+//     P16_6 → counter 6
+//     P16_7 → counter 7
+
 static const struct {
     uint8_t port;
     uint8_t pin;
     uint32_t counter_num;
     en_clk_dst_t pclk_dst;     // PCLK clock destination for Cy_SysClk_PeriPclkAssignDivider
 } pwm_pin_map[] = {
-    // {9,  1, 0, PCLK_TCPWM0_CLOCK_COUNTER_EN0},  // P9_1  - LINE0       (shares counter 0)
-    // {9,  3, 0, PCLK_TCPWM0_CLOCK_COUNTER_EN0},  // P9_3  - LINE_COMPL0 (shares counter 0)
-    // {14, 3, 0, PCLK_TCPWM0_CLOCK_COUNTER_EN0},  // P14_3 - LINE0       (shares counter 0)
-    // {14, 4, 0, PCLK_TCPWM0_CLOCK_COUNTER_EN0},  // P14_4 - LINE_COMPL0 (shares counter 0)
-    {16, 0, 0, PCLK_TCPWM0_CLOCK_COUNTER_EN0},  // P16_0 - LINE0  (counter 0)
-    {16, 1, 1, PCLK_TCPWM0_CLOCK_COUNTER_EN1},  // P16_1 - LINE1  (counter 1)
-    {16, 2, 2, PCLK_TCPWM0_CLOCK_COUNTER_EN2},  // P16_2 - LINE2  (counter 2)
-    {16, 3, 3, PCLK_TCPWM0_CLOCK_COUNTER_EN3},  // P16_3 - LINE3  (counter 3)
-    {16, 4, 4, PCLK_TCPWM0_CLOCK_COUNTER_EN4},  // P16_4 - LINE4  (counter 4)
-    {16, 5, 5, PCLK_TCPWM0_CLOCK_COUNTER_EN5},  // P16_5 - LINE5  (counter 5)
-    {16, 6, 6, PCLK_TCPWM0_CLOCK_COUNTER_EN6},  // P16_6 - LINE6  (counter 6)
-    {16, 7, 7, PCLK_TCPWM0_CLOCK_COUNTER_EN7},  // P16_7 - LINE7  (counter 7)
-    // {17, 0, 0, PCLK_TCPWM0_CLOCK_COUNTER_EN0},  // P17_0 - LINE_COMPL0 (shares counter 0)
-    // {20, 5, 0, PCLK_TCPWM0_CLOCK_COUNTER_EN0},  // P20_5 - LINE_COMPL0 (shares counter 0)
+    {16, 0, 0, PCLK_TCPWM0_CLOCK_COUNTER_EN0},  // P16_0
+    {16, 1, 1, PCLK_TCPWM0_CLOCK_COUNTER_EN1},  // P16_1
+    {16, 2, 2, PCLK_TCPWM0_CLOCK_COUNTER_EN2},  // P16_2
+    {16, 3, 3, PCLK_TCPWM0_CLOCK_COUNTER_EN3},  // P16_3
+    {16, 4, 4, PCLK_TCPWM0_CLOCK_COUNTER_EN4},  // P16_4
+    {16, 5, 5, PCLK_TCPWM0_CLOCK_COUNTER_EN5},  // P16_5
+    {16, 6, 6, PCLK_TCPWM0_CLOCK_COUNTER_EN6},  // P16_6
+    {16, 7, 7, PCLK_TCPWM0_CLOCK_COUNTER_EN7},  // P16_7
 };
 
 // Look up the pin→counter mapping. Returns false if the pin is not PWM-capable.
@@ -97,7 +103,7 @@ static bool pwm_pin_get_counter(uint8_t port, uint8_t pin, uint32_t *counter_num
 }
 
 #define pwm_assert_raise_val(msg, ret)   if (ret != CY_RSLT_SUCCESS) { \
-        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT(msg), ret); \
+            mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT(msg), ret); \
 }
 
 /* Unit conversion macros */
@@ -159,9 +165,9 @@ static void pwm_pin_restore(const machine_pin_obj_t *pin) {
     Cy_GPIO_SetDrivemode(port, pin->pin, CY_GPIO_DM_HIGHZ);
 }
 
-// methods for machine.PWM
+// Compute the period and compare register values from the stored frequency and duty cycle,
+// and write them into the PDL PWM config struct.
 static void pwm_config(machine_pwm_obj_t *self) {
-
     if (self->frequency == 0) {
         mp_raise_ValueError(MP_ERROR_TEXT("PWM frequency must be greater than 0"));
     }
@@ -189,7 +195,6 @@ static void mp_machine_pwm_init_helper(machine_pwm_obj_t *self, size_t n_args, c
         { MP_QSTR_invert,   MP_ARG_KW_ONLY | MP_ARG_BOOL, {.u_bool = false} },
     };
 
-    // Parse the arguments.
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args,
         MP_ARRAY_SIZE(allowed_args), allowed_args, args);
@@ -224,8 +229,7 @@ static void mp_machine_pwm_init_helper(machine_pwm_obj_t *self, size_t n_args, c
     /* Route the TCPWM output to the configured GPIO pin */
     pwm_pin_config(self->pin);
 
-    /* Assign the pre-configured 2000 Hz clock divider (16-bit div #3, peri group 1)
-     * to this counter's PCLK destination so it runs at the same clock as counter 0 */
+    /* Connect the pre-configured 2 kHz clock divider to this counter's PCLK input */
     Cy_SysClk_PeriPclkAssignDivider(self->pclk_dst, CY_SYSCLK_DIV_16_BIT, CYBSP_PWM_LED_CTRL_CLK_DIV_NUM);
 
     cy_rslt_t result = Cy_TCPWM_PWM_Init(TCPWM0,
@@ -261,7 +265,7 @@ static mp_obj_t mp_machine_pwm_make_new(const mp_obj_type_t *type, size_t n_args
             MP_ERROR_TEXT("PWM instance for Pin %q already exists, call deinit() first"), pin->name);
     }
 
-    // Get static peripheral object.
+    // Allocate a new instance from the PWM object pool.
     machine_pwm_obj_t *self = pwm_obj_alloc();
     if (self == NULL) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("PWM: maximum number of instances (%d) reached"), MICROPY_PY_MACHINE_PWM_MAX_OBJS);

--- a/ports/psoc-edge/machine_pwm.c
+++ b/ports/psoc-edge/machine_pwm.c
@@ -46,7 +46,7 @@ typedef struct _machine_pwm_obj_t {
     cy_stc_tcpwm_pwm_config_t pwm_obj;      /**< PDL PWM configuration struct */
     const machine_pin_obj_t *pin;           /**< Resolved GPIO pin object for PWM output */
     uint32_t counter_num;                   /**< TCPWM0 counter index assigned to this PWM instance */
-    en_clk_dst_t pclk_dst;                 /**< PCLK clock destination for this counter's clock assignment */
+    en_clk_dst_t pclk_dst;                  /**< PCLK clock destination for this counter's clock assignment */
     uint32_t frequency;                     /**< PWM output frequency in Hz */
     duty_type_t duty_type;                  /**< Indicates whether duty is set as DUTY_U16 or DUTY_NS */
     mp_int_t duty;                          /**< Duty cycle value: 0-65535 if DUTY_U16, nanoseconds if DUTY_NS */
@@ -56,23 +56,27 @@ typedef struct _machine_pwm_obj_t {
 // Sentinel value meaning "no trigger"; masked with 0x3U when assigned to 2-bit inputMode fields.
 #define CYBSP_PWM_LED_CTRL_INPUT_DISABLED 0x7U
 
-// TCPWM clock = PCLK (100 MHz) / (divider+1) = 100,000,000 / 50,000 = 2000 Hz
-#define CYBSP_PWM_LED_CTRL_CLK_HZ   2000UL
+// TCPWM base clock: PCLK 100 MHz divided to 1 MHz for usable duty resolution at practical
+// frequencies. Divider register value 99 = divisor 100: 100 MHz / 100 = 1 MHz.
+// At 1 MHz a 32-bit counter gives period0 = 1,000,000 at 1 Hz and 1,000 at 1 kHz.
+// Maximum PWM output frequency = PWM_TCPWM_CLK_HZ / 2 = 500 kHz (period0 = 2).
+#define PWM_TCPWM_CLK_HZ        1000000UL
+#define PWM_TCPWM_CLK_DIV_VAL   99U
 
-// Maps (port, pin) → TCPWM0 counter index and PCLK destination for pins that support PWM via
+// Maps (port, pin) : TCPWM0 counter index and PCLK destination for pins that support PWM via
 // HSIOM_SEL_ACT_1 routing. Each entry has a unique counter, so each pin can carry an independent
 // PWM frequency.
 //
 // PWM-capable pins on KIT_PSE84_AI:
-//     P16_0 → counter 0  (shared — P9_1, P9_3, P14_3, P14_4, P17_0, P20_5 also route to counter 0;
-//                          enabling any of those pins simultaneously will conflict with P16_0)
-//     P16_1 → counter 1
-//     P16_2 → counter 2
-//     P16_3 → counter 3
-//     P16_4 → counter 4
-//     P16_5 → counter 5
-//     P16_6 → counter 6
-//     P16_7 → counter 7
+//     P16_0 : counter 0  (shared — P9_1, P9_3, P14_3, P14_4, P17_0, P20_5 also route to counter 0;
+//           :              enabling any of those pins simultaneously will conflict with P16_0)
+//     P16_1 : counter 1
+//     P16_2 : counter 2
+//     P16_3 : counter 3
+//     P16_4 : counter 4
+//     P16_5 : counter 5
+//     P16_6 : counter 6
+//     P16_7 : counter 7
 
 static const struct {
     uint8_t port;
@@ -103,7 +107,7 @@ static bool pwm_pin_get_counter(uint8_t port, uint8_t pin, uint32_t *counter_num
 }
 
 #define pwm_assert_raise_val(msg, ret)   if (ret != CY_RSLT_SUCCESS) { \
-            mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT(msg), ret); \
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT(msg), ret); \
 }
 
 /* Unit conversion macros */
@@ -117,6 +121,7 @@ static bool pwm_pin_get_counter(uint8_t port, uint8_t pin, uint32_t *counter_num
  #define pwm_duty_cycle_u16_to_compare(duty_u16, period) ((int)(((float)(duty_u16 + 1) / (float)65536) * (float)period))
 
 static machine_pwm_obj_t *pwm_obj[MICROPY_PY_MACHINE_PWM_MAX_OBJS] = { NULL };
+static bool pwm_clk_configured = false; // true after the shared divider is programmed to PWM_TCPWM_CLK_HZ
 
 // Search the instance pool for an existing PWM object on the given port/pin; returns NULL if not found.
 static inline machine_pwm_obj_t *pwm_obj_find_by_pin(uint8_t port, uint8_t pin) {
@@ -129,7 +134,7 @@ static inline machine_pwm_obj_t *pwm_obj_find_by_pin(uint8_t port, uint8_t pin) 
 }
 
 // Allocate and return a new PWM object from the instance pool; returns NULL if the pool is full.
-static inline machine_pwm_obj_t *pwm_obj_alloc() {
+static inline machine_pwm_obj_t *pwm_obj_alloc(void) {
     for (uint8_t i = 0; i < MICROPY_PY_MACHINE_PWM_MAX_OBJS; i++) {
         if (pwm_obj[i] == NULL) {
             pwm_obj[i] = mp_obj_malloc(machine_pwm_obj_t, &machine_pwm_type);
@@ -144,6 +149,7 @@ static inline void pwm_obj_free(machine_pwm_obj_t *pwm_obj_ptr) {
     for (uint8_t i = 0; i < MICROPY_PY_MACHINE_PWM_MAX_OBJS; i++) {
         if (pwm_obj[i] == pwm_obj_ptr) {
             pwm_obj[i] = NULL;
+            return;
         }
     }
 }
@@ -174,15 +180,16 @@ static void pwm_config(machine_pwm_obj_t *self) {
     if (self->frequency == 0) {
         mp_raise_ValueError(MP_ERROR_TEXT("PWM frequency must be greater than 0"));
     }
-    self->pwm_obj.period0 = CYBSP_PWM_LED_CTRL_CLK_HZ / self->frequency;
-    self->pwm_obj.period1 = CYBSP_PWM_LED_CTRL_CLK_HZ / self->frequency;
+    self->pwm_obj.period0 = PWM_TCPWM_CLK_HZ / self->frequency;
+    self->pwm_obj.period1 = PWM_TCPWM_CLK_HZ / self->frequency;
 
     if (self->duty_type == DUTY_U16) {
         self->pwm_obj.compare0 = pwm_duty_cycle_u16_to_compare(self->duty, self->pwm_obj.period0);
         self->pwm_obj.compare1 = pwm_duty_cycle_u16_to_compare(self->duty, self->pwm_obj.period1);
     } else if (self->duty_type == DUTY_NS) {
-        self->pwm_obj.compare0 = pwm_duty_cycle_ns_to_u16(self->duty, self->frequency);
-        self->pwm_obj.compare1 = pwm_duty_cycle_ns_to_u16(self->duty, self->frequency);
+        int duty_u16 = pwm_duty_cycle_ns_to_u16(self->duty, self->frequency);
+        self->pwm_obj.compare0 = pwm_duty_cycle_u16_to_compare(duty_u16, self->pwm_obj.period0);
+        self->pwm_obj.compare1 = pwm_duty_cycle_u16_to_compare(duty_u16, self->pwm_obj.period1);
     }
 
     self->pwm_obj.invertPWMOut = self->invert;
@@ -193,7 +200,7 @@ static void mp_machine_pwm_init_helper(machine_pwm_obj_t *self, size_t n_args, c
     enum { ARG_freq, ARG_duty_u16, ARG_duty_ns, ARG_invert};
 
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_freq,     MP_ARG_KW_ONLY | MP_ARG_INT,  {.u_int = VALUE_NOT_SET} },
+        { MP_QSTR_freq,     MP_ARG_REQUIRED | MP_ARG_KW_ONLY | MP_ARG_INT },
         { MP_QSTR_duty_u16, MP_ARG_KW_ONLY | MP_ARG_INT,  {.u_int = VALUE_NOT_SET} },
         { MP_QSTR_duty_ns,  MP_ARG_KW_ONLY | MP_ARG_INT,  {.u_int = VALUE_NOT_SET} },
         { MP_QSTR_invert,   MP_ARG_KW_ONLY | MP_ARG_BOOL, {.u_bool = false} },
@@ -203,13 +210,16 @@ static void mp_machine_pwm_init_helper(machine_pwm_obj_t *self, size_t n_args, c
     mp_arg_parse_all(n_args, pos_args, kw_args,
         MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    if (args[ARG_freq].u_int != VALUE_NOT_SET) {
-        self->frequency = args[ARG_freq].u_int;
+    if (args[ARG_freq].u_int <= 0) {
+        mp_raise_ValueError(MP_ERROR_TEXT("PWM frequency must be greater than 0"));
     }
+    if ((uint32_t)args[ARG_freq].u_int > PWM_TCPWM_CLK_HZ / 2) {
+        mp_raise_msg_varg(&mp_type_ValueError,
+            MP_ERROR_TEXT("PWM frequency must not exceed %lu Hz"), (unsigned long)(PWM_TCPWM_CLK_HZ / 2));
+    }
+    self->frequency = (uint32_t)args[ARG_freq].u_int;
 
-    if (args[ARG_invert].u_bool) {
-        self->invert = true;
-    }
+    self->invert = args[ARG_invert].u_bool;
 
     if (args[ARG_duty_u16].u_int != VALUE_NOT_SET &&
         args[ARG_duty_ns].u_int != VALUE_NOT_SET) {
@@ -233,10 +243,21 @@ static void mp_machine_pwm_init_helper(machine_pwm_obj_t *self, size_t n_args, c
     /* Route the TCPWM output to the configured GPIO pin */
     pwm_pin_config(self->pin);
 
-    /* Connect the pre-configured 2 kHz clock divider to this counter's PCLK input */
+    /* Program the shared 16-bit divider to PWM_TCPWM_CLK_HZ on the first PWM init, then
+     * connect it to this counter's PCLK input. All channels share divider CYBSP_PWM_LED_CTRL_CLK_DIV_NUM
+     * so the reprogramming only needs to happen once. */
+    if (!pwm_clk_configured) {
+        Cy_SysClk_PeriPclkDisableDivider((en_clk_dst_t)CYBSP_PWM_LED_CTRL_CLK_DIV_GRP_NUM,
+            CY_SYSCLK_DIV_16_BIT, CYBSP_PWM_LED_CTRL_CLK_DIV_NUM);
+        Cy_SysClk_PeriPclkSetDivider((en_clk_dst_t)CYBSP_PWM_LED_CTRL_CLK_DIV_GRP_NUM,
+            CY_SYSCLK_DIV_16_BIT, CYBSP_PWM_LED_CTRL_CLK_DIV_NUM, PWM_TCPWM_CLK_DIV_VAL);
+        Cy_SysClk_PeriPclkEnableDivider((en_clk_dst_t)CYBSP_PWM_LED_CTRL_CLK_DIV_GRP_NUM,
+            CY_SYSCLK_DIV_16_BIT, CYBSP_PWM_LED_CTRL_CLK_DIV_NUM);
+        pwm_clk_configured = true;
+    }
     Cy_SysClk_PeriPclkAssignDivider(self->pclk_dst, CY_SYSCLK_DIV_16_BIT, CYBSP_PWM_LED_CTRL_CLK_DIV_NUM);
 
-    cy_rslt_t result = Cy_TCPWM_PWM_Init(TCPWM0,
+    cy_en_tcpwm_status_t result = Cy_TCPWM_PWM_Init(TCPWM0,
         self->counter_num, &self->pwm_obj);
     pwm_assert_raise_val("PWM init failed with return code %lx !", result);
 
@@ -289,11 +310,11 @@ static mp_obj_t mp_machine_pwm_make_new(const mp_obj_type_t *type, size_t n_args
     self->pwm_obj.pwmMode = CY_TCPWM_PWM_MODE_PWM;
     self->pwm_obj.clockPrescaler = CY_TCPWM_PWM_PRESCALER_DIVBY_1;
     self->pwm_obj.pwmAlignment = CY_TCPWM_PWM_LEFT_ALIGN;
-    self->pwm_obj.deadTimeClocks = 0;
+    self->pwm_obj.deadTimeClocks = 0U;
     self->pwm_obj.runMode = CY_TCPWM_PWM_CONTINUOUS;
     self->pwm_obj.enablePeriodSwap = false;
     self->pwm_obj.enableCompareSwap = false;
-    self->pwm_obj.interruptSources = (CY_TCPWM_INT_ON_TC & 0U) | (CY_TCPWM_INT_ON_CC0 & 0U) | (CY_TCPWM_INT_ON_CC1 & 0U);
+    self->pwm_obj.interruptSources = 0U;
     self->pwm_obj.invertPWMOutN = CY_TCPWM_PWM_INVERT_ENABLE;
     self->pwm_obj.killMode = CY_TCPWM_PWM_ASYNC_KILL;
     self->pwm_obj.swapInputMode = CYBSP_PWM_LED_CTRL_INPUT_DISABLED & 0x3U;
@@ -308,7 +329,7 @@ static mp_obj_t mp_machine_pwm_make_new(const mp_obj_type_t *type, size_t n_args
     self->pwm_obj.countInput = CY_TCPWM_INPUT_1;
     self->pwm_obj.swapOverflowUnderflow = false;
     self->pwm_obj.immediateKill = false;
-    self->pwm_obj.tapsEnabled = 45;
+    self->pwm_obj.tapsEnabled = CY_TCPWM_INPUT_0;
     self->pwm_obj.compare2 = CY_TCPWM_GRP_CNT_CC0_DEFAULT;
     self->pwm_obj.compare3 = CY_TCPWM_GRP_CNT_CC0_BUFF_DEFAULT;
     self->pwm_obj.enableCompare1Swap = false;
@@ -326,7 +347,7 @@ static mp_obj_t mp_machine_pwm_make_new(const mp_obj_type_t *type, size_t n_args
     self->pwm_obj.linecompl_out_sel = CY_TCPWM_OUTPUT_INVERTED_PWM_SIGNAL;
     self->pwm_obj.line_out_sel_buff = CY_TCPWM_OUTPUT_PWM_SIGNAL;
     self->pwm_obj.linecompl_out_sel_buff = CY_TCPWM_OUTPUT_INVERTED_PWM_SIGNAL;
-    self->pwm_obj.deadTimeClocks_linecompl_out = 0;
+    self->pwm_obj.deadTimeClocks_linecompl_out = 0U;
 
     // Process the remaining parameters (skip dest at args[0]).
     mp_map_t kw_args;
@@ -345,30 +366,30 @@ static void mp_machine_pwm_deinit(machine_pwm_obj_t *self) {
 
 // Return the current PWM output frequency in Hz.
 static mp_obj_t mp_machine_pwm_freq_get(machine_pwm_obj_t *self) {
-    mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM not implemented"));
+    mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM freq getter/setter not yet implemented"));
 }
 
 // Update the PWM output frequency; recalculates the period register.
 static void mp_machine_pwm_freq_set(machine_pwm_obj_t *self, mp_int_t freq) {
-    mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM not implemented"));
+    mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM freq getter/setter not yet implemented"));
 }
 
 // Return the current duty cycle as a 16-bit value (0-65535).
 static mp_obj_t mp_machine_pwm_duty_get_u16(machine_pwm_obj_t *self) {
-    mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM not implemented"));
+    mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM duty getter/setter not yet implemented"));
 }
 
 // Set the duty cycle from a 16-bit value (0-65535).
 static void mp_machine_pwm_duty_set_u16(machine_pwm_obj_t *self, mp_int_t duty_u16) {
-    mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM not implemented"));
+    mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM duty getter/setter not yet implemented"));
 }
 
 // Return the current on-time duty cycle in nanoseconds.
 static mp_obj_t mp_machine_pwm_duty_get_ns(machine_pwm_obj_t *self) {
-    mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM not implemented"));
+    mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM duty getter/setter not yet implemented"));
 }
 
 // Set the duty cycle as an on-time in nanoseconds.
 static void mp_machine_pwm_duty_set_ns(machine_pwm_obj_t *self, mp_int_t duty_ns) {
-    mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM not implemented"));
+    mp_raise_msg(&mp_type_NotImplementedError, MP_ERROR_TEXT("PWM duty getter/setter not yet implemented"));
 }

--- a/ports/psoc-edge/modmachine.c
+++ b/ports/psoc-edge/modmachine.c
@@ -76,6 +76,6 @@ static void mp_machine_set_freq(size_t n_args, const mp_obj_t *args) {
     { MP_ROM_QSTR(MP_QSTR_RTC),                 MP_ROM_PTR(&machine_rtc_type) }, \
     { MP_ROM_QSTR(MP_QSTR_IPC),                 MP_ROM_PTR(&machine_ipc_type) }, \
     { MP_ROM_QSTR(MP_QSTR_UART),                MP_ROM_PTR(&machine_uart_type) }, \
-	{ MP_ROM_QSTR(MP_QSTR_PWM),                 MP_ROM_PTR(&machine_pwm_type) }, \
+    { MP_ROM_QSTR(MP_QSTR_PWM),                 MP_ROM_PTR(&machine_pwm_type) }, \
 
 #endif // MICROPY_PY_MACHINE

--- a/ports/psoc-edge/modmachine.c
+++ b/ports/psoc-edge/modmachine.c
@@ -76,5 +76,6 @@ static void mp_machine_set_freq(size_t n_args, const mp_obj_t *args) {
     { MP_ROM_QSTR(MP_QSTR_RTC),                 MP_ROM_PTR(&machine_rtc_type) }, \
     { MP_ROM_QSTR(MP_QSTR_IPC),                 MP_ROM_PTR(&machine_ipc_type) }, \
     { MP_ROM_QSTR(MP_QSTR_UART),                MP_ROM_PTR(&machine_uart_type) }, \
+	{ MP_ROM_QSTR(MP_QSTR_PWM),                 MP_ROM_PTR(&machine_pwm_type) }, \
 
 #endif // MICROPY_PY_MACHINE

--- a/ports/psoc-edge/modmachine.h
+++ b/ports/psoc-edge/modmachine.h
@@ -46,5 +46,6 @@ extern const mp_obj_type_t machine_uart_type;
 extern const mp_obj_type_t machine_pdm_pcm_type;
 extern const mp_obj_type_t machine_rtc_type;
 extern const mp_obj_type_t machine_ipc_type;
+extern const mp_obj_type_t machine_pwm_type;
 
 #endif // MICROPY_INCLUDED_PSOCEDGE_MODMACHINE_H

--- a/ports/psoc-edge/mpconfigport.h
+++ b/ports/psoc-edge/mpconfigport.h
@@ -90,7 +90,7 @@
 #define MICROPY_PY_MACHINE_PDM_PCM_INCLUDEFILE  "machine_pdm_pcm.c"
 
 #define MICROPY_PY_MACHINE_PWM                  (1)
-#define MICROPY_PY_MACHINE_PWM_MAX_OBJS         (8)
+#define MICROPY_PY_MACHINE_PWM_MAX_OBJS         (7)
 #define MICROPY_PY_MACHINE_PWM_INCLUDEFILE      "ports/psoc-edge/machine_pwm.c"
 
 // type definitions for the specific machine

--- a/ports/psoc-edge/mpconfigport.h
+++ b/ports/psoc-edge/mpconfigport.h
@@ -89,6 +89,10 @@
 #define MICROPY_PY_MACHINE_PDM_PCM_RING_BUF     (1)
 #define MICROPY_PY_MACHINE_PDM_PCM_INCLUDEFILE  "machine_pdm_pcm.c"
 
+#define MICROPY_PY_MACHINE_PWM                  (1)
+#define MICROPY_PY_MACHINE_PWM_MAX_OBJS         (8)
+#define MICROPY_PY_MACHINE_PWM_INCLUDEFILE      "ports/psoc-edge/machine_pwm.c"
+
 // type definitions for the specific machine
 #define MP_SSIZE_MAX (0x7fffffff)
 

--- a/tests/ports/psoc-edge/BLR-Runner-devs.yml
+++ b/tests/ports/psoc-edge/BLR-Runner-devs.yml
@@ -3,6 +3,7 @@
   features:
     - pin
     - i2c
+    - pwm
 
 - name: KIT_PSE84_AI
   uid: 111B1698012D2400

--- a/tests/ports/psoc-edge/board_ext_hw/hw-connections.md
+++ b/tests/ports/psoc-edge/board_ext_hw/hw-connections.md
@@ -4,6 +4,8 @@
 |-------------------|---------------|---------------|--------------------------------|
 | Pin               | P16_0         | P16_1         | Output to Input                |
 |                   |               |               |                                |
+| PWM               | P16_1         | P16_0         | PWM Output to IO Input         |
+|                   |               |               |                                |
 | UART              | P17_0         | P17_1         | UART RX to TX                  |
 |                   | P16_5         | P16_6         | UART CTS to RTS                |
 

--- a/tests/ports/psoc-edge/board_ext_hw/single/pwm.py
+++ b/tests/ports/psoc-edge/board_ext_hw/single/pwm.py
@@ -165,6 +165,73 @@ try:
 except Exception as e:
     print(e)
 
+#### freq getter / setter tests ####
+
+# freq_get returns the frequency set at construction (duty_u16)
+pwm = PWM(pwm_pin, freq=1000, duty_u16=32767)
+print(f"freq_get after init (duty_u16): {pwm.freq()}")
+pwm.deinit()
+
+# freq_get returns the frequency set at construction (duty_ns)
+pwm = PWM(pwm_pin, freq=500, duty_ns=1000000)
+print(f"freq_get after init (duty_ns): {pwm.freq()}")
+pwm.deinit()
+
+# freq_set changes output frequency (duty_u16, measured on hardware)
+pwm = PWM(pwm_pin, freq=10, duty_u16=32767)
+pwm.freq(50)
+calc_dc, calc_freq = measure_signal()
+validate_signal(exp_freq=50, calc_freq=calc_freq, exp_dc=50, calc_dc=calc_dc)
+pwm.deinit()
+
+# freq_set changes output frequency (duty_ns, measured on hardware)
+# duty_ns=2500000: 25% at 100 Hz -> 50% at 200 Hz (period shrinks from 10ms to 5ms)
+pwm = PWM(pwm_pin, freq=100, duty_ns=2500000)
+pwm.freq(200)
+calc_dc, calc_freq = measure_signal()
+validate_signal(exp_freq=200, calc_freq=calc_freq, exp_dc=50, calc_dc=calc_dc)
+pwm.deinit()
+
+# freq_get after freq_set returns the new frequency
+pwm = PWM(pwm_pin, freq=100, duty_u16=32767)
+pwm.freq(250)
+print(f"freq_get after freq_set: {pwm.freq()}")
+pwm.deinit()
+
+#### Negative freq_set tests ####
+
+# freq_set: frequency must be greater than 0
+pwm = PWM(pwm_pin, freq=100, duty_u16=32767)
+try:
+    pwm.freq(0)
+except Exception as e:
+    print(e)
+pwm.deinit()
+
+# freq_set: negative frequency
+pwm = PWM(pwm_pin, freq=100, duty_u16=32767)
+try:
+    pwm.freq(-1)
+except Exception as e:
+    print(e)
+pwm.deinit()
+
+# freq_set: frequency exceeds maximum
+pwm = PWM(pwm_pin, freq=100, duty_u16=32767)
+try:
+    pwm.freq(500001)
+except Exception as e:
+    print(e)
+pwm.deinit()
+
+# freq_set: duty_ns would exceed new (lower) period
+pwm = PWM(pwm_pin, freq=100, duty_ns=9000000)  # 9 ms on-time, period = 10 ms
+try:
+    pwm.freq(200)  # new period = 5 ms; 9 ms duty exceeds it
+except Exception as e:
+    print(e)
+pwm.deinit()
+
 # PWM instance already exists
 pwm = PWM(pwm_pin, freq=1, duty_u16=32767)
 time.sleep(2)  # Wait for the pwm signal to be initialized and started

--- a/tests/ports/psoc-edge/board_ext_hw/single/pwm.py
+++ b/tests/ports/psoc-edge/board_ext_hw/single/pwm.py
@@ -232,6 +232,70 @@ except Exception as e:
     print(e)
 pwm.deinit()
 
+#### duty_u16 getter / setter tests ####
+
+# duty_u16_get returns value set at construction
+pwm = PWM(pwm_pin, freq=100, duty_u16=32767)
+print(f"duty_u16_get after init: {pwm.duty_u16()}")
+pwm.deinit()
+
+# duty_u16_get converts duty_ns to u16
+# duty_ns=5000000 at 100 Hz = 50% -> u16 = 32767
+pwm = PWM(pwm_pin, freq=100, duty_ns=5000000)
+print(f"duty_u16_get from duty_ns: {pwm.duty_u16()}")
+pwm.deinit()
+
+# duty_u16_set changes output duty cycle (measured on hardware)
+# 16383 / 65536 ~= 25%
+pwm = PWM(pwm_pin, freq=100, duty_u16=32767)
+pwm.duty_u16(16383)
+calc_dc, calc_freq = measure_signal()
+validate_signal(exp_freq=100, calc_freq=calc_freq, exp_dc=25, calc_dc=calc_dc)
+pwm.deinit()
+
+# duty_u16_get after duty_u16_set returns the new value
+pwm = PWM(pwm_pin, freq=100, duty_u16=32767)
+pwm.duty_u16(16383)
+print(f"duty_u16_get after duty_u16_set: {pwm.duty_u16()}")
+pwm.deinit()
+
+#### duty_ns getter / setter tests ####
+
+# duty_ns_get returns value set at construction
+pwm = PWM(pwm_pin, freq=100, duty_ns=2500000)
+print(f"duty_ns_get after init: {pwm.duty_ns()}")
+pwm.deinit()
+
+# duty_ns_get converts duty_u16 to ns
+# duty_u16=32767 at 100 Hz: (32767+1)/65536 * 10000000 = 5000000 ns
+pwm = PWM(pwm_pin, freq=100, duty_u16=32767)
+print(f"duty_ns_get from duty_u16: {pwm.duty_ns()}")
+pwm.deinit()
+
+# duty_ns_set changes output duty cycle (measured on hardware)
+# 2500000 ns at 100 Hz = 25%
+pwm = PWM(pwm_pin, freq=100, duty_u16=32767)
+pwm.duty_ns(2500000)
+calc_dc, calc_freq = measure_signal()
+validate_signal(exp_freq=100, calc_freq=calc_freq, exp_dc=25, calc_dc=calc_dc)
+pwm.deinit()
+
+# duty_ns_get after duty_ns_set returns the new value
+pwm = PWM(pwm_pin, freq=100, duty_u16=32767)
+pwm.duty_ns(2500000)
+print(f"duty_ns_get after duty_ns_set: {pwm.duty_ns()}")
+pwm.deinit()
+
+#### Negative duty setter tests ####
+
+# duty_ns_set: duty exceeds period (period = 10 ms = 10000000 ns at 100 Hz)
+pwm = PWM(pwm_pin, freq=100, duty_u16=32767)
+try:
+    pwm.duty_ns(15000000)
+except Exception as e:
+    print(e)
+pwm.deinit()
+
 # PWM instance already exists
 pwm = PWM(pwm_pin, freq=1, duty_u16=32767)
 time.sleep(2)  # Wait for the pwm signal to be initialized and started

--- a/tests/ports/psoc-edge/board_ext_hw/single/pwm.py
+++ b/tests/ports/psoc-edge/board_ext_hw/single/pwm.py
@@ -1,0 +1,175 @@
+# PWM test
+"""
+Setup: Connect pwm_pin to pin_in
+"""
+
+from machine import PWM, Pin
+import os
+import time
+
+pwm_pin = "P16_0"
+pin_in = "P16_1"
+
+input_pin = Pin(pin_in, Pin.IN)
+
+
+def measure_signal():
+    # In some cases, the first measurement is not accurate
+    # (negative time)
+    # so we need to measure the signal until we get a positive timing
+    positive_timing = False
+    attempts = 0
+    while not positive_timing and attempts < 3:
+        init_level = input_pin.value()
+        # Transient until edge transition
+        # when the synch is done
+        while input_pin.value() == init_level:
+            pass
+
+        # start measuring just after the edge transition
+        init_level_start_time = time.ticks_us()
+
+        # wait for edge transition
+        while input_pin.value() == (not init_level):
+            pass
+        init_level_end_time = time.ticks_us()
+
+        # wait for next edge transition
+        while input_pin.value() == init_level:
+            pass
+        second_level_start_time = time.ticks_us()
+
+        # Identify the low and high level timestamps
+        if init_level == 1:
+            low_level_start_time = init_level_start_time
+            low_level_end_time = init_level_end_time
+            high_level_start_time = init_level_end_time
+            high_level_end_time = second_level_start_time
+        else:
+            low_level_start_time = init_level_end_time
+            low_level_end_time = second_level_start_time
+            high_level_start_time = init_level_start_time
+            high_level_end_time = init_level_end_time
+
+        on_time = time.ticks_diff(high_level_end_time, high_level_start_time)
+        off_time = time.ticks_diff(low_level_end_time, low_level_start_time)
+        time_period = on_time + off_time
+
+        attempts += 1
+        if time_period > 0:
+            positive_timing = True
+
+    # Calculate frequency and duty cycle
+    calc_freq = 1000000 / (time_period)
+    calc_dc = (on_time / time_period) * 100
+    return calc_dc, calc_freq
+
+
+def validate_signal(exp_freq=0, calc_freq=0, calc_dc=0, exp_dc=0, exp_duty_u16=0, exp_duty_ns=0):
+    frequency_tolerance_percent = 10
+    duty_tolerance = 1.0
+
+    if (
+        (exp_freq - exp_freq * frequency_tolerance_percent / 100)
+        < calc_freq
+        < (exp_freq + exp_freq * frequency_tolerance_percent / 100)
+    ) == False:
+        print(
+            f"Expected freq does not match calc freq! \n Exp freq: {exp_freq} \n Calc freq: {calc_freq}"
+        )
+    else:
+        print(f"Expected freq matches calc freq! \n freq: {exp_freq}")
+
+    if ((exp_dc - duty_tolerance) < calc_dc < (exp_dc + duty_tolerance)) == False:
+        print(f"Exp dc(%) does not match calc dc(%)! \n dc: {exp_dc} \n Calc dc: {calc_dc}")
+    else:
+        print(f"Exp dc(%) matches calc dc(%)! \n dc: {exp_dc}")
+
+
+print("*** PWM tests ***")
+# T = 1sec (50% dc)
+pwm = PWM(pwm_pin, freq=1, duty_u16=32767)
+time.sleep(2)  # Wait for the pwm signal to be initialized and started
+calc_dc, calc_freq = measure_signal()
+
+validate_signal(
+    exp_freq=1,
+    calc_freq=calc_freq,
+    exp_dc=50,
+    calc_dc=calc_dc,
+    exp_duty_u16=32767,
+    exp_duty_ns=0,
+)
+
+# Reconfigure frequency and dutycycle
+pwm.init(freq=10, duty_u16=49151)
+calc_dc, calc_freq = measure_signal()
+validate_signal(
+    exp_freq=10, calc_freq=calc_freq, exp_dc=75, calc_dc=calc_dc, exp_duty_u16=49151, exp_duty_ns=0
+)
+
+# Reconfigure frequency and dutycycle
+pwm.init(freq=100, duty_ns=2500000)
+calc_dc, calc_freq = measure_signal()
+validate_signal(
+    exp_freq=100,
+    calc_freq=calc_freq,
+    exp_dc=25,
+    calc_dc=calc_dc,
+    exp_duty_u16=0,
+    exp_duty_ns=2500000,
+)
+pwm.deinit()
+
+#### Negative test cases ####
+
+# PWM frequency out of range
+try:
+    pwm = PWM(pwm_pin, freq=500001, duty_u16=32767)
+except Exception as e:
+    print(e)
+
+# PWM frequency must be greater than 0
+try:
+    pwm = PWM(pwm_pin, freq=0, duty_u16=32767)
+except Exception as e:
+    print(e)
+
+# PWM duty_ns larger than period (20,000,000 ns)
+try:
+    pwm = PWM(pwm_pin, freq=50, duty_ns=25000000)
+except Exception as e:
+    print(e)
+
+# PWM duty cycle only one format should be specified
+try:
+    pwm = PWM(pwm_pin, freq=10, duty_u16=32767, duty_ns=100000)
+except Exception as e:
+    print(e)
+
+# Negative frequency
+try:
+    pwm = PWM(pwm_pin, freq=-1, duty_u16=32767)
+except Exception as e:
+    print(e)
+
+# No duty specified
+try:
+    pwm = PWM(pwm_pin, freq=100)
+except Exception as e:
+    print(e)
+
+# Non-PWM-capable pin
+try:
+    pwm = PWM("P0_0", freq=100, duty_u16=32767)
+except Exception as e:
+    print(e)
+
+# PWM instance already exists
+pwm = PWM(pwm_pin, freq=1, duty_u16=32767)
+time.sleep(2)  # Wait for the pwm signal to be initialized and started
+try:
+    pwm2 = PWM(pwm_pin, freq=1, duty_u16=32767)
+except Exception as e:
+    print(e)
+    pwm.deinit()

--- a/tests/ports/psoc-edge/board_ext_hw/single/pwm.py
+++ b/tests/ports/psoc-edge/board_ext_hw/single/pwm.py
@@ -7,8 +7,8 @@ from machine import PWM, Pin
 import os
 import time
 
-pwm_pin = "P16_0"
-pin_in = "P16_1"
+pwm_pin = "P16_1"
+pin_in = "P16_0"
 
 input_pin = Pin(pin_in, Pin.IN)
 

--- a/tests/ports/psoc-edge/board_ext_hw/single/pwm.py.exp
+++ b/tests/ports/psoc-edge/board_ext_hw/single/pwm.py.exp
@@ -18,4 +18,4 @@ PWM duty should be specified only in one format
 PWM frequency must be greater than 0
 PWM duty should be specified in either ns or u16
 Pin(P0_0) doesn't exist
-PWM instance for Pin P16_0 already exists, call deinit() first
+PWM instance for Pin P16_1 already exists, call deinit() first

--- a/tests/ports/psoc-edge/board_ext_hw/single/pwm.py.exp
+++ b/tests/ports/psoc-edge/board_ext_hw/single/pwm.py.exp
@@ -33,4 +33,19 @@ PWM frequency must be greater than 0
 PWM frequency must be greater than 0
 PWM frequency must not exceed 500000 Hz
 PWM duty in ns is larger than the period 5000000 ns
+duty_u16_get after init: 32767
+duty_u16_get from duty_ns: 32767
+Expected freq matches calc freq! 
+ freq: 100
+Exp dc(%) matches calc dc(%)! 
+ dc: 25
+duty_u16_get after duty_u16_set: 16383
+duty_ns_get after init: 2500000
+duty_ns_get from duty_u16: 5000000
+Expected freq matches calc freq! 
+ freq: 100
+Exp dc(%) matches calc dc(%)! 
+ dc: 25
+duty_ns_get after duty_ns_set: 2500000
+PWM duty in ns is larger than the period 10000000 ns
 PWM instance for Pin P16_1 already exists, call deinit() first

--- a/tests/ports/psoc-edge/board_ext_hw/single/pwm.py.exp
+++ b/tests/ports/psoc-edge/board_ext_hw/single/pwm.py.exp
@@ -13,9 +13,24 @@ Exp dc(%) matches calc dc(%)!
  dc: 25
 PWM frequency must not exceed 500000 Hz
 PWM frequency must be greater than 0
-PWM duty in ns is larger than the period 0 ns
+PWM duty in ns is larger than the period 20000000 ns
 PWM duty should be specified only in one format
 PWM frequency must be greater than 0
 PWM duty should be specified in either ns or u16
 Pin(P0_0) doesn't exist
+freq_get after init (duty_u16): 1000
+freq_get after init (duty_ns): 500
+Expected freq matches calc freq! 
+ freq: 50
+Exp dc(%) matches calc dc(%)! 
+ dc: 50
+Expected freq matches calc freq! 
+ freq: 200
+Exp dc(%) matches calc dc(%)! 
+ dc: 50
+freq_get after freq_set: 250
+PWM frequency must be greater than 0
+PWM frequency must be greater than 0
+PWM frequency must not exceed 500000 Hz
+PWM duty in ns is larger than the period 5000000 ns
 PWM instance for Pin P16_1 already exists, call deinit() first

--- a/tests/ports/psoc-edge/board_ext_hw/single/pwm.py.exp
+++ b/tests/ports/psoc-edge/board_ext_hw/single/pwm.py.exp
@@ -1,0 +1,21 @@
+*** PWM tests ***
+Expected freq matches calc freq! 
+ freq: 1
+Exp dc(%) matches calc dc(%)! 
+ dc: 50
+Expected freq matches calc freq! 
+ freq: 10
+Exp dc(%) matches calc dc(%)! 
+ dc: 75
+Expected freq matches calc freq! 
+ freq: 100
+Exp dc(%) matches calc dc(%)! 
+ dc: 25
+PWM frequency must not exceed 500000 Hz
+PWM frequency must be greater than 0
+PWM duty in ns is larger than the period 0 ns
+PWM duty should be specified only in one format
+PWM frequency must be greater than 0
+PWM duty should be specified in either ns or u16
+Pin(P0_0) doesn't exist
+PWM instance for Pin P16_0 already exists, call deinit() first

--- a/tests/ports/psoc-edge/test-plan.yml
+++ b/tests/ports/psoc-edge/test-plan.yml
@@ -66,7 +66,7 @@
       - board: KIT_PSE84_AI
         features:
           - uart
-	  
+
 - name: pwm
   test: 
     script: ports/psoc-edge/board_ext_hw/single/pwm.py

--- a/tests/ports/psoc-edge/test-plan.yml
+++ b/tests/ports/psoc-edge/test-plan.yml
@@ -66,3 +66,11 @@
       - board: KIT_PSE84_AI
         features:
           - uart
+	  
+- name: pwm
+  test: 
+    script: ports/psoc-edge/board_ext_hw/single/pwm.py
+    device: 
+      - board: KIT_PSE84_AI
+        features:
+          - pwm


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

This PR implements the machine.PWM class for the PSoC Edge (KIT_PSE84_AI) platform, built on top of the PDL TCPWM0 peripheral. The implementation follows the standard MicroPython machine.PWM API.

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant,
     especially links to open issues. -->

- Created the initial skeleton with base type definitions, MicroPython object structure, and module registration.
- Implemented PWM() constructor, PWM.init(), and PWM.deinit().
- Added frequency and duty cycle configuration supporting both duty_u16 and duty_ns modes with conversion helpers.
- Added a pwm_pin_map[] table mapping each PWM-capable pin (P16_1–P16_7) to its own dedicated TCPWM0 counter index and PCLK destination via pwm_get_counter(), ensuring each counter instance receives its own clock assignment.
- Enforced single-instance constraint: creating a second PWM object for an already-active pin raises an error.
- Implemented freq(), duty_u16(), and duty_ns() getter/setter methods.

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this section empty then your Pull Request may be closed. -->

- Verified on-board LED operation and confirmed PWM output on pins P16_1–P16_7 using a logic analyzer.
- Confirmed pins P16_1–P16_7 can operate at independent frequencies simultaneously across multiple PWM instances.
- Validated multiple frequency and duty cycle combinations on P16_4 using a logic analyzer, including getter and setter methods.
- HIL tests on P16_1 covering positive cases (frequency and duty cycle accuracy) and negative cases (out-of-range frequency, duty_ns exceeding the period, duplicate instance creation).

### Trade-offs and Alternatives

<!-- If the Pull Request has some negative impact (i.e. increased code size)
     then please explain why you think the trade-off improvement is worth it.
     If you can think of alternative ways to do this, please explain that here too.

     Delete this heading if not relevant (i.e. small fixes) -->

- Multiple PWM pins are sharing TCPWM counters either with other PWM capable pins or with other BSP peripherals.
- Only 3 PWM capable pins are truly independent and exposed for ready usage on the PSOC board. They are pins P16_3 , P16_5 and P16_6.
- PWM pins not supported in the board as per pins.csv, P0_0, P0_1, P7_3 and P11_6, are not configured.
- PWM pin P16_0 is not supported as the TCPWM counter for this pin is shared with other pins.

### Generative AI

<!-- Please delete the answer below which doesn't apply, or write your own
     answer with more details. -->

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.

<!-- We require everyone to answer this question. If you delete this section or
     ignore it then your PR may be closed.

     For more information, consult the MicroPython Generative AI Policy:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines#generative-ai-policy
     -->
