### PR TITLE
Machine timer module

### DIFF
--- a/docs/psoc-edge/quickref.rst
+++ b/docs/psoc-edge/quickref.rst
@@ -809,7 +809,8 @@ Hardware timer using the TCPWM0 peripheral on the PSOC™ Edge. See :ref:`machin
 
 .. note::
 
-    This port provides **3** independent hardware timer instances (IDs ``0``, ``1``, ``2``), backed by TCPWM0 Group 0 counters 3, 5, and 6
+    This port provides **4** independent hardware timer instances (IDs ``0``, ``1``, ``2``, ``3``), backed by TCPWM0 Group 0 counters 3, 5, 6,
+    and 2
     respectively. Only one instance per ID can exist at a time; constructing a second ``Timer(id)`` without calling ``deinit()`` first raises a
     ``ValueError``.
 
@@ -838,7 +839,7 @@ Constructor
 
     Construct a hardware timer.
 
-      - ``id`` — timer instance identifier. Must be **0**, **1**, or **2**.
+    - ``id`` — timer instance identifier. Must be **0**, **1**, **2**, or **3**.
       - ``mode`` — ``Timer.ONE_SHOT`` or ``Timer.PERIODIC``. Default is ``Timer.PERIODIC``.
       - ``period`` — timer period in **milliseconds**. Must be ``> 0``.
         Either ``period`` or ``freq`` must be provided; supplying both raises a ``ValueError``.
@@ -851,7 +852,7 @@ Constructor
 
     Raises ``ValueError`` if:
 
-      - ``id`` is outside ``0``-``2``.
+    - ``id`` is outside ``0``-``3``.
       - A ``Timer`` with the given ``id`` already exists (call ``deinit()`` first).
       - Neither ``freq`` nor ``period`` is provided.
       - ``period`` is ``0`` or negative.

--- a/docs/psoc-edge/quickref.rst
+++ b/docs/psoc-edge/quickref.rst
@@ -802,6 +802,116 @@ Complete example
     pwm.deinit()
 
 
+Timer
+-----
+
+Hardware timer using the TCPWM0 peripheral on the PSOC™ Edge. See :ref:`machine.Timer <machine.Timer>` for the standard MicroPython Timer API.
+
+.. note::
+
+    This port provides **3** independent hardware timer instances (IDs ``0``, ``1``, ``2``), backed by TCPWM0 Group 0 counters 3, 5, and 6
+    respectively. Only one instance per ID can exist at a time; constructing a second ``Timer(id)`` without calling ``deinit()`` first raises a
+    ``ValueError``.
+
+.. note::
+
+    The timer clock is **1 MHz** (shared with the system tick). This means:
+
+      - The minimum resolvable period is **1 µs**.
+      - With ``tick_hz=1000`` (default) the minimum ``period`` is **1 ms** and the maximum is **4 294 967 ms** (~49.7 days).
+      - With ``freq``, the minimum frequency is **1 Hz** and the maximum is **1 000 000 Hz** (1 MHz).
+      - Computed period ticks must fit in a **32-bit** counter (1 - 4 294 967 295); values outside this range raise a ``ValueError``.
+
+A timer can be created and started using::
+
+    from machine import Timer
+
+    def tick(timer):
+        print("tick")
+
+    tim = Timer(0, mode=Timer.PERIODIC, period=500, callback=tick)
+
+Constructor
+^^^^^^^^^^^^
+
+.. class:: Timer(id, *, mode=Timer.PERIODIC, period, freq, tick_hz=1000, callback, hard=False)
+
+    Construct a hardware timer.
+
+      - ``id`` — timer instance identifier. Must be **0**, **1**, or **2**.
+      - ``mode`` — ``Timer.ONE_SHOT`` or ``Timer.PERIODIC``. Default is ``Timer.PERIODIC``.
+      - ``period`` — timer period in units of ``tick_hz`` (see below). Must be ``> 0``.
+        Either ``period`` or ``freq`` must be provided; supplying both raises a ``ValueError``.
+      - ``freq`` — timer frequency in Hz. Must be ``> 0``. Takes precedence over ``period`` when both are supplied.
+      - ``tick_hz`` — the reference frequency for the ``period`` argument, in Hz. Default is **1000** (i.e. ``period`` in milliseconds).
+        Must be ``> 0``. Ignored when ``freq`` is used.
+      - ``callback`` — a callable invoked on each timer expiry. Receives the ``Timer`` object as its only argument.
+        Must be a callable; passing a non-callable raises a ``ValueError``.
+      - ``hard`` — must be a ``bool``. If ``True``, the callback runs directly in the hardware IRQ context (no scheduler).
+        Heap allocation inside the callback will raise ``MemoryError``; use ``micropython.alloc_emergency_exception_buf()`` before
+        arming a hard timer. Default is ``False`` (soft callback, deferred via the MicroPython scheduler).
+
+    Raises ``ValueError`` if:
+
+      - ``id`` is outside ``0``-``2``.
+      - A ``Timer`` with the given ``id`` already exists (call ``deinit()`` first).
+      - Neither ``freq`` nor ``period`` is provided.
+      - ``period`` is ``0`` or negative.
+      - ``freq`` is ``0`` or negative.
+      - ``tick_hz`` is ``0`` or negative.
+      - The computed period exceeds the 32-bit counter range (e.g. ``freq=2_000_000``).
+      - ``hard`` is not a ``bool``.
+      - ``callback`` is not callable.
+
+Complete example
+^^^^^^^^^^^^^^^^
+
+::
+
+    from machine import Timer
+    import micropython
+    import time
+
+    # --- Periodic soft timer (default) ---
+    count = 0
+
+    def on_tick(timer):
+        global count
+        count += 1
+        print("tick", count)
+
+    tim = Timer(0, mode=Timer.PERIODIC, period=500, callback=on_tick)
+    time.sleep(3)          # let it fire ~6 times
+    tim.deinit()
+
+    # --- One-shot timer ---
+    def on_done(timer):
+        print("one-shot fired")
+
+    tim = Timer(1, mode=Timer.ONE_SHOT, period=1000, callback=on_done)
+    time.sleep(2)
+    tim.deinit()
+
+    # --- Frequency-based timer ---
+    def on_freq(timer):
+        print("2 Hz tick")
+
+    tim = Timer(2, mode=Timer.PERIODIC, freq=2, callback=on_freq)
+    time.sleep(3)
+    tim.deinit()
+
+    # --- Hard IRQ timer (allocation-free callback required) ---
+    micropython.alloc_emergency_exception_buf(100)
+    fired = [False]
+
+    def on_hard(timer):
+        fired[0] = True     # list index write is allocation-free
+
+    tim = Timer(0, mode=Timer.ONE_SHOT, period=100, callback=on_hard, hard=True)
+    time.sleep_ms(200)
+    tim.deinit()
+    print("hard fired:", fired[0])
+
 Network Module
 --------------
 
@@ -922,115 +1032,3 @@ to a Wi-Fi network:
             time.sleep(1)
 
         print("[Network] Connection failed")
-	
-
-Timer
------
-
-Hardware timer using the TCPWM0 peripheral on the PSOC™ Edge. See :ref:`machine.Timer <machine.Timer>` for the standard MicroPython Timer API.
-
-.. note::
-
-    This port provides **3** independent hardware timer instances (IDs ``0``, ``1``, ``2``), backed by TCPWM0 Group 0 counters 3, 5, and 6
-    respectively. Only one instance per ID can exist at a time; constructing a second ``Timer(id)`` without calling ``deinit()`` first raises a
-    ``ValueError``.
-
-.. note::
-
-    The timer clock is **1 MHz** (shared with the system tick). This means:
-
-      - The minimum resolvable period is **1 µs**.
-      - With ``tick_hz=1000`` (default) the minimum ``period`` is **1 ms** and the maximum is **4 294 967 ms** (~49.7 days).
-      - With ``freq``, the minimum frequency is **1 Hz** and the maximum is **1 000 000 Hz** (1 MHz).
-      - Computed period ticks must fit in a **32-bit** counter (1 - 4 294 967 295); values outside this range raise a ``ValueError``.
-
-A timer can be created and started using::
-
-    from machine import Timer
-
-    def tick(timer):
-        print("tick")
-
-    tim = Timer(0, mode=Timer.PERIODIC, period=500, callback=tick)
-
-Constructor
-^^^^^^^^^^^^
-
-.. class:: Timer(id, *, mode=Timer.PERIODIC, period, freq, tick_hz=1000, callback, hard=False)
-
-    Construct a hardware timer.
-
-      - ``id`` — timer instance identifier. Must be **0**, **1**, or **2**.
-      - ``mode`` — ``Timer.ONE_SHOT`` or ``Timer.PERIODIC``. Default is ``Timer.PERIODIC``.
-      - ``period`` — timer period in units of ``tick_hz`` (see below). Must be ``> 0``.
-        Either ``period`` or ``freq`` must be provided; supplying both raises a ``ValueError``.
-      - ``freq`` — timer frequency in Hz. Must be ``> 0``. Takes precedence over ``period`` when both are supplied.
-      - ``tick_hz`` — the reference frequency for the ``period`` argument, in Hz. Default is **1000** (i.e. ``period`` in milliseconds).
-        Must be ``> 0``. Ignored when ``freq`` is used.
-      - ``callback`` — a callable invoked on each timer expiry. Receives the ``Timer`` object as its only argument.
-        Must be a callable; passing a non-callable raises a ``ValueError``.
-      - ``hard`` — must be a ``bool``. If ``True``, the callback runs directly in the hardware IRQ context (no scheduler).
-        Heap allocation inside the callback will raise ``MemoryError``; use ``micropython.alloc_emergency_exception_buf()`` before
-        arming a hard timer. Default is ``False`` (soft callback, deferred via the MicroPython scheduler).
-
-    Raises ``ValueError`` if:
-
-      - ``id`` is outside ``0``-``2``.
-      - A ``Timer`` with the given ``id`` already exists (call ``deinit()`` first).
-      - Neither ``freq`` nor ``period`` is provided.
-      - ``period`` is ``0`` or negative.
-      - ``freq`` is ``0`` or negative.
-      - ``tick_hz`` is ``0`` or negative.
-      - The computed period exceeds the 32-bit counter range (e.g. ``freq=2_000_000``).
-      - ``hard`` is not a ``bool``.
-      - ``callback`` is not callable.
-
-Complete example
-^^^^^^^^^^^^^^^^
-
-::
-
-    from machine import Timer
-    import micropython
-    import time
-
-    # --- Periodic soft timer (default) ---
-    count = 0
-
-    def on_tick(timer):
-        global count
-        count += 1
-        print("tick", count)
-
-    tim = Timer(0, mode=Timer.PERIODIC, period=500, callback=on_tick)
-    time.sleep(3)          # let it fire ~6 times
-    tim.deinit()
-
-    # --- One-shot timer ---
-    def on_done(timer):
-        print("one-shot fired")
-
-    tim = Timer(1, mode=Timer.ONE_SHOT, period=1000, callback=on_done)
-    time.sleep(2)
-    tim.deinit()
-
-    # --- Frequency-based timer ---
-    def on_freq(timer):
-        print("2 Hz tick")
-
-    tim = Timer(2, mode=Timer.PERIODIC, freq=2, callback=on_freq)
-    time.sleep(3)
-    tim.deinit()
-
-    # --- Hard IRQ timer (allocation-free callback required) ---
-    micropython.alloc_emergency_exception_buf(100)
-    fired = [False]
-
-    def on_hard(timer):
-        fired[0] = True     # list index write is allocation-free
-
-    tim = Timer(0, mode=Timer.ONE_SHOT, period=100, callback=on_hard, hard=True)
-    time.sleep_ms(200)
-    tim.deinit()
-    print("hard fired:", fired[0])
-

--- a/docs/psoc-edge/quickref.rst
+++ b/docs/psoc-edge/quickref.rst
@@ -839,27 +839,27 @@ Constructor
 
     Construct a hardware timer.
 
-    - ``id`` — timer instance identifier. Must be **0**, **1**, **2**, or **3**.
-      - ``mode`` — ``Timer.ONE_SHOT`` or ``Timer.PERIODIC``. Default is ``Timer.PERIODIC``.
-      - ``period`` — timer period in **milliseconds**. Must be ``> 0``.
-        Either ``period`` or ``freq`` must be provided; supplying both raises a ``ValueError``.
-      - ``freq`` — timer frequency in Hz. Must be ``> 0``. Takes precedence over ``period`` when both are supplied.
-      - ``callback`` — a callable invoked on each timer expiry. Receives the ``Timer`` object as its only argument.
-        Must be a callable; passing a non-callable raises a ``ValueError``.
-      - ``hard`` — must be a ``bool``. If ``True``, the callback runs directly in the hardware IRQ context (no scheduler).
-        Heap allocation inside the callback will raise ``MemoryError``; use ``micropython.alloc_emergency_exception_buf()`` before
-        arming a hard timer. Default is ``False`` (soft callback, deferred via the MicroPython scheduler).
+            - ``id`` — timer instance identifier. Must be **0**, **1**, **2**, or **3**.
+            - ``mode`` — ``Timer.ONE_SHOT`` or ``Timer.PERIODIC``. Default is ``Timer.PERIODIC``.
+            - ``period`` — timer period in **milliseconds**. Must be ``> 0``.
+                Either ``period`` or ``freq`` must be provided; supplying both raises a ``ValueError``.
+            - ``freq`` — timer frequency in Hz. Must be ``> 0``. Takes precedence over ``period`` when both are supplied.
+            - ``callback`` — a callable invoked on each timer expiry. Receives the ``Timer`` object as its only argument.
+                Must be a callable; passing a non-callable raises a ``ValueError``.
+            - ``hard`` — must be a ``bool``. If ``True``, the callback runs directly in the hardware IRQ context (no scheduler).
+                Heap allocation inside the callback will raise ``MemoryError``; use ``micropython.alloc_emergency_exception_buf()`` before
+                arming a hard timer. Default is ``False`` (soft callback, deferred via the MicroPython scheduler).
 
     Raises ``ValueError`` if:
 
-    - ``id`` is outside ``0``-``3``.
-      - A ``Timer`` with the given ``id`` already exists (call ``deinit()`` first).
-      - Neither ``freq`` nor ``period`` is provided.
-      - ``period`` is ``0`` or negative.
-      - ``freq`` is ``0`` or negative.
-      - The computed period exceeds the 32-bit counter range (e.g. ``freq=2_000_000``).
-      - ``hard`` is not a ``bool``.
-      - ``callback`` is not callable.
+            - ``id`` is outside ``0``-``3``.
+            - A ``Timer`` with the given ``id`` already exists (call ``deinit()`` first).
+            - Neither ``freq`` nor ``period`` is provided.
+            - ``period`` is ``0`` or negative.
+            - ``freq`` is ``0`` or negative.
+            - The computed period exceeds the 32-bit counter range (e.g. ``freq=2_000_000``).
+            - ``hard`` is not a ``bool``.
+            - ``callback`` is not callable.
 
 Complete example
 ^^^^^^^^^^^^^^^^

--- a/docs/psoc-edge/quickref.rst
+++ b/docs/psoc-edge/quickref.rst
@@ -922,3 +922,115 @@ to a Wi-Fi network:
             time.sleep(1)
 
         print("[Network] Connection failed")
+	
+
+Timer
+-----
+
+Hardware timer using the TCPWM0 peripheral on the PSOC™ Edge. See :ref:`machine.Timer <machine.Timer>` for the standard MicroPython Timer API.
+
+.. note::
+
+    This port provides **3** independent hardware timer instances (IDs ``0``, ``1``, ``2``), backed by TCPWM0 Group 0 counters 3, 5, and 6
+    respectively. Only one instance per ID can exist at a time; constructing a second ``Timer(id)`` without calling ``deinit()`` first raises a
+    ``ValueError``.
+
+.. note::
+
+    The timer clock is **1 MHz** (shared with the system tick). This means:
+
+      - The minimum resolvable period is **1 µs**.
+      - With ``tick_hz=1000`` (default) the minimum ``period`` is **1 ms** and the maximum is **4 294 967 ms** (~49.7 days).
+      - With ``freq``, the minimum frequency is **1 Hz** and the maximum is **1 000 000 Hz** (1 MHz).
+      - Computed period ticks must fit in a **32-bit** counter (1 - 4 294 967 295); values outside this range raise a ``ValueError``.
+
+A timer can be created and started using::
+
+    from machine import Timer
+
+    def tick(timer):
+        print("tick")
+
+    tim = Timer(0, mode=Timer.PERIODIC, period=500, callback=tick)
+
+Constructor
+^^^^^^^^^^^^
+
+.. class:: Timer(id, *, mode=Timer.PERIODIC, period, freq, tick_hz=1000, callback, hard=False)
+
+    Construct a hardware timer.
+
+      - ``id`` — timer instance identifier. Must be **0**, **1**, or **2**.
+      - ``mode`` — ``Timer.ONE_SHOT`` or ``Timer.PERIODIC``. Default is ``Timer.PERIODIC``.
+      - ``period`` — timer period in units of ``tick_hz`` (see below). Must be ``> 0``.
+        Either ``period`` or ``freq`` must be provided; supplying both raises a ``ValueError``.
+      - ``freq`` — timer frequency in Hz. Must be ``> 0``. Takes precedence over ``period`` when both are supplied.
+      - ``tick_hz`` — the reference frequency for the ``period`` argument, in Hz. Default is **1000** (i.e. ``period`` in milliseconds).
+        Must be ``> 0``. Ignored when ``freq`` is used.
+      - ``callback`` — a callable invoked on each timer expiry. Receives the ``Timer`` object as its only argument.
+        Must be a callable; passing a non-callable raises a ``ValueError``.
+      - ``hard`` — must be a ``bool``. If ``True``, the callback runs directly in the hardware IRQ context (no scheduler).
+        Heap allocation inside the callback will raise ``MemoryError``; use ``micropython.alloc_emergency_exception_buf()`` before
+        arming a hard timer. Default is ``False`` (soft callback, deferred via the MicroPython scheduler).
+
+    Raises ``ValueError`` if:
+
+      - ``id`` is outside ``0``-``2``.
+      - A ``Timer`` with the given ``id`` already exists (call ``deinit()`` first).
+      - Neither ``freq`` nor ``period`` is provided.
+      - ``period`` is ``0`` or negative.
+      - ``freq`` is ``0`` or negative.
+      - ``tick_hz`` is ``0`` or negative.
+      - The computed period exceeds the 32-bit counter range (e.g. ``freq=2_000_000``).
+      - ``hard`` is not a ``bool``.
+      - ``callback`` is not callable.
+
+Complete example
+^^^^^^^^^^^^^^^^
+
+::
+
+    from machine import Timer
+    import micropython
+    import time
+
+    # --- Periodic soft timer (default) ---
+    count = 0
+
+    def on_tick(timer):
+        global count
+        count += 1
+        print("tick", count)
+
+    tim = Timer(0, mode=Timer.PERIODIC, period=500, callback=on_tick)
+    time.sleep(3)          # let it fire ~6 times
+    tim.deinit()
+
+    # --- One-shot timer ---
+    def on_done(timer):
+        print("one-shot fired")
+
+    tim = Timer(1, mode=Timer.ONE_SHOT, period=1000, callback=on_done)
+    time.sleep(2)
+    tim.deinit()
+
+    # --- Frequency-based timer ---
+    def on_freq(timer):
+        print("2 Hz tick")
+
+    tim = Timer(2, mode=Timer.PERIODIC, freq=2, callback=on_freq)
+    time.sleep(3)
+    tim.deinit()
+
+    # --- Hard IRQ timer (allocation-free callback required) ---
+    micropython.alloc_emergency_exception_buf(100)
+    fired = [False]
+
+    def on_hard(timer):
+        fired[0] = True     # list index write is allocation-free
+
+    tim = Timer(0, mode=Timer.ONE_SHOT, period=100, callback=on_hard, hard=True)
+    time.sleep_ms(200)
+    tim.deinit()
+    print("hard fired:", fired[0])
+

--- a/docs/psoc-edge/quickref.rst
+++ b/docs/psoc-edge/quickref.rst
@@ -818,7 +818,7 @@ Hardware timer using the TCPWM0 peripheral on the PSOC™ Edge. See :ref:`machin
     The timer clock is **1 MHz** (shared with the system tick). This means:
 
       - The minimum resolvable period is **1 µs**.
-      - With ``tick_hz=1000`` (default) the minimum ``period`` is **1 ms** and the maximum is **4 294 967 ms** (~49.7 days).
+      - With ``period`` the minimum value is **1 ms** and the maximum is **4 294 967 ms** (~49.7 days).
       - With ``freq``, the minimum frequency is **1 Hz** and the maximum is **1 000 000 Hz** (1 MHz).
       - Computed period ticks must fit in a **32-bit** counter (1 - 4 294 967 295); values outside this range raise a ``ValueError``.
 
@@ -834,17 +834,15 @@ A timer can be created and started using::
 Constructor
 ^^^^^^^^^^^^
 
-.. class:: Timer(id, *, mode=Timer.PERIODIC, period, freq, tick_hz=1000, callback, hard=False)
+.. class:: Timer(id, *, mode=Timer.PERIODIC, period, freq, callback, hard=False)
 
     Construct a hardware timer.
 
       - ``id`` — timer instance identifier. Must be **0**, **1**, or **2**.
       - ``mode`` — ``Timer.ONE_SHOT`` or ``Timer.PERIODIC``. Default is ``Timer.PERIODIC``.
-      - ``period`` — timer period in units of ``tick_hz`` (see below). Must be ``> 0``.
+      - ``period`` — timer period in **milliseconds**. Must be ``> 0``.
         Either ``period`` or ``freq`` must be provided; supplying both raises a ``ValueError``.
       - ``freq`` — timer frequency in Hz. Must be ``> 0``. Takes precedence over ``period`` when both are supplied.
-      - ``tick_hz`` — the reference frequency for the ``period`` argument, in Hz. Default is **1000** (i.e. ``period`` in milliseconds).
-        Must be ``> 0``. Ignored when ``freq`` is used.
       - ``callback`` — a callable invoked on each timer expiry. Receives the ``Timer`` object as its only argument.
         Must be a callable; passing a non-callable raises a ``ValueError``.
       - ``hard`` — must be a ``bool``. If ``True``, the callback runs directly in the hardware IRQ context (no scheduler).
@@ -858,7 +856,6 @@ Constructor
       - Neither ``freq`` nor ``period`` is provided.
       - ``period`` is ``0`` or negative.
       - ``freq`` is ``0`` or negative.
-      - ``tick_hz`` is ``0`` or negative.
       - The computed period exceeds the 32-bit counter range (e.g. ``freq=2_000_000``).
       - ``hard`` is not a ``bool``.
       - ``callback`` is not callable.

--- a/ports/psoc-edge/Makefile
+++ b/ports/psoc-edge/Makefile
@@ -459,6 +459,7 @@ MOD_SRC_C += \
 	modpsocedge.c \
 	machine_ipc.c \
 	machine_scb.c \
+	machine_timer.c \
 
 ifeq ($(MICROPY_PY_EXT_FLASH),1)
 	CFLAGS += -DMICROPY_ENABLE_EXT_QSPI_FLASH=1

--- a/ports/psoc-edge/machine_timer.c
+++ b/ports/psoc-edge/machine_timer.c
@@ -38,6 +38,8 @@
 #include "cy_tcpwm.h"
 #include "cy_sysclk.h"
 #include "cycfg_peripheral_clocks.h"
+#include "cycfg_peripherals.h"
+#include "mtb_hal.h"
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -45,8 +47,7 @@
 
 #define MACHINE_TIMER_NUM_INSTANCES  (3)
 
-// PCLK 16-bit divider #2 is shared with the system tick timer (modtime.c) and
-// is already running at 1 MHz after time_init() is called at startup.
+// Shared general-purpose timer divider target frequency used by this module.
 #define TIMER_CLK_HZ  (1000000UL)
 
 // Input-pin disabled sentinel (upper 2 bits are ignored; mask to 2-bit field)
@@ -96,6 +97,25 @@ static const timer_hw_t timer_hw[MACHINE_TIMER_NUM_INSTANCES] = {
 
 static machine_timer_obj_t *timer_obj[MACHINE_TIMER_NUM_INSTANCES] = { NULL };
 
+static bool machine_timer_clock_configured = false;
+
+static void machine_timer_configure_clock(void) {
+    if (machine_timer_clock_configured) {
+        return;
+    }
+
+    // Keep timer periods stable even when other modules stop configuring this divider.
+    cy_rslt_t rslt = mtb_hal_clock_set_peri_clock_freq(&CYBSP_GENERAL_PURPOSE_TIMER_clock_ref,
+        TIMER_CLK_HZ, 1000);
+    if (rslt != CY_RSLT_SUCCESS) {
+        mp_raise_msg_varg(&mp_type_ValueError,
+            MP_ERROR_TEXT("Timer clock setup failed (0x%lx)"),
+            (unsigned long)rslt);
+    }
+
+    machine_timer_clock_configured = true;
+}
+
 // ---------------------------------------------------------------------------
 // IRQ handlers — one per timer, each delegates to the common body
 // ---------------------------------------------------------------------------
@@ -107,8 +127,11 @@ static void machine_timer_isr(machine_timer_obj_t *self) {
             Cy_TCPWM_Counter_Disable(TCPWM0, self->counter_num);
             self->active = false;
         }
-        if (mp_irq_dispatch(self->callback, MP_OBJ_FROM_PTR(self), self->ishard) < 0) {
-            // Uncaught exception: disable callback so periodic timers don't spam errors.
+        if (self->callback != mp_const_none
+            && mp_irq_dispatch(self->callback, MP_OBJ_FROM_PTR(self), self->ishard) < 0) {
+            // Uncaught exception: stop timer and disable callback to avoid repeated IRQ spam.
+            Cy_TCPWM_Counter_Disable(TCPWM0, self->counter_num);
+            self->active = false;
             self->callback = mp_const_none;
         }
     }
@@ -141,6 +164,8 @@ static const cy_israddress timer_handlers[MACHINE_TIMER_NUM_INSTANCES] = {
 // ---------------------------------------------------------------------------
 
 static void machine_timer_start(machine_timer_obj_t *self, uint32_t period_ticks) {
+    machine_timer_configure_clock();
+
     // Stop counter and unregister any existing IRQ before reconfiguring.
     Cy_TCPWM_Counter_Disable(TCPWM0, self->counter_num);
     if (self->active) {
@@ -243,6 +268,14 @@ static mp_obj_t machine_timer_init_helper(machine_timer_obj_t *self,
         mp_raise_ValueError(MP_ERROR_TEXT("hard must be bool"));
     }
     self->ishard = (hard == mp_const_true);
+
+    // Hard IRQ callbacks not supported on FreeRTOS: scheduler cannot be locked from ISR context.
+    // TODO: Re-enable hard irq and remove this patch
+    #if defined(CY_RTOS_AWARE)
+    if (self->ishard) {
+        self->ishard = false;  // silently convert to soft callback
+    }
+    #endif
 
     // Compute period in timer clock ticks in 64-bit, then range-check.
     uint64_t period_ticks_64;

--- a/ports/psoc-edge/machine_timer.c
+++ b/ports/psoc-edge/machine_timer.c
@@ -70,7 +70,6 @@ typedef struct _machine_timer_obj_t {
     mp_obj_t callback;
     bool ishard;
     bool active;
-    bool constructed;
     sys_int_cfg_t irq_cfg;
 } machine_timer_obj_t;
 
@@ -96,7 +95,7 @@ static const timer_hw_t timer_hw[MACHINE_TIMER_NUM_INSTANCES] = {
 // Static instance pool — one entry per hardware timer
 // ---------------------------------------------------------------------------
 
-static machine_timer_obj_t timer_obj[MACHINE_TIMER_NUM_INSTANCES];
+static machine_timer_obj_t *timer_obj[MACHINE_TIMER_NUM_INSTANCES] = { NULL };
 
 // ---------------------------------------------------------------------------
 // IRQ handlers — one per timer, each delegates to the common body
@@ -117,13 +116,19 @@ static void machine_timer_isr(machine_timer_obj_t *self) {
 }
 
 static void timer0_irq_handler(void) {
-    machine_timer_isr(&timer_obj[0]);
+    if (timer_obj[0] != NULL) {
+        machine_timer_isr(timer_obj[0]);
+    }
 }
 static void timer1_irq_handler(void) {
-    machine_timer_isr(&timer_obj[1]);
+    if (timer_obj[1] != NULL) {
+        machine_timer_isr(timer_obj[1]);
+    }
 }
 static void timer2_irq_handler(void) {
-    machine_timer_isr(&timer_obj[2]);
+    if (timer_obj[2] != NULL) {
+        machine_timer_isr(timer_obj[2]);
+    }
 }
 
 static const cy_israddress timer_handlers[MACHINE_TIMER_NUM_INSTANCES] = {
@@ -183,7 +188,7 @@ static void machine_timer_start(machine_timer_obj_t *self, uint32_t period_ticks
     };
 
     cy_en_tcpwm_status_t result = Cy_TCPWM_Counter_Init(TCPWM0, self->counter_num, &cfg);
-    if (result != CY_RSLT_SUCCESS) {
+    if (result != CY_TCPWM_SUCCESS) {
         mp_raise_msg_varg(&mp_type_ValueError,
             MP_ERROR_TEXT("Timer(%u) init failed (PDL error 0x%lx)"),
             (unsigned)self->id, (unsigned long)result);
@@ -290,25 +295,35 @@ static mp_obj_t machine_timer_make_new(const mp_obj_type_t *type,
             MACHINE_TIMER_NUM_INSTANCES - 1);
     }
 
-    machine_timer_obj_t *self = &timer_obj[id];
-    if (self->constructed) {
+    if (timer_obj[id] != NULL) {
         mp_raise_msg_varg(&mp_type_ValueError,
             MP_ERROR_TEXT("Timer(%u) already created."), (unsigned)id);
     }
 
-    self->base.type = &machine_timer_type;
+    machine_timer_obj_t *self = mp_obj_malloc(machine_timer_obj_t, &machine_timer_type);
+    timer_obj[id] = self;
+
     self->id = (uint8_t)id;
     self->counter_num = timer_hw[id].counter_num;
     self->irq_num = timer_hw[id].irq_num;
     self->pclk_dst = timer_hw[id].pclk_dst;
+    self->callback = mp_const_none;
+    self->ishard = false;
+    self->active = false;
 
     if (n_args > 1 || n_kw > 0) {
         mp_map_t kw_map;
         mp_map_init_fixed_table(&kw_map, n_kw, args + n_args);
-        machine_timer_init_helper(self, n_args - 1, args + 1, &kw_map);
-    }
 
-    self->constructed = true;
+        nlr_buf_t nl;
+        if (nlr_push(&nl) == 0) {
+            machine_timer_init_helper(self, n_args - 1, args + 1, &kw_map);
+            nlr_pop();
+        } else {
+            timer_obj[id] = NULL;
+            nlr_jump(nl.ret_val);
+        }
+    }
 
     return MP_OBJ_FROM_PTR(self);
 }
@@ -337,7 +352,7 @@ static mp_obj_t machine_timer_deinit(mp_obj_t self_in) {
     self->callback = mp_const_none;
     self->ishard = false;
     self->active = false;
-    self->constructed = false;
+    timer_obj[self->id] = NULL;
     return mp_const_none;
 }
 static MP_DEFINE_CONST_FUN_OBJ_1(machine_timer_deinit_obj, machine_timer_deinit);
@@ -359,30 +374,19 @@ static void machine_timer_print(const mp_print_t *print, mp_obj_t self_in,
 // Module-level lifecycle called from main.c
 // ---------------------------------------------------------------------------
 
-void machine_timer_init_all(void) {
-    for (uint8_t i = 0; i < MACHINE_TIMER_NUM_INSTANCES; i++) {
-        timer_obj[i].id = i;
-        timer_obj[i].counter_num = timer_hw[i].counter_num;
-        timer_obj[i].irq_num = timer_hw[i].irq_num;
-        timer_obj[i].pclk_dst = timer_hw[i].pclk_dst;
-        timer_obj[i].callback = mp_const_none;
-        timer_obj[i].ishard = false;
-        timer_obj[i].active = false;
-        timer_obj[i].constructed = false;
-    }
-}
-
 void machine_timer_deinit_all(void) {
     for (uint8_t i = 0; i < MACHINE_TIMER_NUM_INSTANCES; i++) {
-        machine_timer_obj_t *self = &timer_obj[i];
-        Cy_TCPWM_Counter_Disable(TCPWM0, self->counter_num);
-        if (self->active) {
-            sys_int_deinit(&self->irq_cfg);
+        machine_timer_obj_t *self = timer_obj[i];
+        if (self != NULL) {
+            Cy_TCPWM_Counter_Disable(TCPWM0, self->counter_num);
+            if (self->active) {
+                sys_int_deinit(&self->irq_cfg);
+            }
+            self->callback = mp_const_none;
+            self->ishard = false;
+            self->active = false;
+            timer_obj[i] = NULL;
         }
-        self->callback = mp_const_none;
-        self->ishard = false;
-        self->active = false;
-        self->constructed = false;
     }
 }
 

--- a/ports/psoc-edge/machine_timer.c
+++ b/ports/psoc-edge/machine_timer.c
@@ -1,0 +1,379 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022-2024 Infineon Technologies AG
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+// Hardware timer using TCPWM0 Group 0 counters 3, 5, 6 (IDs 0, 1, 2).
+// Counter 2 is reserved for the system tick timer (modtime.c).
+// Counters 0, 1, 4, 7 are allocated by the BSP.  3, 5, 6 are free for use.
+
+#include "py/obj.h"
+#include "py/runtime.h"
+#include "modmachine.h"
+#include "sys_int.h"
+
+#include "cy_tcpwm_counter.h"
+#include "cy_tcpwm.h"
+#include "cy_sysclk.h"
+#include "cycfg_peripheral_clocks.h"
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+#define MACHINE_TIMER_NUM_INSTANCES  (3)
+
+// PCLK 16-bit divider #2 is shared with the system tick timer (modtime.c) and
+// is already running at 1 MHz after time_init() is called at startup.
+#define TIMER_CLK_HZ  (1000000UL)
+
+// Input-pin disabled sentinel (upper 2 bits are ignored; mask to 2-bit field)
+#define TIMER_INPUT_DISABLED  (0x7U)
+
+// Timer mode values — also exposed as Python class constants
+#define TIMER_MODE_ONE_SHOT  (1)
+#define TIMER_MODE_PERIODIC  (2)
+
+// ---------------------------------------------------------------------------
+// Object type
+// ---------------------------------------------------------------------------
+
+typedef struct _machine_timer_obj_t {
+    mp_obj_base_t base;
+    uint8_t id;                  // 0, 1, or 2
+    uint32_t counter_num;        // TCPWM0 counter index: 3, 5, or 6
+    IRQn_Type irq_num;
+    en_clk_dst_t pclk_dst;
+    uint16_t mode;               // TIMER_MODE_ONE_SHOT or TIMER_MODE_PERIODIC
+    mp_obj_t callback;
+    bool active;
+    sys_int_cfg_t irq_cfg;
+} machine_timer_obj_t;
+
+const mp_obj_type_t machine_timer_type;  // forward declaration
+
+// ---------------------------------------------------------------------------
+// Per-ID hardware mapping
+// ---------------------------------------------------------------------------
+
+typedef struct {
+    uint32_t counter_num;
+    IRQn_Type irq_num;
+    en_clk_dst_t pclk_dst;
+} timer_hw_t;
+
+static const timer_hw_t timer_hw[MACHINE_TIMER_NUM_INSTANCES] = {
+    { 3U, tcpwm_0_interrupts_3_IRQn, PCLK_TCPWM0_CLOCK_COUNTER_EN3 },
+    { 5U, tcpwm_0_interrupts_5_IRQn, PCLK_TCPWM0_CLOCK_COUNTER_EN5 },
+    { 6U, tcpwm_0_interrupts_6_IRQn, PCLK_TCPWM0_CLOCK_COUNTER_EN6 },
+};
+
+// ---------------------------------------------------------------------------
+// Static instance pool — one entry per hardware timer
+// ---------------------------------------------------------------------------
+
+static machine_timer_obj_t timer_obj[MACHINE_TIMER_NUM_INSTANCES];
+
+// ---------------------------------------------------------------------------
+// IRQ handlers — one per timer, each delegates to the common body
+// ---------------------------------------------------------------------------
+
+static void machine_timer_isr(machine_timer_obj_t *self) {
+    if (Cy_TCPWM_GetInterruptStatus(TCPWM0, self->counter_num) & CY_TCPWM_INT_ON_TC) {
+        Cy_TCPWM_ClearInterrupt(TCPWM0, self->counter_num, CY_TCPWM_INT_ON_TC);
+        if (self->mode == TIMER_MODE_ONE_SHOT) {
+            Cy_TCPWM_Counter_Disable(TCPWM0, self->counter_num);
+            self->active = false;
+        }
+        if (self->callback != mp_const_none) {
+            mp_sched_schedule(self->callback, MP_OBJ_FROM_PTR(self));
+        }
+    }
+}
+
+static void timer0_irq_handler(void) {
+    machine_timer_isr(&timer_obj[0]);
+}
+static void timer1_irq_handler(void) {
+    machine_timer_isr(&timer_obj[1]);
+}
+static void timer2_irq_handler(void) {
+    machine_timer_isr(&timer_obj[2]);
+}
+
+static const cy_israddress timer_handlers[MACHINE_TIMER_NUM_INSTANCES] = {
+    timer0_irq_handler,
+    timer1_irq_handler,
+    timer2_irq_handler,
+};
+
+// ---------------------------------------------------------------------------
+// Start (or restart) a timer with the given period in clock ticks
+// ---------------------------------------------------------------------------
+
+static void machine_timer_start(machine_timer_obj_t *self, uint32_t period_ticks) {
+    // Stop counter and unregister any existing IRQ before reconfiguring.
+    Cy_TCPWM_Counter_Disable(TCPWM0, self->counter_num);
+    if (self->active) {
+        sys_int_deinit(&self->irq_cfg);
+        self->active = false;
+    }
+
+    // Connect the shared 1 MHz PCLK divider to this counter's clock input.
+    Cy_SysClk_PeriPclkAssignDivider(self->pclk_dst,
+        CY_SYSCLK_DIV_16_BIT, CYBSP_GENERAL_PURPOSE_TIMER_CLK_DIV_NUM);
+
+    // The counter counts 0 → period_reg (inclusive) then fires TC.
+    // So period_reg = period_ticks - 1.
+    cy_stc_tcpwm_counter_config_t cfg = {
+        .period = period_ticks - 1U,
+        .clockPrescaler = CY_TCPWM_COUNTER_PRESCALER_DIVBY_1,
+        .runMode = (self->mode == TIMER_MODE_ONE_SHOT)
+                              ? CY_TCPWM_COUNTER_ONESHOT
+                              : CY_TCPWM_COUNTER_CONTINUOUS,
+        .countDirection = CY_TCPWM_COUNTER_COUNT_UP,
+        .compareOrCapture = CY_TCPWM_COUNTER_MODE_COMPARE,
+        .compare0 = 0U,
+        .compare1 = 0U,
+        .enableCompareSwap = false,
+        .interruptSources = CY_TCPWM_INT_ON_TC,
+        // All trigger inputs disabled
+        .captureInputMode = TIMER_INPUT_DISABLED & 0x3U,
+        .captureInput = CY_TCPWM_INPUT_0,
+        .reloadInputMode = TIMER_INPUT_DISABLED & 0x3U,
+        .reloadInput = CY_TCPWM_INPUT_0,
+        .startInputMode = TIMER_INPUT_DISABLED & 0x3U,
+        .startInput = CY_TCPWM_INPUT_0,
+        .stopInputMode = TIMER_INPUT_DISABLED & 0x3U,
+        .stopInput = CY_TCPWM_INPUT_0,
+        .countInputMode = TIMER_INPUT_DISABLED & 0x3U,
+        .countInput = CY_TCPWM_INPUT_1,
+        .capture1InputMode = TIMER_INPUT_DISABLED & 0x3U,
+        .capture1Input = CY_TCPWM_INPUT_0,
+        .enableCompare1Swap = false,
+        .compare2 = CY_TCPWM_GRP_CNT_CC0_DEFAULT,
+        .compare3 = CY_TCPWM_GRP_CNT_CC0_BUFF_DEFAULT,
+        .trigger0Event = CY_TCPWM_CNT_TRIGGER_ON_DISABLED,
+        .trigger1Event = CY_TCPWM_CNT_TRIGGER_ON_DISABLED,
+    };
+
+    cy_en_tcpwm_status_t result = Cy_TCPWM_Counter_Init(TCPWM0, self->counter_num, &cfg);
+    if (result != CY_RSLT_SUCCESS) {
+        mp_raise_msg_varg(&mp_type_ValueError,
+            MP_ERROR_TEXT("Timer(%u) init failed (PDL error 0x%lx)"),
+            (unsigned)self->id, (unsigned long)result);
+    }
+
+    // Register IRQ before enabling so no TC edge is missed.
+    self->irq_cfg.irq_num = self->irq_num;
+    self->irq_cfg.priority = SYS_INT_IRQ_LOWEST_PRIORITY;
+    self->irq_cfg.handler = timer_handlers[self->id];
+    sys_int_init(&self->irq_cfg);
+
+    self->active = true;
+    Cy_TCPWM_Counter_Enable(TCPWM0, self->counter_num);
+    Cy_TCPWM_TriggerReloadOrIndex_Single(TCPWM0, self->counter_num);
+}
+
+// ---------------------------------------------------------------------------
+// Python init helper (shared by make_new and .init())
+// ---------------------------------------------------------------------------
+
+static mp_obj_t machine_timer_init_helper(machine_timer_obj_t *self,
+    size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+
+    enum { ARG_mode, ARG_callback, ARG_period, ARG_tick_hz, ARG_freq };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_mode,     MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = TIMER_MODE_PERIODIC} },
+        { MP_QSTR_callback, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
+        { MP_QSTR_period,   MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = -1} },
+        { MP_QSTR_tick_hz,  MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 1000} },
+        { MP_QSTR_freq,     MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
+    };
+
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args, pos_args, kw_args,
+        MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    // Validate mode
+    mp_int_t mode = args[ARG_mode].u_int;
+    if (mode != TIMER_MODE_ONE_SHOT && mode != TIMER_MODE_PERIODIC) {
+        mp_raise_ValueError(MP_ERROR_TEXT("invalid mode"));
+    }
+    self->mode = (uint16_t)mode;
+
+    // Validate callback
+    mp_obj_t callback = args[ARG_callback].u_obj;
+    if (callback != mp_const_none && !mp_obj_is_callable(callback)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("callback must be callable"));
+    }
+    self->callback = callback;
+
+    // Compute period in timer clock ticks
+    uint32_t period_ticks;
+    if (args[ARG_freq].u_obj != mp_const_none) {
+        mp_int_t freq = mp_obj_get_int(args[ARG_freq].u_obj);
+        if (freq <= 0) {
+            mp_raise_ValueError(MP_ERROR_TEXT("freq must be > 0"));
+        }
+        period_ticks = TIMER_CLK_HZ / (uint32_t)freq;
+    } else if (args[ARG_period].u_int >= 0) {
+        mp_int_t tick_hz = args[ARG_tick_hz].u_int;
+        if (tick_hz <= 0) {
+            mp_raise_ValueError(MP_ERROR_TEXT("tick_hz must be > 0"));
+        }
+        period_ticks = (uint32_t)(
+            (uint64_t)TIMER_CLK_HZ * (uint64_t)(uint32_t)args[ARG_period].u_int
+            / (uint64_t)(uint32_t)tick_hz);
+    } else {
+        mp_raise_ValueError(MP_ERROR_TEXT("either freq or period must be specified"));
+    }
+
+    if (period_ticks == 0U || period_ticks > 0xFFFFFFFFUL) {
+        mp_raise_ValueError(MP_ERROR_TEXT("period out of range for 32-bit counter"));
+    }
+
+    machine_timer_start(self, period_ticks);
+    return mp_const_none;
+}
+
+// ---------------------------------------------------------------------------
+// machine.Timer(id [, mode=, freq=, period=, tick_hz=, callback=])
+// ---------------------------------------------------------------------------
+
+static mp_obj_t machine_timer_make_new(const mp_obj_type_t *type,
+    size_t n_args, size_t n_kw, const mp_obj_t *args) {
+
+    mp_arg_check_num(n_args, n_kw, 1, MP_OBJ_FUN_ARGS_MAX, true);
+
+    mp_int_t id = mp_obj_get_int(args[0]);
+    if (id < 0 || id >= MACHINE_TIMER_NUM_INSTANCES) {
+        mp_raise_msg_varg(&mp_type_ValueError,
+            MP_ERROR_TEXT("Timer id must be in range 0-%d"),
+            MACHINE_TIMER_NUM_INSTANCES - 1);
+    }
+
+    machine_timer_obj_t *self = &timer_obj[id];
+    self->base.type = &machine_timer_type;
+    self->id = (uint8_t)id;
+    self->counter_num = timer_hw[id].counter_num;
+    self->irq_num = timer_hw[id].irq_num;
+    self->pclk_dst = timer_hw[id].pclk_dst;
+
+    if (n_args > 1 || n_kw > 0) {
+        mp_map_t kw_map;
+        mp_map_init_fixed_table(&kw_map, n_kw, args + n_args);
+        machine_timer_init_helper(self, n_args - 1, args + 1, &kw_map);
+    }
+
+    return MP_OBJ_FROM_PTR(self);
+}
+
+// ---------------------------------------------------------------------------
+// timer.init(mode=, freq=, period=, tick_hz=, callback=)
+// ---------------------------------------------------------------------------
+
+static mp_obj_t machine_timer_init(size_t n_args, const mp_obj_t *args,
+    mp_map_t *kw_args) {
+    return machine_timer_init_helper(MP_OBJ_TO_PTR(args[0]),
+        n_args - 1, args + 1, kw_args);
+}
+static MP_DEFINE_CONST_FUN_OBJ_KW(machine_timer_init_obj, 1, machine_timer_init);
+
+// ---------------------------------------------------------------------------
+// timer.deinit()
+// ---------------------------------------------------------------------------
+
+static mp_obj_t machine_timer_deinit(mp_obj_t self_in) {
+    machine_timer_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    Cy_TCPWM_Counter_Disable(TCPWM0, self->counter_num);
+    if (self->active) {
+        sys_int_deinit(&self->irq_cfg);
+    }
+    self->callback = mp_const_none;
+    self->active = false;
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(machine_timer_deinit_obj, machine_timer_deinit);
+
+// ---------------------------------------------------------------------------
+// __repr__ / print
+// ---------------------------------------------------------------------------
+
+static void machine_timer_print(const mp_print_t *print, mp_obj_t self_in,
+    mp_print_kind_t kind) {
+    machine_timer_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    mp_printf(print, "Timer(%u, mode=%s, active=%s)",
+        (unsigned)self->id,
+        self->mode == TIMER_MODE_ONE_SHOT ? "ONE_SHOT" : "PERIODIC",
+        self->active ? "True" : "False");
+}
+
+// ---------------------------------------------------------------------------
+// Module-level lifecycle called from main.c
+// ---------------------------------------------------------------------------
+
+void machine_timer_init_all(void) {
+    for (uint8_t i = 0; i < MACHINE_TIMER_NUM_INSTANCES; i++) {
+        timer_obj[i].id = i;
+        timer_obj[i].counter_num = timer_hw[i].counter_num;
+        timer_obj[i].irq_num = timer_hw[i].irq_num;
+        timer_obj[i].pclk_dst = timer_hw[i].pclk_dst;
+        timer_obj[i].callback = mp_const_none;
+        timer_obj[i].active = false;
+    }
+}
+
+void machine_timer_deinit_all(void) {
+    for (uint8_t i = 0; i < MACHINE_TIMER_NUM_INSTANCES; i++) {
+        machine_timer_obj_t *self = &timer_obj[i];
+        Cy_TCPWM_Counter_Disable(TCPWM0, self->counter_num);
+        if (self->active) {
+            sys_int_deinit(&self->irq_cfg);
+        }
+        self->callback = mp_const_none;
+        self->active = false;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Type definition
+// ---------------------------------------------------------------------------
+
+static const mp_rom_map_elem_t machine_timer_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_init),     MP_ROM_PTR(&machine_timer_init_obj) },
+    { MP_ROM_QSTR(MP_QSTR_deinit),   MP_ROM_PTR(&machine_timer_deinit_obj) },
+    { MP_ROM_QSTR(MP_QSTR_ONE_SHOT), MP_ROM_INT(TIMER_MODE_ONE_SHOT) },
+    { MP_ROM_QSTR(MP_QSTR_PERIODIC), MP_ROM_INT(TIMER_MODE_PERIODIC) },
+};
+static MP_DEFINE_CONST_DICT(machine_timer_locals_dict, machine_timer_locals_dict_table);
+
+MP_DEFINE_CONST_OBJ_TYPE(
+    machine_timer_type,
+    MP_QSTR_Timer,
+    MP_TYPE_FLAG_NONE,
+    make_new, machine_timer_make_new,
+    print, machine_timer_print,
+    locals_dict, &machine_timer_locals_dict
+    );

--- a/ports/psoc-edge/machine_timer.c
+++ b/ports/psoc-edge/machine_timer.c
@@ -235,12 +235,11 @@ static void machine_timer_start(machine_timer_obj_t *self, uint32_t period_ticks
 static mp_obj_t machine_timer_init_helper(machine_timer_obj_t *self,
     size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
 
-    enum { ARG_mode, ARG_callback, ARG_period, ARG_tick_hz, ARG_freq, ARG_hard };
+    enum { ARG_mode, ARG_callback, ARG_period, ARG_freq, ARG_hard };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_mode,     MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = TIMER_MODE_PERIODIC} },
         { MP_QSTR_callback, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
         { MP_QSTR_period,   MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = -1} },
-        { MP_QSTR_tick_hz,  MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 1000} },
         { MP_QSTR_freq,     MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
         { MP_QSTR_hard,     MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_FALSE} },
     };
@@ -287,13 +286,9 @@ static mp_obj_t machine_timer_init_helper(machine_timer_obj_t *self,
         }
         period_ticks_64 = (uint64_t)TIMER_CLK_HZ / (uint64_t)(uint32_t)freq;
     } else if (args[ARG_period].u_int > 0) {
-        mp_int_t tick_hz = args[ARG_tick_hz].u_int;
-        if (tick_hz <= 0) {
-            mp_raise_ValueError(MP_ERROR_TEXT("tick_hz must be > 0"));
-        }
-        period_ticks_64 = (
-            (uint64_t)TIMER_CLK_HZ * (uint64_t)(uint32_t)args[ARG_period].u_int
-            / (uint64_t)(uint32_t)tick_hz);
+        // period is in milliseconds; convert to timer clock ticks (1 MHz base).
+        period_ticks_64 = (uint64_t)TIMER_CLK_HZ * (uint64_t)(uint32_t)args[ARG_period].u_int
+            / 1000UL;
     } else if (mp_map_lookup(kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_period), MP_MAP_LOOKUP) != NULL) {
         mp_raise_ValueError(MP_ERROR_TEXT("period must be > 0"));
     } else {
@@ -311,7 +306,7 @@ static mp_obj_t machine_timer_init_helper(machine_timer_obj_t *self,
 }
 
 // ---------------------------------------------------------------------------
-// machine.Timer(id [, mode=, freq=, period=, tick_hz=, callback=, hard=])
+// machine.Timer(id [, mode=, freq=, period=, callback=, hard=])
 // ---------------------------------------------------------------------------
 
 static mp_obj_t machine_timer_make_new(const mp_obj_type_t *type,
@@ -360,7 +355,7 @@ static mp_obj_t machine_timer_make_new(const mp_obj_type_t *type,
 }
 
 // ---------------------------------------------------------------------------
-// timer.init(mode=, freq=, period=, tick_hz=, callback=, hard=)
+// timer.init(mode=, freq=, period=, callback=, hard=)
 // ---------------------------------------------------------------------------
 
 static mp_obj_t machine_timer_init(size_t n_args, const mp_obj_t *args,

--- a/ports/psoc-edge/machine_timer.c
+++ b/ports/psoc-edge/machine_timer.c
@@ -31,6 +31,7 @@
 #include "py/obj.h"
 #include "py/runtime.h"
 #include "modmachine.h"
+#include "shared/runtime/mpirq.h"
 #include "sys_int.h"
 
 #include "cy_tcpwm_counter.h"
@@ -67,6 +68,7 @@ typedef struct _machine_timer_obj_t {
     en_clk_dst_t pclk_dst;
     uint16_t mode;               // TIMER_MODE_ONE_SHOT or TIMER_MODE_PERIODIC
     mp_obj_t callback;
+    bool ishard;
     bool active;
     bool constructed;
     sys_int_cfg_t irq_cfg;
@@ -107,8 +109,9 @@ static void machine_timer_isr(machine_timer_obj_t *self) {
             Cy_TCPWM_Counter_Disable(TCPWM0, self->counter_num);
             self->active = false;
         }
-        if (self->callback != mp_const_none) {
-            mp_sched_schedule(self->callback, MP_OBJ_FROM_PTR(self));
+        if (mp_irq_dispatch(self->callback, MP_OBJ_FROM_PTR(self), self->ishard) < 0) {
+            // Uncaught exception: disable callback so periodic timers don't spam errors.
+            self->callback = mp_const_none;
         }
     }
 }
@@ -204,13 +207,14 @@ static void machine_timer_start(machine_timer_obj_t *self, uint32_t period_ticks
 static mp_obj_t machine_timer_init_helper(machine_timer_obj_t *self,
     size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
 
-    enum { ARG_mode, ARG_callback, ARG_period, ARG_tick_hz, ARG_freq };
+    enum { ARG_mode, ARG_callback, ARG_period, ARG_tick_hz, ARG_freq, ARG_hard };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_mode,     MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = TIMER_MODE_PERIODIC} },
         { MP_QSTR_callback, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
         { MP_QSTR_period,   MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = -1} },
         { MP_QSTR_tick_hz,  MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 1000} },
         { MP_QSTR_freq,     MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
+        { MP_QSTR_hard,     MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_FALSE} },
     };
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
@@ -230,6 +234,12 @@ static mp_obj_t machine_timer_init_helper(machine_timer_obj_t *self,
         mp_raise_ValueError(MP_ERROR_TEXT("callback must be callable"));
     }
     self->callback = callback;
+
+    mp_obj_t hard = args[ARG_hard].u_obj;
+    if (!mp_obj_is_bool(hard)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("hard must be bool"));
+    }
+    self->ishard = (hard == mp_const_true);
 
     // Compute period in timer clock ticks in 64-bit, then range-check.
     uint64_t period_ticks_64;
@@ -265,7 +275,7 @@ static mp_obj_t machine_timer_init_helper(machine_timer_obj_t *self,
 }
 
 // ---------------------------------------------------------------------------
-// machine.Timer(id [, mode=, freq=, period=, tick_hz=, callback=])
+// machine.Timer(id [, mode=, freq=, period=, tick_hz=, callback=, hard=])
 // ---------------------------------------------------------------------------
 
 static mp_obj_t machine_timer_make_new(const mp_obj_type_t *type,
@@ -291,7 +301,6 @@ static mp_obj_t machine_timer_make_new(const mp_obj_type_t *type,
     self->counter_num = timer_hw[id].counter_num;
     self->irq_num = timer_hw[id].irq_num;
     self->pclk_dst = timer_hw[id].pclk_dst;
-    self->constructed = true;
 
     if (n_args > 1 || n_kw > 0) {
         mp_map_t kw_map;
@@ -299,11 +308,13 @@ static mp_obj_t machine_timer_make_new(const mp_obj_type_t *type,
         machine_timer_init_helper(self, n_args - 1, args + 1, &kw_map);
     }
 
+    self->constructed = true;
+
     return MP_OBJ_FROM_PTR(self);
 }
 
 // ---------------------------------------------------------------------------
-// timer.init(mode=, freq=, period=, tick_hz=, callback=)
+// timer.init(mode=, freq=, period=, tick_hz=, callback=, hard=)
 // ---------------------------------------------------------------------------
 
 static mp_obj_t machine_timer_init(size_t n_args, const mp_obj_t *args,
@@ -324,6 +335,7 @@ static mp_obj_t machine_timer_deinit(mp_obj_t self_in) {
         sys_int_deinit(&self->irq_cfg);
     }
     self->callback = mp_const_none;
+    self->ishard = false;
     self->active = false;
     self->constructed = false;
     return mp_const_none;
@@ -354,6 +366,7 @@ void machine_timer_init_all(void) {
         timer_obj[i].irq_num = timer_hw[i].irq_num;
         timer_obj[i].pclk_dst = timer_hw[i].pclk_dst;
         timer_obj[i].callback = mp_const_none;
+        timer_obj[i].ishard = false;
         timer_obj[i].active = false;
         timer_obj[i].constructed = false;
     }
@@ -367,6 +380,7 @@ void machine_timer_deinit_all(void) {
             sys_int_deinit(&self->irq_cfg);
         }
         self->callback = mp_const_none;
+        self->ishard = false;
         self->active = false;
         self->constructed = false;
     }

--- a/ports/psoc-edge/machine_timer.c
+++ b/ports/psoc-edge/machine_timer.c
@@ -64,7 +64,6 @@ typedef struct _machine_timer_obj_t {
     mp_obj_base_t base;
     uint8_t id;                  // 0, 1, or 2
     uint32_t counter_num;        // TCPWM0 counter index: 3, 5, or 6
-    IRQn_Type irq_num;
     en_clk_dst_t pclk_dst;
     uint16_t mode;               // TIMER_MODE_ONE_SHOT or TIMER_MODE_PERIODIC
     mp_obj_t callback;
@@ -195,7 +194,6 @@ static void machine_timer_start(machine_timer_obj_t *self, uint32_t period_ticks
     }
 
     // Register IRQ before enabling so no TC edge is missed.
-    self->irq_cfg.irq_num = self->irq_num;
     self->irq_cfg.priority = SYS_INT_IRQ_LOWEST_PRIORITY;
     self->irq_cfg.handler = timer_handlers[self->id];
     sys_int_init(&self->irq_cfg);
@@ -305,11 +303,11 @@ static mp_obj_t machine_timer_make_new(const mp_obj_type_t *type,
 
     self->id = (uint8_t)id;
     self->counter_num = timer_hw[id].counter_num;
-    self->irq_num = timer_hw[id].irq_num;
     self->pclk_dst = timer_hw[id].pclk_dst;
     self->callback = mp_const_none;
     self->ishard = false;
     self->active = false;
+    self->irq_cfg.irq_num = timer_hw[id].irq_num;
 
     if (n_args > 1 || n_kw > 0) {
         mp_map_t kw_map;
@@ -364,10 +362,12 @@ static MP_DEFINE_CONST_FUN_OBJ_1(machine_timer_deinit_obj, machine_timer_deinit)
 static void machine_timer_print(const mp_print_t *print, mp_obj_t self_in,
     mp_print_kind_t kind) {
     machine_timer_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_printf(print, "Timer(Id=%u, mode=%s, active=%s)",
+    uint32_t period_ticks = Cy_TCPWM_Counter_GetPeriod(TCPWM0, self->counter_num) + 1U;
+    uint32_t freq = period_ticks != 0U ? (TIMER_CLK_HZ / period_ticks) : 0U;
+    mp_printf(print, "Timer(id=%u, mode=Timer.%s, freq=%u)",
         (unsigned)self->id,
-        self->mode == TIMER_MODE_ONE_SHOT ? "ONE_SHOT" : "PERIODIC",
-        self->active ? "True" : "False");
+        self->mode == TIMER_MODE_ONE_SHOT ? "OneShot" : "Periodic",
+        (unsigned)freq);
 }
 
 // ---------------------------------------------------------------------------

--- a/ports/psoc-edge/machine_timer.c
+++ b/ports/psoc-edge/machine_timer.c
@@ -24,9 +24,8 @@
  * THE SOFTWARE.
  */
 
-// Hardware timer using TCPWM0 Group 0 counters 3, 5, 6 (IDs 0, 1, 2).
-// Counter 2 is reserved for the system tick timer (modtime.c).
-// Counters 0, 1, 4, 7 are allocated by the BSP.  3, 5, 6 are free for use.
+// Hardware timer using TCPWM0 Group 0 counters 3, 5, 6, 2 (IDs 0, 1, 2, 3).
+// Counters 0, 1, 4, 7 are allocated by the BSP.  2, 3, 5, 6 are used by Timer.
 
 #include "py/obj.h"
 #include "py/runtime.h"
@@ -45,7 +44,7 @@
 // Constants
 // ---------------------------------------------------------------------------
 
-#define MACHINE_TIMER_NUM_INSTANCES  (3)
+#define MACHINE_TIMER_NUM_INSTANCES  (4)
 
 // Shared general-purpose timer divider target frequency used by this module.
 #define TIMER_CLK_HZ  (1000000UL)
@@ -63,8 +62,8 @@
 
 typedef struct _machine_timer_obj_t {
     mp_obj_base_t base;
-    uint8_t id;                  // 0, 1, or 2
-    uint32_t counter_num;        // TCPWM0 counter index: 3, 5, or 6
+    uint8_t id;                  // 0, 1, 2, or 3
+    uint32_t counter_num;        // TCPWM0 counter index: 3, 5, 6, or 2
     en_clk_dst_t pclk_dst;
     uint16_t mode;               // TIMER_MODE_ONE_SHOT or TIMER_MODE_PERIODIC
     mp_obj_t callback;
@@ -89,6 +88,7 @@ static const timer_hw_t timer_hw[MACHINE_TIMER_NUM_INSTANCES] = {
     { 3U, tcpwm_0_interrupts_3_IRQn, PCLK_TCPWM0_CLOCK_COUNTER_EN3 },
     { 5U, tcpwm_0_interrupts_5_IRQn, PCLK_TCPWM0_CLOCK_COUNTER_EN5 },
     { 6U, tcpwm_0_interrupts_6_IRQn, PCLK_TCPWM0_CLOCK_COUNTER_EN6 },
+    { 2U, tcpwm_0_interrupts_2_IRQn, PCLK_TCPWM0_CLOCK_COUNTER_EN2 },
 };
 
 // ---------------------------------------------------------------------------
@@ -152,11 +152,17 @@ static void timer2_irq_handler(void) {
         machine_timer_isr(timer_obj[2]);
     }
 }
+static void timer3_irq_handler(void) {
+    if (timer_obj[3] != NULL) {
+        machine_timer_isr(timer_obj[3]);
+    }
+}
 
 static const cy_israddress timer_handlers[MACHINE_TIMER_NUM_INSTANCES] = {
     timer0_irq_handler,
     timer1_irq_handler,
     timer2_irq_handler,
+    timer3_irq_handler,
 };
 
 // ---------------------------------------------------------------------------

--- a/ports/psoc-edge/machine_timer.c
+++ b/ports/psoc-edge/machine_timer.c
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2022-2024 Infineon Technologies AG
+ * Copyright (c) 2026 Infineon Technologies AG
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -231,20 +231,21 @@ static mp_obj_t machine_timer_init_helper(machine_timer_obj_t *self,
     }
     self->callback = callback;
 
-    // Compute period in timer clock ticks
+    // Compute period in timer clock ticks in 64-bit, then range-check.
+    uint64_t period_ticks_64;
     uint32_t period_ticks;
     if (args[ARG_freq].u_obj != mp_const_none) {
         mp_int_t freq = mp_obj_get_int(args[ARG_freq].u_obj);
         if (freq <= 0) {
             mp_raise_ValueError(MP_ERROR_TEXT("freq must be > 0"));
         }
-        period_ticks = TIMER_CLK_HZ / (uint32_t)freq;
+        period_ticks_64 = (uint64_t)TIMER_CLK_HZ / (uint64_t)(uint32_t)freq;
     } else if (args[ARG_period].u_int > 0) {
         mp_int_t tick_hz = args[ARG_tick_hz].u_int;
         if (tick_hz <= 0) {
             mp_raise_ValueError(MP_ERROR_TEXT("tick_hz must be > 0"));
         }
-        period_ticks = (uint32_t)(
+        period_ticks_64 = (
             (uint64_t)TIMER_CLK_HZ * (uint64_t)(uint32_t)args[ARG_period].u_int
             / (uint64_t)(uint32_t)tick_hz);
     } else if (mp_map_lookup(kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_period), MP_MAP_LOOKUP) != NULL) {
@@ -253,9 +254,11 @@ static mp_obj_t machine_timer_init_helper(machine_timer_obj_t *self,
         mp_raise_ValueError(MP_ERROR_TEXT("either freq or period must be specified"));
     }
 
-    if (period_ticks == 0U || period_ticks > 0xFFFFFFFFUL) {
+    if (period_ticks_64 == 0U || period_ticks_64 > UINT32_MAX) {
         mp_raise_ValueError(MP_ERROR_TEXT("period out of range for 32-bit counter"));
     }
+
+    period_ticks = (uint32_t)period_ticks_64;
 
     machine_timer_start(self, period_ticks);
     return mp_const_none;

--- a/ports/psoc-edge/machine_timer.c
+++ b/ports/psoc-edge/machine_timer.c
@@ -322,6 +322,7 @@ static mp_obj_t machine_timer_deinit(mp_obj_t self_in) {
     }
     self->callback = mp_const_none;
     self->active = false;
+    self->constructed = false;
     return mp_const_none;
 }
 static MP_DEFINE_CONST_FUN_OBJ_1(machine_timer_deinit_obj, machine_timer_deinit);

--- a/ports/psoc-edge/machine_timer.c
+++ b/ports/psoc-edge/machine_timer.c
@@ -68,6 +68,7 @@ typedef struct _machine_timer_obj_t {
     uint16_t mode;               // TIMER_MODE_ONE_SHOT or TIMER_MODE_PERIODIC
     mp_obj_t callback;
     bool active;
+    bool constructed;
     sys_int_cfg_t irq_cfg;
 } machine_timer_obj_t;
 
@@ -238,7 +239,7 @@ static mp_obj_t machine_timer_init_helper(machine_timer_obj_t *self,
             mp_raise_ValueError(MP_ERROR_TEXT("freq must be > 0"));
         }
         period_ticks = TIMER_CLK_HZ / (uint32_t)freq;
-    } else if (args[ARG_period].u_int >= 0) {
+    } else if (args[ARG_period].u_int > 0) {
         mp_int_t tick_hz = args[ARG_tick_hz].u_int;
         if (tick_hz <= 0) {
             mp_raise_ValueError(MP_ERROR_TEXT("tick_hz must be > 0"));
@@ -246,6 +247,8 @@ static mp_obj_t machine_timer_init_helper(machine_timer_obj_t *self,
         period_ticks = (uint32_t)(
             (uint64_t)TIMER_CLK_HZ * (uint64_t)(uint32_t)args[ARG_period].u_int
             / (uint64_t)(uint32_t)tick_hz);
+    } else if (mp_map_lookup(kw_args, MP_OBJ_NEW_QSTR(MP_QSTR_period), MP_MAP_LOOKUP) != NULL) {
+        mp_raise_ValueError(MP_ERROR_TEXT("period must be > 0"));
     } else {
         mp_raise_ValueError(MP_ERROR_TEXT("either freq or period must be specified"));
     }
@@ -275,11 +278,17 @@ static mp_obj_t machine_timer_make_new(const mp_obj_type_t *type,
     }
 
     machine_timer_obj_t *self = &timer_obj[id];
+    if (self->constructed) {
+        mp_raise_msg_varg(&mp_type_ValueError,
+            MP_ERROR_TEXT("Timer(%u) already created."), (unsigned)id);
+    }
+
     self->base.type = &machine_timer_type;
     self->id = (uint8_t)id;
     self->counter_num = timer_hw[id].counter_num;
     self->irq_num = timer_hw[id].irq_num;
     self->pclk_dst = timer_hw[id].pclk_dst;
+    self->constructed = true;
 
     if (n_args > 1 || n_kw > 0) {
         mp_map_t kw_map;
@@ -324,7 +333,7 @@ static MP_DEFINE_CONST_FUN_OBJ_1(machine_timer_deinit_obj, machine_timer_deinit)
 static void machine_timer_print(const mp_print_t *print, mp_obj_t self_in,
     mp_print_kind_t kind) {
     machine_timer_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_printf(print, "Timer(%u, mode=%s, active=%s)",
+    mp_printf(print, "Timer(Id=%u, mode=%s, active=%s)",
         (unsigned)self->id,
         self->mode == TIMER_MODE_ONE_SHOT ? "ONE_SHOT" : "PERIODIC",
         self->active ? "True" : "False");
@@ -342,6 +351,7 @@ void machine_timer_init_all(void) {
         timer_obj[i].pclk_dst = timer_hw[i].pclk_dst;
         timer_obj[i].callback = mp_const_none;
         timer_obj[i].active = false;
+        timer_obj[i].constructed = false;
     }
 }
 
@@ -354,6 +364,7 @@ void machine_timer_deinit_all(void) {
         }
         self->callback = mp_const_none;
         self->active = false;
+        self->constructed = false;
     }
 }
 

--- a/ports/psoc-edge/main.c
+++ b/ports/psoc-edge/main.c
@@ -89,7 +89,7 @@ extern void machine_spi_target_deinit_all(void);
 extern void machine_pdm_pcm_deinit_all(void);
 extern void machine_ipc_deinit_all(void);
 extern void mp_hal_ticks_init(void);
-
+extern void machine_timer_deinit_all(void);
 void mpy_task(void *arg);
 static TaskHandle_t mpy_task_handle;
 
@@ -224,6 +224,7 @@ soft_reset:
     #endif
     machine_pdm_pcm_deinit_all();
     machine_ipc_deinit_all();
+    machine_timer_deinit_all();
 
     #if MICROPY_PY_NETWORK
     mod_network_deinit();

--- a/ports/psoc-edge/modmachine.c
+++ b/ports/psoc-edge/modmachine.c
@@ -85,6 +85,6 @@ static void mp_machine_set_freq(size_t n_args, const mp_obj_t *args) {
     { MP_ROM_QSTR(MP_QSTR_UART),                MP_ROM_PTR(&machine_uart_type) }, \
     { MP_ROM_QSTR(MP_QSTR_PWM),                 MP_ROM_PTR(&machine_pwm_type) }, \
     { MP_ROM_QSTR(MP_QSTR_Timer),               MP_ROM_PTR(&machine_timer_type) }, \
-	MICROPY_PY_MACHINE_SPITARGET_GLOBAL
+    MICROPY_PY_MACHINE_SPITARGET_GLOBAL
 
 #endif // MICROPY_PY_MACHINE

--- a/ports/psoc-edge/modmachine.c
+++ b/ports/psoc-edge/modmachine.c
@@ -84,6 +84,7 @@ static void mp_machine_set_freq(size_t n_args, const mp_obj_t *args) {
     { MP_ROM_QSTR(MP_QSTR_IPC),                 MP_ROM_PTR(&machine_ipc_type) }, \
     { MP_ROM_QSTR(MP_QSTR_UART),                MP_ROM_PTR(&machine_uart_type) }, \
     { MP_ROM_QSTR(MP_QSTR_PWM),                 MP_ROM_PTR(&machine_pwm_type) }, \
-    MICROPY_PY_MACHINE_SPITARGET_GLOBAL
+    { MP_ROM_QSTR(MP_QSTR_Timer),               MP_ROM_PTR(&machine_timer_type) }, \
+	MICROPY_PY_MACHINE_SPITARGET_GLOBAL
 
 #endif // MICROPY_PY_MACHINE

--- a/ports/psoc-edge/modmachine.h
+++ b/ports/psoc-edge/modmachine.h
@@ -47,6 +47,7 @@ extern const mp_obj_type_t machine_pdm_pcm_type;
 extern const mp_obj_type_t machine_rtc_type;
 extern const mp_obj_type_t machine_ipc_type;
 extern const mp_obj_type_t machine_pwm_type;
+extern const mp_obj_type_t machine_timer_type;
 
 #if MICROPY_PY_MACHINE_SPI_TARGET
 extern const mp_obj_type_t machine_spi_target_type;

--- a/tests/ports/psoc-edge/board_only_hw/single/timer.py
+++ b/tests/ports/psoc-edge/board_only_hw/single/timer.py
@@ -34,9 +34,6 @@ def test_oneshot():
     finally:
         tim_oneshot.deinit()  # Deinitialize the Oneshot timer
 
-    tim_new_id = Timer(3, period=100, mode=Timer.ONE_SHOT, callback=call_oneshot)
-    tim_new_id.deinit()
-
 
 # Periodic timer
 def test_periodic():
@@ -99,6 +96,10 @@ def test_frequency_input():
                 break
     finally:
         tim_freq.deinit()
+
+    # Verify Timer ID 3 (counter 2) can be constructed and deinitialized.
+    tim_id3 = Timer(3, period=100, mode=Timer.ONE_SHOT, callback=call_oneshot)
+    tim_id3.deinit()
 
 
 # Negative test cases to validate that invalid parameters raise ValueError as expected.

--- a/tests/ports/psoc-edge/board_only_hw/single/timer.py
+++ b/tests/ports/psoc-edge/board_only_hw/single/timer.py
@@ -1,4 +1,5 @@
 from machine import Timer
+import micropython
 import time
 
 oneshot_triggered = False
@@ -160,6 +161,85 @@ def test_recreate_after_deinit():
     print("Recreate Timer(0) after deinit: OK")
 
 
+def print_result(name, ok):
+    print("{}: {}".format(name, "OK" if ok else "FAIL"))
+
+
+# Test hard parameter behavior.
+def test_hard_parameter_checks():
+    print("*****Timer hard Parameter Tests*****")
+
+    # 1) hard defaults to False (soft callback path).
+    soft_events = []
+
+    def cb_soft(timer):
+        # callback with list append works.
+        soft_events.append(1)
+
+    tim_soft = Timer(0, period=50, tick_hz=1000, mode=Timer.PERIODIC, callback=cb_soft)
+    try:
+        time.sleep_ms(250)
+    finally:
+        tim_soft.deinit()
+    print_result("default_soft", len(soft_events) > 0)
+
+    # 2) hard=True should execute callback successfully.
+
+    # reserves a small emergency buffer so exceptions in
+    # interrupt/hard-IRQ context can still be created and reported safely
+    micropython.alloc_emergency_exception_buf(100)
+    hard_events = []
+    hard_seen = False
+
+    def cb_hard(timer):
+        nonlocal hard_seen
+        try:
+            hard_events.append(1)
+        except MemoryError:
+            hard_seen = True
+            return
+
+    tim_hard = Timer(1, period=50, tick_hz=1000, mode=Timer.PERIODIC, callback=cb_hard, hard=True)
+    try:
+        time.sleep_ms(250)
+    finally:
+        tim_hard.deinit()
+    print_result("hard_true_callback_invoked", hard_seen)
+
+    # 3) hard must be bool.
+    try:
+        Timer(2, period=100, tick_hz=1000, mode=Timer.ONE_SHOT, callback=call_oneshot, hard=1)
+        print_result("hard_bool_validation", False)
+    except ValueError:
+        print_result("hard_bool_validation", True)
+    except Exception:
+        print_result("hard_bool_validation", False)
+
+    # 4) hard accepts both bool values.
+    hard_false_ok = False
+    hard_true_ok = False
+
+    try:
+        t_bool = Timer(
+            2, period=200, tick_hz=1000, mode=Timer.ONE_SHOT, callback=call_oneshot, hard=False
+        )
+        t_bool.deinit()
+        hard_false_ok = True
+    except Exception:
+        hard_false_ok = False
+
+    try:
+        t_bool = Timer(
+            2, period=200, tick_hz=1000, mode=Timer.ONE_SHOT, callback=call_oneshot, hard=True
+        )
+        t_bool.deinit()
+        hard_true_ok = True
+    except Exception:
+        hard_true_ok = False
+
+    print_result("hard_bool_values", hard_false_ok and hard_true_ok)
+
+
 ########## Main Execution ############
 
 if __name__ == "__main__":
@@ -172,3 +252,4 @@ if __name__ == "__main__":
     test_frequency_input()
     test_negative_cases()
     test_recreate_after_deinit()
+    test_hard_parameter_checks()

--- a/tests/ports/psoc-edge/board_only_hw/single/timer.py
+++ b/tests/ports/psoc-edge/board_only_hw/single/timer.py
@@ -34,6 +34,9 @@ def test_oneshot():
     finally:
         tim_oneshot.deinit()  # Deinitialize the Oneshot timer
 
+    tim_new_id = Timer(3, period=100, mode=Timer.ONE_SHOT, callback=call_oneshot)
+    tim_new_id.deinit()
+
 
 # Periodic timer
 def test_periodic():
@@ -108,7 +111,7 @@ def test_negative_cases():
         lambda: Timer(-1, period=1000, mode=Timer.ONE_SHOT, callback=call_oneshot),
     )
     expect_value_error(
-        "invalid_id_3:", lambda: Timer(3, period=1000, mode=Timer.ONE_SHOT, callback=call_oneshot)
+        "invalid_id_4:", lambda: Timer(4, period=1000, mode=Timer.ONE_SHOT, callback=call_oneshot)
     )
 
     # Constructor check for duplicate object creation on the same ID.

--- a/tests/ports/psoc-edge/board_only_hw/single/timer.py
+++ b/tests/ports/psoc-edge/board_only_hw/single/timer.py
@@ -188,13 +188,13 @@ def test_hard_parameter_checks():
     # reserves a small emergency buffer so exceptions in
     # interrupt/hard-IRQ context can still be created and reported safely
     micropython.alloc_emergency_exception_buf(100)
-    hard_events = []
     hard_seen = False
 
     def cb_hard(timer):
         nonlocal hard_seen
         try:
-            hard_events.append(1)
+            # Any heap allocation in hard IRQ context should raise MemoryError.
+            _ = bytearray(1)
         except MemoryError:
             hard_seen = True
             return
@@ -204,7 +204,7 @@ def test_hard_parameter_checks():
         time.sleep_ms(250)
     finally:
         tim_hard.deinit()
-    print_result("hard_true_callback_invoked", hard_seen)
+    print_result("hard_true tested", hard_seen)
 
     # 3) hard must be bool.
     try:

--- a/tests/ports/psoc-edge/board_only_hw/single/timer.py
+++ b/tests/ports/psoc-edge/board_only_hw/single/timer.py
@@ -1,0 +1,174 @@
+from machine import Timer
+import time
+
+oneshot_triggered = False
+periodic_triggered = False
+
+
+# Callback functions for the timers to set the respective flags when triggered.
+def call_oneshot(timer):
+    global oneshot_triggered
+    oneshot_triggered = True
+
+
+# Callback function for the periodic timer to set the respective flag when triggered.
+def call_periodic(timer):
+    global periodic_triggered
+    periodic_triggered = True
+
+
+# Oneshot timer
+def test_oneshot():
+    # Oneshot timer
+    global oneshot_triggered
+    tim_oneshot = Timer(0, period=1000, mode=Timer.ONE_SHOT, callback=call_oneshot)
+
+    try:
+        # Wait for 5 seconds
+        for i in range(5):
+            time.sleep(1)
+            if oneshot_triggered:
+                print("Oneshot timer triggered")
+                oneshot_triggered = False
+    finally:
+        tim_oneshot.deinit()  # Deinitialize the Oneshot timer
+
+
+# Periodic timer
+def test_periodic():
+    # Periodic timer
+    global periodic_triggered
+    tim_periodic = Timer(1, period=1000, mode=Timer.PERIODIC, callback=call_periodic)
+
+    try:
+        # Wait for 10 seconds
+        for i in range(10):
+            time.sleep(1)
+            if periodic_triggered:
+                print("Periodic timer triggered")
+                periodic_triggered = False
+    finally:
+        tim_periodic.deinit()  # Deinitialize the periodic timer
+
+
+# Test that multiple timers can operate simultaneously without interference, and that their callbacks are triggered as expected.
+def test_multiple_timers():
+    global oneshot_triggered
+    global periodic_triggered
+    # Multiple timers
+    tim_oneshot = Timer(0, period=1000, mode=Timer.ONE_SHOT, callback=call_oneshot)
+    tim_periodic = Timer(1, period=3500, mode=Timer.PERIODIC, callback=call_periodic)
+
+    try:
+        # Wait for 10 seconds
+        for i in range(10):
+            time.sleep(1)
+            if oneshot_triggered:
+                print("Oneshot timer triggered")
+                oneshot_triggered = False
+            if periodic_triggered:
+                print("Periodic timer triggered")
+                periodic_triggered = False
+    finally:
+        tim_oneshot.deinit()  # Deinitialize the Oneshot timer
+        tim_periodic.deinit()  # Deinitialize the periodic timer
+
+
+# Helper function to execute a test function and print the expected ValueError message.
+def expect_value_error(label, fn):
+    try:
+        fn()
+    except ValueError as e:
+        print(label, e)
+
+
+def test_frequency_input():
+    global oneshot_triggered
+    tim_freq = Timer(2, freq=2, mode=Timer.ONE_SHOT, callback=call_oneshot)
+
+    try:
+        for i in range(3):
+            time.sleep(1)
+            if oneshot_triggered:
+                print("Frequency-based timer triggered")
+                oneshot_triggered = False
+                break
+    finally:
+        tim_freq.deinit()
+
+
+# Negative test cases to validate that invalid parameters raise ValueError as expected.
+def test_negative_cases():
+    print("*****Negative Timer Parameter Tests*****")
+
+    # Constructor boundary checks for invalid timer IDs.
+    expect_value_error(
+        "invalid_id_-1:",
+        lambda: Timer(-1, period=1000, mode=Timer.ONE_SHOT, callback=call_oneshot),
+    )
+    expect_value_error(
+        "invalid_id_3:", lambda: Timer(3, period=1000, mode=Timer.ONE_SHOT, callback=call_oneshot)
+    )
+
+    # Constructor check for duplicate object creation on the same ID.
+    tdup = Timer(2, period=10000, mode=Timer.ONE_SHOT, callback=call_oneshot)
+    try:
+        expect_value_error(
+            "duplicate_id_2:",
+            lambda: Timer(2, period=1000, mode=Timer.ONE_SHOT, callback=call_oneshot),
+        )
+    finally:
+        tdup.deinit()
+
+    # Exercise init() validation paths without consuming additional timer IDs.
+    tim = Timer(0)
+    try:
+        expect_value_error(
+            "invalid_mode:", lambda: tim.init(mode=99, period=1000, callback=call_oneshot)
+        )
+        expect_value_error(
+            "invalid_callback:", lambda: tim.init(mode=Timer.ONE_SHOT, period=1000, callback=1)
+        )
+        expect_value_error(
+            "freq_zero:", lambda: tim.init(mode=Timer.ONE_SHOT, freq=0, callback=call_oneshot)
+        )
+        expect_value_error(
+            "period_zero:", lambda: tim.init(mode=Timer.ONE_SHOT, period=0, callback=call_oneshot)
+        )
+        expect_value_error(
+            "tick_hz_zero:",
+            lambda: tim.init(mode=Timer.ONE_SHOT, period=1000, tick_hz=0, callback=call_oneshot),
+        )
+        expect_value_error(
+            "missing_freq_period:", lambda: tim.init(mode=Timer.ONE_SHOT, callback=call_oneshot)
+        )
+        expect_value_error(
+            "period_ticks_zero:",
+            lambda: tim.init(mode=Timer.ONE_SHOT, freq=2000000, callback=call_oneshot),
+        )
+    finally:
+        tim.deinit()
+
+
+# Test that a timer can be recreated after deinitialization, which should succeed without error.
+def test_recreate_after_deinit():
+    tim = Timer(0, period=10000, mode=Timer.ONE_SHOT, callback=call_oneshot)
+    tim.deinit()
+
+    tim_new = Timer(0, period=10000, mode=Timer.ONE_SHOT, callback=call_oneshot)
+    tim_new.deinit()
+    print("Recreate Timer(0) after deinit: OK")
+
+
+########## Main Execution ############
+
+if __name__ == "__main__":
+    print("*****Oneshot Timer Execution*****")
+    test_oneshot()
+    print("*****Periodic Timer Execution*****")
+    test_periodic()
+    print("*****Multiple Timers Execution*****")
+    test_multiple_timers()
+    test_frequency_input()
+    test_negative_cases()
+    test_recreate_after_deinit()

--- a/tests/ports/psoc-edge/board_only_hw/single/timer.py
+++ b/tests/ports/psoc-edge/board_only_hw/single/timer.py
@@ -137,10 +137,6 @@ def test_negative_cases():
             "period_zero:", lambda: tim.init(mode=Timer.ONE_SHOT, period=0, callback=call_oneshot)
         )
         expect_value_error(
-            "tick_hz_zero:",
-            lambda: tim.init(mode=Timer.ONE_SHOT, period=1000, tick_hz=0, callback=call_oneshot),
-        )
-        expect_value_error(
             "missing_freq_period:", lambda: tim.init(mode=Timer.ONE_SHOT, callback=call_oneshot)
         )
         expect_value_error(
@@ -176,7 +172,7 @@ def test_hard_parameter_checks():
         # callback with list append works.
         soft_events.append(1)
 
-    tim_soft = Timer(0, period=50, tick_hz=1000, mode=Timer.PERIODIC, callback=cb_soft)
+    tim_soft = Timer(0, period=50, mode=Timer.PERIODIC, callback=cb_soft)
     try:
         time.sleep_ms(250)
     finally:
@@ -202,7 +198,7 @@ def test_hard_parameter_checks():
     #         hard_seen = True
     #         return
 
-    # tim_hard = Timer(1, period=50, tick_hz=1000, mode=Timer.PERIODIC, callback=cb_hard, hard=True)
+    # tim_hard = Timer(1, period=50, mode=Timer.PERIODIC, callback=cb_hard, hard=True)
     # try:
     #     time.sleep_ms(250)
     # finally:
@@ -211,7 +207,7 @@ def test_hard_parameter_checks():
 
     # 3) hard must be bool.
     try:
-        Timer(2, period=100, tick_hz=1000, mode=Timer.ONE_SHOT, callback=call_oneshot, hard=1)
+        Timer(2, period=100, mode=Timer.ONE_SHOT, callback=call_oneshot, hard=1)
         print_result("hard_bool_validation", False)
     except ValueError:
         print_result("hard_bool_validation", True)
@@ -223,18 +219,14 @@ def test_hard_parameter_checks():
     hard_true_ok = False
 
     try:
-        t_bool = Timer(
-            2, period=200, tick_hz=1000, mode=Timer.ONE_SHOT, callback=call_oneshot, hard=False
-        )
+        t_bool = Timer(2, period=200, mode=Timer.ONE_SHOT, callback=call_oneshot, hard=False)
         t_bool.deinit()
         hard_false_ok = True
     except Exception:
         hard_false_ok = False
 
     try:
-        t_bool = Timer(
-            2, period=200, tick_hz=1000, mode=Timer.ONE_SHOT, callback=call_oneshot, hard=True
-        )
+        t_bool = Timer(2, period=200, mode=Timer.ONE_SHOT, callback=call_oneshot, hard=True)
         t_bool.deinit()
         hard_true_ok = True
     except Exception:

--- a/tests/ports/psoc-edge/board_only_hw/single/timer.py
+++ b/tests/ports/psoc-edge/board_only_hw/single/timer.py
@@ -184,27 +184,30 @@ def test_hard_parameter_checks():
     print_result("default_soft", len(soft_events) > 0)
 
     # 2) hard=True should execute callback successfully.
+    # TRhis test case will be commented out until the hard callback path is implemented.
+    # The test case also validates that when hard=True,
+    # the callback is executed in hard IRQ context where heap allocations are not allowed
 
     # reserves a small emergency buffer so exceptions in
-    # interrupt/hard-IRQ context can still be created and reported safely
-    micropython.alloc_emergency_exception_buf(100)
-    hard_seen = False
+    # interrupt/hard-IRQ context can still be created and reported safely.
+    # micropython.alloc_emergency_exception_buf(100)
+    # hard_seen = False
 
-    def cb_hard(timer):
-        nonlocal hard_seen
-        try:
-            # Any heap allocation in hard IRQ context should raise MemoryError.
-            _ = bytearray(1)
-        except MemoryError:
-            hard_seen = True
-            return
+    # def cb_hard(timer):
+    #     nonlocal hard_seen
+    #     try:
+    #         # Any heap allocation in hard IRQ context should raise MemoryError.
+    #         _ = bytearray(1)
+    #     except MemoryError:
+    #         hard_seen = True
+    #         return
 
-    tim_hard = Timer(1, period=50, tick_hz=1000, mode=Timer.PERIODIC, callback=cb_hard, hard=True)
-    try:
-        time.sleep_ms(250)
-    finally:
-        tim_hard.deinit()
-    print_result("hard_true tested", hard_seen)
+    # tim_hard = Timer(1, period=50, tick_hz=1000, mode=Timer.PERIODIC, callback=cb_hard, hard=True)
+    # try:
+    #     time.sleep_ms(250)
+    # finally:
+    #     tim_hard.deinit()
+    # print_result("hard_true tested", hard_seen)
 
     # 3) hard must be bool.
     try:

--- a/tests/ports/psoc-edge/board_only_hw/single/timer.py.exp
+++ b/tests/ports/psoc-edge/board_only_hw/single/timer.py.exp
@@ -29,6 +29,6 @@ period_ticks_zero: period out of range for 32-bit counter
 Recreate Timer(0) after deinit: OK
 *****Timer hard Parameter Tests*****
 default_soft: OK
-hard_true_callback_invoked: OK
+hard_true tested: OK
 hard_bool_validation: OK
 hard_bool_values: OK

--- a/tests/ports/psoc-edge/board_only_hw/single/timer.py.exp
+++ b/tests/ports/psoc-edge/board_only_hw/single/timer.py.exp
@@ -27,3 +27,8 @@ tick_hz_zero: tick_hz must be > 0
 missing_freq_period: either freq or period must be specified
 period_ticks_zero: period out of range for 32-bit counter
 Recreate Timer(0) after deinit: OK
+*****Timer hard Parameter Tests*****
+default_soft: OK
+hard_true_callback_invoked: OK
+hard_bool_validation: OK
+hard_bool_values: OK

--- a/tests/ports/psoc-edge/board_only_hw/single/timer.py.exp
+++ b/tests/ports/psoc-edge/board_only_hw/single/timer.py.exp
@@ -29,6 +29,5 @@ period_ticks_zero: period out of range for 32-bit counter
 Recreate Timer(0) after deinit: OK
 *****Timer hard Parameter Tests*****
 default_soft: OK
-hard_true tested: OK
 hard_bool_validation: OK
 hard_bool_values: OK

--- a/tests/ports/psoc-edge/board_only_hw/single/timer.py.exp
+++ b/tests/ports/psoc-edge/board_only_hw/single/timer.py.exp
@@ -1,0 +1,29 @@
+*****Oneshot Timer Execution*****
+Oneshot timer triggered
+*****Periodic Timer Execution*****
+Periodic timer triggered
+Periodic timer triggered
+Periodic timer triggered
+Periodic timer triggered
+Periodic timer triggered
+Periodic timer triggered
+Periodic timer triggered
+Periodic timer triggered
+Periodic timer triggered
+*****Multiple Timers Execution*****
+Oneshot timer triggered
+Periodic timer triggered
+Periodic timer triggered
+Frequency-based timer triggered
+*****Negative Timer Parameter Tests*****
+invalid_id_-1: Timer id must be in range 0-2
+invalid_id_3: Timer id must be in range 0-2
+duplicate_id_2: Timer(2) already created.
+invalid_mode: invalid mode
+invalid_callback: callback must be callable
+freq_zero: freq must be > 0
+period_zero: period must be > 0
+tick_hz_zero: tick_hz must be > 0
+missing_freq_period: either freq or period must be specified
+period_ticks_zero: period out of range for 32-bit counter
+Recreate Timer(0) after deinit: OK

--- a/tests/ports/psoc-edge/board_only_hw/single/timer.py.exp
+++ b/tests/ports/psoc-edge/board_only_hw/single/timer.py.exp
@@ -16,8 +16,8 @@ Periodic timer triggered
 Periodic timer triggered
 Frequency-based timer triggered
 *****Negative Timer Parameter Tests*****
-invalid_id_-1: Timer id must be in range 0-2
-invalid_id_3: Timer id must be in range 0-2
+invalid_id_-1: Timer id must be in range 0-3
+invalid_id_4: Timer id must be in range 0-3
 duplicate_id_2: Timer(2) already created.
 invalid_mode: invalid mode
 invalid_callback: callback must be callable

--- a/tests/ports/psoc-edge/board_only_hw/single/timer.py.exp
+++ b/tests/ports/psoc-edge/board_only_hw/single/timer.py.exp
@@ -23,7 +23,6 @@ invalid_mode: invalid mode
 invalid_callback: callback must be callable
 freq_zero: freq must be > 0
 period_zero: period must be > 0
-tick_hz_zero: tick_hz must be > 0
 missing_freq_period: either freq or period must be specified
 period_ticks_zero: period out of range for 32-bit counter
 Recreate Timer(0) after deinit: OK


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant,
     especially links to open issues. -->

- Machine Timer module implemented.
- Timer Constructor, Init and Deinit code implementation in place.
- Additional boundary checks added for input parameters. For example, negative value, duplicate instances checks.
- Soft read-time implementation as a mp scheduler.
- Timer and related interrupts are torn down in the main() when a soft reset is triggered.
- HIL testing for both positive and negative TCs

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this section empty then your Pull Request may be closed. -->

- Testing on local environment with callback method implementing an LEG toggle
- HIL testing : Performed with positive and Negative test cases (excluding testing for Hard real-time implementation)

### Trade-offs and Alternatives

<!-- If the Pull Request has some negative impact (i.e. increased code size)
     then please explain why you think the trade-off improvement is worth it.
     If you can think of alternative ways to do this, please explain that here too.

     Delete this heading if not relevant (i.e. small fixes) -->

- Only 4 TCPWM counters (and pins) are supported for Timer.
- Hardware timer using TCPWM0 Group 0 counters 2, 3, 5, 6 (given IDs 0, 1, 2, 3).
- The other counters in TCPWM0 ( 0, 1, 4, 7 ) are allocated by the BSP.
- "Hard" real-time parameter is allowed, but will be internally converted to soft and executed. This is because the Hard IRQ requests are not available using the current FreeRTOS implementation. The complete functionality will be achieved once the FreeRTOS IRQ handling is completed.

### Generative AI

<!-- Please delete the answer below which doesn't apply, or write your own
     answer with more details. -->

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.

<!-- We require everyone to answer this question. If you delete this section or
     ignore it then your PR may be closed.

     For more information, consult the MicroPython Generative AI Policy:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines#generative-ai-policy
     -->
