### PR TITLE
psoc-edge: Refactor time stack and fix time_ns() epoch/monotonic behavior

### DIFF
--- a/ports/psoc-edge/Makefile
+++ b/ports/psoc-edge/Makefile
@@ -314,6 +314,7 @@ PSE_LIB_SRC_C += $(addprefix $(PSE_LIB_TOP_DIR)/, \
 	mtb-dsl-pse8xxgp/pdl/drivers/source/cy_syspm_pdcm.c \
 	mtb-dsl-pse8xxgp/pdl/drivers/source/cy_syspm_ppu.c \
 	mtb-dsl-pse8xxgp/pdl/drivers/source/cy_syspm_v4.c \
+	mtb-dsl-pse8xxgp/pdl/drivers/source/cy_systick_v2.c \
 	mtb-dsl-pse8xxgp/pdl/drivers/source/cy_tcpwm_counter.c \
 	mtb-dsl-pse8xxgp/pdl/drivers/source/cy_tcpwm_pwm.c \
 	mtb-dsl-pse8xxgp/pdl/drivers/source/ppu_v1.c \
@@ -487,6 +488,7 @@ SRC_C += \
 	help.c \
 	main.c \
 	mphalport.c \
+	systick.c \
 	sys_int.c \
 
 # List of sources for qstr extraction

--- a/ports/psoc-edge/machine_rtc.c
+++ b/ports/psoc-edge/machine_rtc.c
@@ -156,6 +156,20 @@ static bool rtc_validate_date_time(int sec, int min, int hour, int mday, int mon
     return mday <= days_in_month;
 }
 
+void machine_rtc_get_datetime(timeutils_struct_time_t *time) {
+    cy_stc_rtc_config_t current_date_time = {0};
+    Cy_RTC_GetDateAndTime(&current_date_time);
+
+    time->tm_year = current_date_time.year + RTC_CENTURY;
+    time->tm_mon = current_date_time.month;
+    time->tm_mday = current_date_time.date;
+    time->tm_hour = current_date_time.hour;
+    time->tm_min = current_date_time.min;
+    time->tm_sec = current_date_time.sec;
+    time->tm_wday = current_date_time.dayOfWeek - 1u;
+    time->tm_yday = timeutils_year_day(current_date_time.year + RTC_CENTURY, current_date_time.month, current_date_time.date);
+}
+
 void machine_rtc_init_all(void) {
     /* Variable used to store return status of RTC API */
     cy_en_rtc_status_t rtc_status;
@@ -180,18 +194,18 @@ void machine_rtc_init_all(void) {
 // overwritten with the correct value. datetime() does not raise an error for incorrect
 // weekday values - the hardware ensures weekday always matches the actual calendar date.
 static mp_obj_t machine_rtc_datetime_helper(mp_uint_t n_args, const mp_obj_t *args) {
-    cy_stc_rtc_config_t curr_date_time = {0};  // Initialize all fields to 0
     if (n_args == 1) {
         /* Get the current date and time */
-        Cy_RTC_GetDateAndTime(&curr_date_time);
+        timeutils_struct_time_t time;
+        machine_rtc_get_datetime(&time);
         mp_obj_t tuple[8] = {
-            mp_obj_new_int(curr_date_time.year + RTC_CENTURY),
-            mp_obj_new_int(curr_date_time.month),
-            mp_obj_new_int(curr_date_time.date),
-            mp_obj_new_int(curr_date_time.dayOfWeek),
-            mp_obj_new_int(curr_date_time.hour),
-            mp_obj_new_int(curr_date_time.min),
-            mp_obj_new_int(curr_date_time.sec),
+            mp_obj_new_int(time.tm_year),
+            mp_obj_new_int(time.tm_mon),
+            mp_obj_new_int(time.tm_mday),
+            mp_obj_new_int(time.tm_wday + 1u),
+            mp_obj_new_int(time.tm_hour),
+            mp_obj_new_int(time.tm_min),
+            mp_obj_new_int(time.tm_sec),
             mp_obj_new_int(0),
         };
         return mp_obj_new_tuple(8, tuple);

--- a/ports/psoc-edge/machine_rtc.c
+++ b/ports/psoc-edge/machine_rtc.c
@@ -83,6 +83,7 @@ typedef struct _machine_rtc_obj_t {
     uint64_t alarm_elapse_time_s;
     bool alarmset;
     bool repeat;
+    volatile bool time_updated;
 } machine_rtc_obj_t;
 
 void srss_interrupt_rtc_IRQHandler(void);
@@ -94,10 +95,21 @@ static machine_rtc_obj_t machine_rtc_obj = {
     .alarm_period_s = 0,
     .alarm_elapse_time_s = 0,
     .alarmset = false,
-    .repeat = false
+    .repeat = false,
+    .time_updated = true,
 };
 
 static bool rtc_irq_initialized = false;
+
+static inline void machine_rtc_mark_time_updated(void) {
+    machine_rtc_obj.time_updated = true;
+}
+
+bool machine_rtc_read_and_clear_time_updated(void) {
+    bool updated = machine_rtc_obj.time_updated;
+    machine_rtc_obj.time_updated = false;
+    return updated;
+}
 
 static inline uint32_t rtc_breg_read(uint32_t index) {
     return BACKUP_BREG_SET2[index];
@@ -186,6 +198,10 @@ void machine_rtc_init_all(void) {
         rtc_access_retry--;
         Cy_SysLib_Delay(RTC_RETRY_DELAY_MS);
     } while ((rtc_status != CY_RTC_SUCCESS) && (rtc_access_retry != 0));
+
+    if (rtc_status == CY_RTC_SUCCESS) {
+        machine_rtc_mark_time_updated();
+    }
 }
 
 // Helper function to set/get datetime
@@ -229,6 +245,7 @@ static mp_obj_t machine_rtc_datetime_helper(mp_uint_t n_args, const mp_obj_t *ar
 
         uint32_t year = year_full - RTC_CENTURY;
         Cy_RTC_SetDateAndTimeDirect(sec, min, hour, date, month, year);
+        machine_rtc_mark_time_updated();
     }
     return mp_const_none;
 }
@@ -363,6 +380,7 @@ static mp_obj_t machine_rtc_deinit(mp_obj_t self_in) {
     /* Resets RTC to 1st Jan' 2015 as mentioned in MPY guide*/
     Cy_RTC_SetDateAndTimeDirect(RTC_INIT_SECOND, RTC_INIT_MINUTE, RTC_INIT_HOUR,
         RTC_INIT_MDAY, RTC_INIT_MONTH, RTC_INIT_YEAR);
+    machine_rtc_mark_time_updated();
     return mp_const_none;
 }
 static MP_DEFINE_CONST_FUN_OBJ_1(machine_rtc_deinit_obj, machine_rtc_deinit);

--- a/ports/psoc-edge/main.c
+++ b/ports/psoc-edge/main.c
@@ -80,11 +80,11 @@ typedef enum {
 } boot_mode_t;
 
 extern void machine_rtc_init_all(void);
-extern void time_init(void);
 extern void machine_pin_irq_deinit_all(void);
 extern void machine_hw_i2c_deinit_all(void);
 extern void machine_pdm_pcm_deinit_all(void);
 extern void machine_ipc_deinit_all(void);
+extern void mp_hal_ticks_init(void);
 
 void mpy_task(void *arg);
 static TaskHandle_t mpy_task_handle;
@@ -155,7 +155,7 @@ void mpy_task(void *arg) {
     mp_cstack_init_with_top((void *)&arg, MPY_TASK_STACK_SIZE * sizeof(StackType_t));
     #endif
 
-    time_init();
+    mp_hal_ticks_init();
     #if MICROPY_PY_NETWORK
     network_hw_init();
     #endif

--- a/ports/psoc-edge/modtime.c
+++ b/ports/psoc-edge/modtime.c
@@ -27,109 +27,29 @@
 
 // std includes
 #include "stdio.h"
+#include <stdint.h>
 
 // micropython includes
 #include "extmod/modtime.h"
+#include "modmachine.h"
 #include "py/runtime.h"
 #include "shared/timeutils/timeutils.h"
 
-// MTB includes
-#include "mtb_hal.h"
-#include "cybsp.h"
-
-mtb_hal_timer_t psoc_edge_timer;
-
-#define TIMER_HW CYBSP_GENERAL_PURPOSE_TIMER_HW    // TCPWM0
-#define TIMER_NUM CYBSP_GENERAL_PURPOSE_TIMER_NUM  // 2
-#define TIMER_INPUT_DISABLED 0x7U
-
-
-static const mtb_hal_peri_div_t clock_ref =
-{
-    .clk_dst = (en_clk_dst_t)PCLK_TCPWM0_CLOCK_COUNTER_EN2,
-    .div_type = CY_SYSCLK_DIV_16_BIT,
-    .div_num = 2,
-};
-static const mtb_hal_clock_t hal_clock =
-{
-    .clock_ref = &clock_ref,
-    .interface = &mtb_hal_clock_peri_interface,
-};
-
-static const cy_stc_tcpwm_counter_config_t timer_config =
-{
-    .period = 15000000,
-    .clockPrescaler = CY_TCPWM_COUNTER_PRESCALER_DIVBY_1,
-    .runMode = CY_TCPWM_COUNTER_CONTINUOUS,
-    .countDirection = CY_TCPWM_COUNTER_COUNT_UP,
-    .compareOrCapture = CY_TCPWM_COUNTER_MODE_COMPARE,
-    .compare0 = 0,
-    .compare1 = 16384,
-    .enableCompareSwap = false,
-    .interruptSources = CY_TCPWM_INT_NONE,
-    .captureInputMode = 0x3U,
-    .captureInput = CY_TCPWM_INPUT_0,
-    .reloadInputMode = 0x3U,
-    .reloadInput = CY_TCPWM_INPUT_0,
-    .startInputMode = 0x3U,
-    .startInput = CY_TCPWM_INPUT_0,
-    .stopInputMode = 0x3U,
-    .stopInput = CY_TCPWM_INPUT_0,
-    .countInputMode = 0x3U,
-    .countInput = CY_TCPWM_INPUT_1,
-    .capture1InputMode = 0x3U,
-    .capture1Input = CY_TCPWM_INPUT_0,
-    .compare2 = 16384,
-    .compare3 = 16384,
-    .enableCompare1Swap = false,
-    .trigger0Event = CY_TCPWM_CNT_TRIGGER_ON_DISABLED,
-    .trigger1Event = CY_TCPWM_CNT_TRIGGER_ON_DISABLED,
-};
-
-static const mtb_hal_timer_configurator_t timer_hal_config =
-{
-    .tcpwm_base = TIMER_HW,
-    .clock = &hal_clock,
-    .tcpwm_cntnum = TIMER_NUM,
-};
-
-void time_init(void) {
-    cy_rslt_t rslt;
-
-    rslt = Cy_TCPWM_Counter_Init(TIMER_HW, TIMER_NUM, &timer_config);
-
-    if (rslt == CY_RSLT_SUCCESS) {
-        rslt = mtb_hal_timer_setup(&psoc_edge_timer, &timer_hal_config, NULL);
-    }
-
-    if (rslt == CY_RSLT_SUCCESS) {
-        rslt = mtb_hal_clock_set_peri_clock_freq(&clock_ref, 1000000, 1000);
-    }
-
-    if (rslt == CY_RSLT_SUCCESS) {
-        rslt = mtb_hal_timer_start(&psoc_edge_timer);
-    }
-}
+extern void machine_rtc_get_datetime(timeutils_struct_time_t *time);
 
 static void mp_time_localtime_get(timeutils_struct_time_t *time) {
-    cy_stc_rtc_config_t current_date_time = {0};
-    Cy_RTC_GetDateAndTime(&current_date_time);
+    machine_rtc_get_datetime(time);
+}
 
-    time->tm_year = current_date_time.year;
-    time->tm_mon = current_date_time.month;
-    time->tm_mday = current_date_time.date;
-    time->tm_hour = current_date_time.hour;
-    time->tm_min = current_date_time.min;
-    time->tm_sec = current_date_time.sec;
-    time->tm_wday = current_date_time.dayOfWeek - 1u;
-    time->tm_yday = timeutils_year_day(current_date_time.year, current_date_time.month, current_date_time.date);
+uint64_t mp_hal_time_get_epoch_seconds(void) {
+    timeutils_struct_time_t current_date_time;
+    machine_rtc_get_datetime(&current_date_time);
+
+    return timeutils_seconds_since_epoch(current_date_time.tm_year, current_date_time.tm_mon, current_date_time.tm_mday,
+        current_date_time.tm_hour, current_date_time.tm_min, current_date_time.tm_sec);
 }
 
 // Return the number of seconds since the Epoch.
 static mp_obj_t mp_time_time_get(void) {
-    cy_stc_rtc_config_t current_date_time = {0};
-    Cy_RTC_GetDateAndTime(&current_date_time);
-
-    return timeutils_obj_from_timestamp(timeutils_seconds_since_epoch(current_date_time.year, current_date_time.month, current_date_time.date,
-        current_date_time.hour, current_date_time.min, current_date_time.sec));
+    return timeutils_obj_from_timestamp(mp_hal_time_get_epoch_seconds());
 }

--- a/ports/psoc-edge/mphalport.c
+++ b/ports/psoc-edge/mphalport.c
@@ -25,7 +25,6 @@
  */
 
 // std includes
-#include "stdbool.h"   // because of missing include in shared/timeutils/timeutils.h
 #include "stdio.h"
 
 // MTB includes
@@ -39,10 +38,8 @@
 #include "mphalport.h"
 
 #include "py/runtime.h"
-#include "shared/timeutils/timeutils.h"
 
 extern mtb_hal_uart_t DEBUG_UART_hal_obj;
-extern mtb_hal_timer_t psoc_edge_timer;
 
 void mp_hal_get_random(size_t n, uint8_t *buf) {
     uint32_t r = 0;
@@ -53,41 +50,6 @@ void mp_hal_get_random(size_t n, uint8_t *buf) {
         buf[i] = (uint8_t)r;
         r >>= 8;
     }
-}
-
-void mp_hal_delay_ms(mp_uint_t ms) {
-    mp_uint_t start = mp_hal_ticks_ms();
-    while (mp_hal_ticks_ms() - start < ms) {
-        mp_event_handle_nowait();
-    }
-}
-
-void mp_hal_delay_us(mp_uint_t us) {
-    mtb_hal_system_delay_us(us);
-}
-
-uint64_t mp_hal_time_ns(void) {
-    // TODO: This is not fully functional until rtc machine module is implemented.
-    cy_stc_rtc_config_t current_date_time = {0};
-    Cy_RTC_GetDateAndTime(&current_date_time);
-
-    uint64_t s = timeutils_seconds_since_epoch(current_date_time.year, current_date_time.month, current_date_time.date,
-        current_date_time.hour, current_date_time.min, current_date_time.sec);
-
-    // add ticks to make sure time is strictly monotonic
-    return s * 1000000000ULL + mtb_hal_timer_read(&psoc_edge_timer) * 1000ULL;
-}
-
-mp_uint_t mp_hal_ticks_ms(void) {
-    return mtb_hal_timer_read(&psoc_edge_timer) / 1000;
-}
-
-mp_uint_t mp_hal_ticks_us(void) {
-    return mtb_hal_timer_read(&psoc_edge_timer);
-}
-
-mp_uint_t mp_hal_ticks_cpu(void) {
-    return mtb_hal_timer_read(&psoc_edge_timer);
 }
 
 uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags) {

--- a/ports/psoc-edge/mphalport.h
+++ b/ports/psoc-edge/mphalport.h
@@ -60,7 +60,6 @@ void mp_hal_delay_us(mp_uint_t us);
 void mp_hal_delay_us_fast(mp_uint_t us);
 void mp_hal_delay_ms(mp_uint_t ms);
 
-void mp_hal_stdio_init(void);
 uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags);
 int mp_hal_stdin_rx_chr(void);
 void mp_hal_set_interrupt_char(int c); // -1 to disable

--- a/ports/psoc-edge/mphalport.h
+++ b/ports/psoc-edge/mphalport.h
@@ -37,18 +37,30 @@
 #include "py/runtime.h"
 #include "machine_pin.h"
 
+#include "cybsp.h"
+
+static inline void enable_irq(mp_uint_t state) {
+    if (state == 0) {
+        __enable_irq();
+    }
+}
+
+static inline mp_uint_t disable_irq(void) {
+    mp_uint_t state = __get_PRIMASK();
+    __disable_irq();
+    return state;
+}
+
+#define MICROPY_BEGIN_ATOMIC_SECTION()     disable_irq()
+#define MICROPY_END_ATOMIC_SECTION(state)  enable_irq(state)
+
 #define mp_hal_delay_us_fast mp_hal_delay_us
 
 void mp_hal_delay_us(mp_uint_t us);
 void mp_hal_delay_us_fast(mp_uint_t us);
 void mp_hal_delay_ms(mp_uint_t ms);
 
-uint64_t mp_hal_time_ns(void);
-
-mp_uint_t mp_hal_ticks_us(void);
-mp_uint_t mp_hal_ticks_ms(void);
-mp_uint_t mp_hal_ticks_cpu(void);
-
+void mp_hal_stdio_init(void);
 uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags);
 int mp_hal_stdin_rx_chr(void);
 void mp_hal_set_interrupt_char(int c); // -1 to disable

--- a/ports/psoc-edge/systick.c
+++ b/ports/psoc-edge/systick.c
@@ -1,0 +1,130 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2026 Infineon Technologies AG
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <stdint.h>
+
+#include "cybsp.h"
+#include "cy_systick.h"
+
+#include "mphalport.h"
+
+#include "py/runtime.h"
+
+volatile uint64_t psoc_edge_systick_ms_count;
+uint32_t psoc_edge_systick_cpu_hz;
+
+// Use the SysTick pending-interrupt state as rollover evidence. This matches our
+// callback-based ms counter model ("ISR increment still outstanding") and avoids
+// Cy_SysTick_GetCountFlag()'s read-to-clear side effect.
+#define MP_HAL_SYSTICK_WRAP_PENDING() (((SCB->ICSR) & SCB_ICSR_PENDSTSET_Msk) != 0u)
+
+typedef struct {
+    uint64_t ms_count;
+    uint32_t systick_reload;
+    uint32_t systick_val;
+    uint32_t cpu_hz;
+} mp_hal_systick_snapshot_t;
+
+static void psoc_edge_systick_callback(void) {
+    psoc_edge_systick_ms_count += 1;
+}
+
+void mp_hal_ticks_init(void) {
+    psoc_edge_systick_cpu_hz = SystemCoreClock;
+    if (psoc_edge_systick_cpu_hz < 1000) {
+        mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("invalid SystemCoreClock (< 1000 Hz)."));
+    }
+
+    // Configure SysTick for 1ms period and count overflows in software.
+    uint32_t systick_interval = psoc_edge_systick_cpu_hz / 1000;
+
+    psoc_edge_systick_ms_count = 0;
+    Cy_SysTick_Init(CY_SYSTICK_CLOCK_SOURCE_CLK_CPU, systick_interval - 1);
+    Cy_SysTick_SetCallback(0, psoc_edge_systick_callback);
+}
+
+static mp_hal_systick_snapshot_t mp_hal_systick_snapshot(void) {
+    mp_hal_systick_snapshot_t snap;
+
+    mp_uint_t irq_state = MICROPY_BEGIN_ATOMIC_SECTION();
+    snap.ms_count = psoc_edge_systick_ms_count;
+    snap.systick_reload = Cy_SysTick_GetReload();
+    snap.systick_val = Cy_SysTick_GetValue();
+    // SysTick may have wrapped but its ISR not run yet; account for that pending rollover
+    // so software time does not momentarily go backwards across the wrap boundary.
+    if (MP_HAL_SYSTICK_WRAP_PENDING()) {
+        snap.ms_count += 1;
+    }
+    snap.cpu_hz = psoc_edge_systick_cpu_hz;
+    MICROPY_END_ATOMIC_SECTION(irq_state);
+
+    if (snap.cpu_hz == 0) {
+        mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("invalid systick CPU clock."));
+    }
+
+    return snap;
+}
+
+uint64_t mp_hal_systick_ticks_us64(void) {
+    mp_hal_systick_snapshot_t snap = mp_hal_systick_snapshot();
+
+    uint32_t elapsed_cycles = snap.systick_reload - snap.systick_val;
+    return snap.ms_count * 1000ULL + ((uint64_t)elapsed_cycles * 1000000ULL) / snap.cpu_hz;
+}
+
+mp_uint_t mp_hal_ticks_ms(void) {
+    return mp_hal_systick_ticks_us64() / 1000ULL;
+}
+
+mp_uint_t mp_hal_ticks_us(void) {
+    return mp_hal_systick_ticks_us64();
+}
+
+mp_uint_t mp_hal_ticks_cpu(void) {
+    mp_hal_systick_snapshot_t snap = mp_hal_systick_snapshot();
+    return snap.ms_count * snap.cpu_hz + (snap.systick_reload - snap.systick_val);
+}
+
+void mp_hal_delay_ms(mp_uint_t ms) {
+    mp_uint_t start = mp_hal_ticks_ms();
+    while (mp_hal_ticks_ms() - start < ms) {
+        mp_event_handle_nowait();
+    }
+}
+
+void mp_hal_delay_us(mp_uint_t us) {
+    mp_uint_t start = mp_hal_ticks_us();
+    while (mp_hal_ticks_us() - start < us) {
+        mp_event_handle_nowait();
+    }
+}
+
+extern uint64_t mp_hal_time_get_epoch_seconds(void);
+
+uint64_t mp_hal_time_ns(void) {
+    uint64_t s = mp_hal_time_get_epoch_seconds();
+    return s * 1000000000ULL + mp_hal_systick_ticks_us64() * 1000ULL;
+}

--- a/ports/psoc-edge/systick.c
+++ b/ports/psoc-edge/systick.c
@@ -49,29 +49,43 @@ typedef struct {
     uint32_t cpu_hz;
 } mp_hal_systick_snapshot_t;
 
+#if !defined(CY_RTOS_AWARE)
 static void psoc_edge_systick_callback(void) {
     psoc_edge_systick_ms_count += 1;
 }
+#endif
 
 void mp_hal_ticks_init(void) {
     psoc_edge_systick_cpu_hz = SystemCoreClock;
+    psoc_edge_systick_ms_count = 0;
+    #if defined(CY_RTOS_AWARE)
+    // SysTick is already configured by FreeRTOS vPortSetupTimerInterrupt() at
+    // 1 ms per tick (configTICK_RATE_HZ == 1000). psoc_edge_systick_ms_count is
+    // driven from xTaskGetTickCount() inside mp_hal_systick_snapshot() so no
+    // Cypress HAL callback setup is needed here.
+    #else
     if (psoc_edge_systick_cpu_hz < 1000) {
         mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("invalid SystemCoreClock (< 1000 Hz)."));
     }
-
     // Configure SysTick for 1ms period and count overflows in software.
     uint32_t systick_interval = psoc_edge_systick_cpu_hz / 1000;
-
-    psoc_edge_systick_ms_count = 0;
     Cy_SysTick_Init(CY_SYSTICK_CLOCK_SOURCE_CLK_CPU, systick_interval - 1);
     Cy_SysTick_SetCallback(0, psoc_edge_systick_callback);
+    #endif
 }
 
 static mp_hal_systick_snapshot_t mp_hal_systick_snapshot(void) {
     mp_hal_systick_snapshot_t snap;
 
     mp_uint_t irq_state = MICROPY_BEGIN_ATOMIC_SECTION();
+    #if defined(CY_RTOS_AWARE)
+    // Drive ms_count from FreeRTOS tick counter (1 tick == 1 ms, configTICK_RATE_HZ == 1000).
+    // Keep psoc_edge_systick_ms_count in sync so any external reader stays consistent.
+    snap.ms_count = (uint64_t)xTaskGetTickCount();
+    psoc_edge_systick_ms_count = snap.ms_count;
+    #else
     snap.ms_count = psoc_edge_systick_ms_count;
+    #endif
     snap.systick_reload = Cy_SysTick_GetReload();
     snap.systick_val = Cy_SysTick_GetValue();
     // SysTick may have wrapped but its ISR not run yet; account for that pending rollover

--- a/ports/psoc-edge/systick.c
+++ b/ports/psoc-edge/systick.c
@@ -24,6 +24,7 @@
  * THE SOFTWARE.
  */
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include "cybsp.h"
@@ -123,8 +124,34 @@ void mp_hal_delay_us(mp_uint_t us) {
 }
 
 extern uint64_t mp_hal_time_get_epoch_seconds(void);
+extern bool machine_rtc_read_and_clear_time_updated(void);
 
 uint64_t mp_hal_time_ns(void) {
-    uint64_t s = mp_hal_time_get_epoch_seconds();
-    return s * 1000000000ULL + mp_hal_systick_ticks_us64() * 1000ULL;
+    static uint64_t time_us_offset_from_epoch = 0;
+    // Resync whenever RTC time was updated (set/deinit/init path marks this).
+    bool need_resync = machine_rtc_read_and_clear_time_updated();
+
+    while (need_resync) {
+        // Wait until RTC second changes so we can anchor the monotonic timer
+        // to a known wall-clock second boundary.
+        uint64_t prev_seconds = mp_hal_time_get_epoch_seconds();
+        uint64_t edge_ticks_us;
+        uint64_t edge_seconds;
+
+        do {
+            edge_seconds = mp_hal_time_get_epoch_seconds();
+        } while (edge_seconds == prev_seconds);
+
+        // Capture the monotonic timestamp immediately after observing the RTC
+        // second rollover so the fixed offset stays aligned to wall-clock time.
+        // `edge_seconds` is the first observed second after the rollover.
+        edge_ticks_us = mp_hal_systick_ticks_us64();
+        time_us_offset_from_epoch = edge_seconds * 1000000ULL - edge_ticks_us;
+
+        // If RTC was updated during calibration, repeat once more to align with
+        // the latest RTC second boundary.
+        need_resync = machine_rtc_read_and_clear_time_updated();
+    }
+
+    return (time_us_offset_from_epoch + mp_hal_systick_ticks_us64()) * 1000ULL;
 }

--- a/ports/psoc-edge/systick.c
+++ b/ports/psoc-edge/systick.c
@@ -62,10 +62,13 @@ void mp_hal_ticks_init(void) {
     // SysTick is already configured by FreeRTOS vPortSetupTimerInterrupt() at
     // 1 ms per tick (configTICK_RATE_HZ == 1000). psoc_edge_systick_ms_count is
     // driven from xTaskGetTickCount() inside mp_hal_systick_snapshot() so no
-    // Cypress HAL callback setup is needed here.
+    // callback setup is needed here.
     #else
     if (psoc_edge_systick_cpu_hz < 1000) {
-        mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("invalid SystemCoreClock (< 1000 Hz)."));
+        // Invalid system clock for a ms ticker.
+        // As micropython is not yet initialized, therefore
+        // mp_raise_msg() is not usable here.
+        CY_ASSERT(0);
     }
     // Configure SysTick for 1ms period and count overflows in software.
     uint32_t systick_interval = psoc_edge_systick_cpu_hz / 1000;

--- a/tests/ports/psoc-edge/board_only_hw/single/time.py
+++ b/tests/ports/psoc-edge/board_only_hw/single/time.py
@@ -39,7 +39,7 @@ def test_ticks_cpu():
     time.sleep_us(1)
     t1 = time.ticks_cpu()
     diff = time.ticks_diff(t1, t0)
-    tick_val = [t0, t1, diff, 0 <= diff <= 500]
+    tick_val = [t0, t1, diff, diff >= 0]
     if tick_val[3]:
         print("Status: PASS")
     else:
@@ -79,9 +79,98 @@ def test_us_deviation():
         print("[instant, t0, t1, diff] : [", i, t0, t1, time.ticks_diff(t1, t0), "]")
 
 
+def test_time_time_vs_time_ns():
+    print("\n***** Test 6: time() vs time_ns() *****\n")
+    # Retry a few times to avoid second-boundary races between the two calls.
+    match = True
+    for _ in range(5):
+        # t_ns = time.time_ns()
+        # t_s = time.time()
+        if int(time.time_ns() // 1_000_000_000) != time.time():
+            match = False
+            print(
+                "time() and time_ns() mismatch: time()=",
+                time.time(),
+                " time_ns()=",
+                time.time_ns(),
+            )
+        time.sleep_ms(1)
+
+    if match:
+        print("Status: PASS")
+    else:
+        print("Status: FAIL")
+
+
+def test_time_ns_strictly_monotonic():
+    print("\n***** Test 7: time_ns() strict monotonicity *****\n")
+    prev = time.time_ns()
+    monotonic = True
+    for _ in range(50):
+        cur = time.time_ns()
+        if cur <= prev:
+            monotonic = False
+            break
+        prev = cur
+
+    if monotonic:
+        print("Status: PASS")
+    else:
+        print("Status: FAIL")
+
+
+def test_time_elapsed_matches_delay():
+    print("\n***** Test 8: Delay vs elapsed time *****\n")
+    delays_ms = [20, 50, 100, 250]
+
+    # Use second-scale delays to validate elapsed time with time().
+    delays_s = [1, 2]
+
+    # Tolerance is intentionally relaxed for scheduler/clock granularity variance.
+    tolerance_ns = 1_000_000  # 1 ms tolerance for time_ns()
+    tolerance_s = 1
+
+    all_ok = True
+    for delay_ms in delays_ms:
+        t0_ns = time.time_ns()
+        time.sleep_ms(delay_ms)
+        t1_ns = time.time_ns()
+
+        elapsed_ns = t1_ns - t0_ns
+        target_ns = delay_ms * 1_000_000
+
+        ns_ok = (elapsed_ns >= target_ns - tolerance_ns) and (
+            elapsed_ns <= target_ns + tolerance_ns
+        )
+
+        if not ns_ok:
+            all_ok = False
+            print("Delay(ms)=", delay_ms, " elapsed_ns=", elapsed_ns, " -> FAIL")
+
+    for delay_s in delays_s:
+        t0_s = time.time()
+        time.sleep(delay_s)
+        t1_s = time.time()
+
+        elapsed_s = t1_s - t0_s
+        s_ok = (elapsed_s >= delay_s) and (elapsed_s <= delay_s + tolerance_s)
+
+        if not s_ok:
+            all_ok = False
+            print("Delay(s)=", delay_s, " elapsed_s=", elapsed_s, " -> FAIL")
+
+    if all_ok:
+        print("Status: PASS")
+    else:
+        print("Status: FAIL")
+
+
 test_ticks_ms()
 test_ticks_us()
 test_ticks_cpu()
 test_boundary_us_cond()
+test_time_time_vs_time_ns()
+test_time_ns_strictly_monotonic()
+test_time_elapsed_matches_delay()
 # Enable this test only if needed for advanced checking
 # test_us_deviation()

--- a/tests/ports/psoc-edge/board_only_hw/single/time.py.exp
+++ b/tests/ports/psoc-edge/board_only_hw/single/time.py.exp
@@ -14,3 +14,15 @@ Status: PASS
 ***** Test 4: Checking boundary conditions *****
 
 PASS
+
+***** Test 6: time() vs time_ns() *****
+
+Status: PASS
+
+***** Test 7: time_ns() strict monotonicity *****
+
+Status: PASS
+
+***** Test 8: Delay vs elapsed time *****
+
+Status: PASS


### PR DESCRIPTION
## Summary
This PR refactors the PSoC Edge time stack and fixes `mp_hal_time_ns()` so it provides a stable epoch-based nanosecond value with monotonic sub-second progression.


## What Changed
1. SysTick timekeeping moved into dedicated `systick.c`.
2. RTC access and normalization logic centralized in `machine_rtc.c`.
3. Boot-time initialization flow updated in `main.c` to use the new split.
4. Build wiring updated in `Makefile` for the new unit and PDL dependency.
5. `mp_hal_time_ns()` reworked to avoid mixing absolute epoch seconds with raw uptime directly.
6. RTC-update-aware resync mechanism added so epoch offset is recalibrated when RTC time changes.

## Behavior Notes
- `time.time()` and `time.time_ns()` are now consistent at integer-second granularity:
  - `time.time_ns() // 1_000_000_000 == time.time()` should hold (modulo boundary timing race).

## Why This Is Needed
Previous behavior could overcount elapsed time by combining RTC epoch seconds with full monotonic uptime in a way that introduced drift/offset errors. This change preserves:
- absolute epoch anchoring from RTC
- high-resolution sub-second progression from SysTick
- explicit resync when RTC is updated
