### PR TITLE
Machine uart+mp hal periph pins helpers

### DIFF
--- a/docs/psoc-edge/quickref.rst
+++ b/docs/psoc-edge/quickref.rst
@@ -720,7 +720,6 @@ Constructor
 
    These parameters are not implemented:
    
-   - ``id``
    - ``txbuf``
    - ``invert`` 
   

--- a/ports/psoc-edge/machine_i2c.c
+++ b/ports/psoc-edge/machine_i2c.c
@@ -112,14 +112,14 @@ static void machine_hw_i2c_init(machine_hw_i2c_obj_t *self, uint32_t freq_hz) {
     };
 
     const mp_hal_pin_af_config_t i2c_pins_config[] = {
-        MP_HAL_PIN_AF_CONF(self->scl, CY_GPIO_DM_OD_DRIVESLOW, 1, MACHINE_PIN_AF_SIGNAL_I2C_SCL),
-        MP_HAL_PIN_AF_CONF(self->sda, CY_GPIO_DM_OD_DRIVESLOW, 1, MACHINE_PIN_AF_SIGNAL_I2C_SDA),
+        MP_HAL_PIN_AF_CONF_INIT(self->scl, CY_GPIO_DM_OD_DRIVESLOW, 1, MACHINE_PIN_AF_SIGNAL_I2C_SCL),
+        MP_HAL_PIN_AF_CONF_INIT(self->sda, CY_GPIO_DM_OD_DRIVESLOW, 1, MACHINE_PIN_AF_SIGNAL_I2C_SDA),
     };
 
     uint8_t scb_unit = i2c_pins_config[0].af->unit;
     self->scb_obj = machine_scb_obj_alloc(scb_unit, self, machine_hw_i2c_scb_isr);
 
-    mp_hal_periph_pins_af_config(i2c_pins_config, 2);
+    mp_hal_periph_pins_af_init(i2c_pins_config, 2);
 
     result = Cy_SCB_I2C_Init(self->scb_obj->scb, &self->cfg, &self->ctx);
     i2c_assert_raise_val("I2C init failed: 0x%lx", result);

--- a/ports/psoc-edge/machine_i2c.c
+++ b/ports/psoc-edge/machine_i2c.c
@@ -116,8 +116,10 @@ static void machine_hw_i2c_init(machine_hw_i2c_obj_t *self, uint32_t freq_hz) {
         MP_HAL_PIN_AF_CONF_INIT(self->sda, CY_GPIO_DM_OD_DRIVESLOW, 1, MACHINE_PIN_AF_SIGNAL_I2C_SDA),
     };
 
-    uint8_t scb_unit = i2c_pins_config[0].af->unit;
-    self->scb_obj = machine_scb_obj_alloc(scb_unit, self, machine_hw_i2c_scb_isr);
+    machine_pin_af_unit_t af_unit = MACHINE_PIN_AF_UNIT_NONE;
+    mp_hal_periph_pins_af_resolve_fn_unit(i2c_pins_config, 2, MACHINE_PIN_AF_FN_I2C, &af_unit);
+
+    self->scb_obj = machine_scb_obj_alloc(af_unit, self, machine_hw_i2c_scb_isr);
 
     mp_hal_periph_pins_af_init(i2c_pins_config, 2);
 

--- a/ports/psoc-edge/machine_i2c_target.c
+++ b/ports/psoc-edge/machine_i2c_target.c
@@ -184,13 +184,13 @@ static void i2c_target_init(machine_i2c_target_obj_t *self, machine_i2c_target_d
     self->addrsize = addrsize;
 
     const mp_hal_pin_af_config_t i2c_pins_config[] = {
-        MP_HAL_PIN_AF_CONF(self->scl, CY_GPIO_DM_OD_DRIVESLOW, 1, MACHINE_PIN_AF_SIGNAL_I2C_SCL),
-        MP_HAL_PIN_AF_CONF(self->sda, CY_GPIO_DM_OD_DRIVESLOW, 1, MACHINE_PIN_AF_SIGNAL_I2C_SDA),
+        MP_HAL_PIN_AF_CONF_INIT(self->scl, CY_GPIO_DM_OD_DRIVESLOW, 1, MACHINE_PIN_AF_SIGNAL_I2C_SCL),
+        MP_HAL_PIN_AF_CONF_INIT(self->sda, CY_GPIO_DM_OD_DRIVESLOW, 1, MACHINE_PIN_AF_SIGNAL_I2C_SDA),
     };
 
     self->scb_obj = machine_scb_obj_alloc(i2c_pins_config[0].af->unit, self, machine_i2c_target_scb_isr);
 
-    mp_hal_periph_pins_af_config(i2c_pins_config, 2);
+    mp_hal_periph_pins_af_init(i2c_pins_config, 2);
 
     result = Cy_SCB_I2C_Init(self->scb_obj->scb, &self->cfg, &self->ctx);
     if (result != CY_RSLT_SUCCESS) {

--- a/ports/psoc-edge/machine_i2c_target.c
+++ b/ports/psoc-edge/machine_i2c_target.c
@@ -188,7 +188,10 @@ static void i2c_target_init(machine_i2c_target_obj_t *self, machine_i2c_target_d
         MP_HAL_PIN_AF_CONF_INIT(self->sda, CY_GPIO_DM_OD_DRIVESLOW, 1, MACHINE_PIN_AF_SIGNAL_I2C_SDA),
     };
 
-    self->scb_obj = machine_scb_obj_alloc(i2c_pins_config[0].af->unit, self, machine_i2c_target_scb_isr);
+    machine_pin_af_unit_t af_unit = MACHINE_PIN_AF_UNIT_NONE;
+    mp_hal_periph_pins_af_resolve_fn_unit(i2c_pins_config, 2, MACHINE_PIN_AF_FN_I2C, &af_unit);
+
+    self->scb_obj = machine_scb_obj_alloc(af_unit, self, machine_i2c_target_scb_isr);
 
     mp_hal_periph_pins_af_init(i2c_pins_config, 2);
 

--- a/ports/psoc-edge/machine_pdm_pcm.c
+++ b/ports/psoc-edge/machine_pdm_pcm.c
@@ -479,11 +479,11 @@ static void mp_machine_pdm_pcm_init_helper(machine_pdm_pcm_obj_t *self, mp_arg_v
     self->data = mp_hal_get_pin_obj(args[ARG_data].u_obj);
 
     const mp_hal_pin_af_config_t pdm_pins_config[] = {
-        MP_HAL_PIN_AF_CONF(self->sck, CY_GPIO_DM_STRONG_IN_OFF, 1, MACHINE_PIN_AF_SIGNAL_PDM_CLK),
-        MP_HAL_PIN_AF_CONF(self->data, CY_GPIO_DM_HIGHZ, 1, MACHINE_PIN_AF_SIGNAL_PDM_DATA),
+        MP_HAL_PIN_AF_CONF_INIT(self->sck, CY_GPIO_DM_STRONG_IN_OFF, 1, MACHINE_PIN_AF_SIGNAL_PDM_CLK),
+        MP_HAL_PIN_AF_CONF_INIT(self->data, CY_GPIO_DM_HIGHZ, 1, MACHINE_PIN_AF_SIGNAL_PDM_DATA),
     };
 
-    mp_hal_periph_pins_af_config(pdm_pins_config, 2);
+    mp_hal_periph_pins_af_init(pdm_pins_config, 2);
     /** } */
 
     /**

--- a/ports/psoc-edge/machine_pdm_pcm.c
+++ b/ports/psoc-edge/machine_pdm_pcm.c
@@ -483,6 +483,9 @@ static void mp_machine_pdm_pcm_init_helper(machine_pdm_pcm_obj_t *self, mp_arg_v
         MP_HAL_PIN_AF_CONF_INIT(self->data, CY_GPIO_DM_HIGHZ, 1, MACHINE_PIN_AF_SIGNAL_PDM_DATA),
     };
 
+    machine_pin_af_unit_t af_unit = MACHINE_PIN_AF_UNIT_NONE;
+    mp_hal_periph_pins_af_resolve_fn_unit(pdm_pins_config, 2, MACHINE_PIN_AF_FN_PDM, &af_unit);
+
     mp_hal_periph_pins_af_init(pdm_pins_config, 2);
     /** } */
 

--- a/ports/psoc-edge/machine_pin.c
+++ b/ports/psoc-edge/machine_pin.c
@@ -196,6 +196,27 @@ const machine_pin_obj_t *machine_pin_get_named_pin(const mp_obj_dict_t *named_pi
     return NULL;
 }
 
+const machine_pin_obj_t *machine_pin_get_af_pin(machine_pin_af_unit_t af_unit, machine_pin_af_signal_t af_signal) {
+    const mp_map_t *cpu_map = &machine_pin_cpu_pins_locals_dict.map;
+
+    for (size_t i = 0; i < cpu_map->alloc; i++) {
+        const mp_map_elem_t *elem = &cpu_map->table[i];
+        if (elem->value == MP_OBJ_NULL) {
+            continue;
+        }
+
+        const machine_pin_obj_t *pin = MP_OBJ_TO_PTR(elem->value);
+        for (uint8_t j = 0; j < pin->af_num; j++) {
+            const machine_pin_af_obj_t *af = &pin->af[j];
+            if (af->unit == af_unit && af->signal == af_signal) {
+                return pin;
+            }
+        }
+    }
+
+    return NULL;
+}
+
 const machine_pin_obj_t *machine_pin_get_pin_obj(mp_obj_t obj) {
     const machine_pin_obj_t *pin_obj;
 

--- a/ports/psoc-edge/machine_pin.h
+++ b/ports/psoc-edge/machine_pin.h
@@ -51,5 +51,6 @@ extern const mp_obj_dict_t machine_pin_cpu_pins_locals_dict;
 extern const mp_obj_dict_t machine_pin_board_pins_locals_dict;
 
 const machine_pin_obj_t *machine_pin_get_pin_obj(mp_obj_t obj);
+const machine_pin_obj_t *machine_pin_get_af_pin(machine_pin_af_unit_t af_unit, machine_pin_af_signal_t af_signal);
 
 #endif // MICROPY_INCLUDED_PSOC_EDGE_MACHINE_PIN_H

--- a/ports/psoc-edge/machine_pin_af.h
+++ b/ports/psoc-edge/machine_pin_af.h
@@ -40,6 +40,8 @@ typedef enum {
     /* TODO: Add additional functionalities */
 } machine_pin_af_fn_t;
 
+extern const char *machine_pin_af_fn_str[];
+
 typedef enum {
     MACHINE_PIN_AF_SIGNAL_I2C_SDA,
     MACHINE_PIN_AF_SIGNAL_I2C_SCL,
@@ -65,12 +67,16 @@ typedef enum {
 
 extern const char *machine_pin_af_signal_str[];
 
+#define MACHINE_PIN_AF_UNIT_NONE  0xFF
+typedef uint16_t machine_pin_af_unit_t;
+typedef void *machine_pin_af_periph_t;
+
 typedef struct {
     en_hsiom_sel_t idx;
     machine_pin_af_fn_t fn;
-    uint16_t unit;
+    machine_pin_af_unit_t unit;
     machine_pin_af_signal_t signal;
-    void *periph;
+    machine_pin_af_periph_t periph;
 } machine_pin_af_obj_t;
 
 extern const mp_obj_type_t machine_pin_af_type;

--- a/ports/psoc-edge/machine_pin_af.h
+++ b/ports/psoc-edge/machine_pin_af.h
@@ -38,6 +38,8 @@ typedef enum {
     MACHINE_PIN_AF_FN_PDM,
     MACHINE_PIN_AF_FN_TCPWM,
     /* TODO: Add additional functionalities */
+
+    MACHINE_PIN_AF_FN_NONE = 0xFF
 } machine_pin_af_fn_t;
 
 extern const char *machine_pin_af_fn_str[];

--- a/ports/psoc-edge/machine_scb.c
+++ b/ports/psoc-edge/machine_scb.c
@@ -63,6 +63,7 @@ MICROPY_PY_MACHINE_FOR_ALL_SCB(DEFINE_SCB_IRQ_HANDLER)
 
 #define MAP_SCB_IRQ_CONFIG(scb) \
     [scb] = { \
+        scb, \
         SCB##scb, \
         { \
             scb_##scb##_interrupt_IRQn, \
@@ -70,6 +71,10 @@ MICROPY_PY_MACHINE_FOR_ALL_SCB(DEFINE_SCB_IRQ_HANDLER)
             SCB##scb##_IRQ_Handler \
         }, \
         PCLK_SCB##scb##_CLOCK_SCB_EN, \
+        CY_MMIO_SCB##scb##_PERI_NR, \
+        CY_MMIO_SCB##scb##_GROUP_NR, \
+        CY_MMIO_SCB##scb##_SLAVE_NR, \
+        CY_MMIO_SCB##scb##_CLK_HF_NR, \
         NULL, \
         NULL, \
     },
@@ -131,6 +136,16 @@ machine_scb_obj_t *machine_scb_obj_alloc(uint8_t scb, mp_obj_t parent, machine_s
     if (obj->parent != NULL) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("SCB %u is already in use by another I2C, SPI or UART instance."), scb);
     }
+    /*
+     * Enable the peripheral clock gate for this SCB. The BSP's
+     * cycfg_config_reservations() only does this for the SCBs that are
+     * configured in the board design (e.g. the debug UART). Any SCB
+     * that was not pre-configured will have its clock gate disabled, and
+     * attempting to read or write its registers stalls the AHB bus,
+     * causing a hard lock-up. Calling this for already-enabled SCBs is
+     * idempotent.
+     */
+    Cy_SysClk_PeriGroupSlaveInit(obj->peri_nr, obj->group_nr, obj->slave_nr, obj->clk_hf_nr);
     obj->parent = parent;
     obj->parent_handler = handler;
     return &machine_scb_obj[scb];
@@ -139,6 +154,12 @@ machine_scb_obj_t *machine_scb_obj_alloc(uint8_t scb, mp_obj_t parent, machine_s
 void machine_scb_obj_free(machine_scb_obj_t *scb) {
     scb->parent = NULL;
     scb->parent_handler = NULL;
+    Cy_SysClk_PeriGroupSlaveDeinit(scb->peri_nr, scb->group_nr, scb->slave_nr);
+}
+
+bool machine_scb_is_free(uint8_t scb) {
+    return machine_scb_obj[scb].parent == NULL;
+
 }
 
 void machine_scb_enable_group(uint8_t scb) {

--- a/ports/psoc-edge/machine_scb.h
+++ b/ports/psoc-edge/machine_scb.h
@@ -33,15 +33,21 @@
 typedef void (*machine_scb_parent_irq_handler_t)(mp_obj_t scb_obj);
 
 typedef struct _machine_scb_obj_t {
+    int8_t id;
     CySCB_Type *scb;
     sys_int_cfg_t irq;
     en_clk_dst_t clk;
+    uint8_t peri_nr;
+    uint8_t group_nr;
+    uint8_t slave_nr;
+    uint8_t clk_hf_nr;
     mp_obj_t parent;
     machine_scb_parent_irq_handler_t parent_handler;
 } machine_scb_obj_t;
 
 machine_scb_obj_t *machine_scb_obj_alloc(uint8_t scb, mp_obj_t parent, machine_scb_parent_irq_handler_t handler);
 void machine_scb_obj_free(machine_scb_obj_t *scb);
+bool machine_scb_is_free(uint8_t scb);
 void machine_scb_enable_group(uint8_t scb);
 void machine_scb_peri_pclk_config_divider(en_clk_dst_t clk_dst,
     cy_en_divider_types_t div_type, uint8_t div_num, uint32_t div_val);

--- a/ports/psoc-edge/machine_spi.c
+++ b/ports/psoc-edge/machine_spi.c
@@ -108,7 +108,11 @@ static uint8_t machine_spi_pins_config_and_get_scb_unit(
             CY_GPIO_DM_HIGHZ, 0,
             MACHINE_PIN_AF_SIGNAL_SPI_MISO),
     };
-    uint8_t scb_unit = spi_pins_config[0].af->unit;
+
+    machine_pin_af_unit_t af_unit = MACHINE_PIN_AF_UNIT_NONE;
+    mp_hal_periph_pins_af_resolve_fn_unit(spi_pins_config, MP_ARRAY_SIZE(spi_pins_config), MACHINE_PIN_AF_FN_SPI, &af_unit);
+
+    uint8_t scb_unit = (uint8_t)af_unit;
     mp_hal_periph_pins_af_init(spi_pins_config, MP_ARRAY_SIZE(spi_pins_config));
     return scb_unit;
 }

--- a/ports/psoc-edge/machine_spi.c
+++ b/ports/psoc-edge/machine_spi.c
@@ -98,18 +98,18 @@ static uint8_t machine_spi_pins_config_and_get_scb_unit(
     mp_hal_pin_obj_t miso) {
     // CS/SSEL is managed externally by the user via machine.Pin
     const mp_hal_pin_af_config_t spi_pins_config[] = {
-        MP_HAL_PIN_AF_CONF(sck,
+        MP_HAL_PIN_AF_CONF_INIT(sck,
             CY_GPIO_DM_STRONG_IN_OFF, 1,
             MACHINE_PIN_AF_SIGNAL_SPI_CLK),
-        MP_HAL_PIN_AF_CONF(mosi,
+        MP_HAL_PIN_AF_CONF_INIT(mosi,
             CY_GPIO_DM_STRONG_IN_OFF, 1,
             MACHINE_PIN_AF_SIGNAL_SPI_MOSI),
-        MP_HAL_PIN_AF_CONF(miso,
+        MP_HAL_PIN_AF_CONF_INIT(miso,
             CY_GPIO_DM_HIGHZ, 0,
             MACHINE_PIN_AF_SIGNAL_SPI_MISO),
     };
     uint8_t scb_unit = spi_pins_config[0].af->unit;
-    mp_hal_periph_pins_af_config(spi_pins_config, MP_ARRAY_SIZE(spi_pins_config));
+    mp_hal_periph_pins_af_init(spi_pins_config, MP_ARRAY_SIZE(spi_pins_config));
     return scb_unit;
 }
 

--- a/ports/psoc-edge/machine_spi_target.c
+++ b/ports/psoc-edge/machine_spi_target.c
@@ -118,8 +118,12 @@ static uint8_t machine_spi_target_pins_config_and_get_scb_unit(
             CY_GPIO_DM_HIGHZ, 0,
             MACHINE_PIN_AF_SIGNAL_SPI_SELECT0),
     };
-    uint8_t scb_unit = spi_pins_config[0].af->unit;
-    mp_hal_periph_pins_af_init(spi_pins_config, 4);
+
+    machine_pin_af_unit_t af_unit = MACHINE_PIN_AF_UNIT_NONE;
+    mp_hal_periph_pins_af_resolve_fn_unit(spi_pins_config, MP_ARRAY_SIZE(spi_pins_config), MACHINE_PIN_AF_FN_SPI, &af_unit);
+
+    uint8_t scb_unit = (uint8_t)af_unit;
+    mp_hal_periph_pins_af_init(spi_pins_config, MP_ARRAY_SIZE(spi_pins_config));
     return scb_unit;
 }
 

--- a/ports/psoc-edge/machine_spi_target.c
+++ b/ports/psoc-edge/machine_spi_target.c
@@ -105,21 +105,21 @@ static uint8_t machine_spi_target_pins_config_and_get_scb_unit(
     mp_hal_pin_obj_t ssel) {
     // Pin config: SCK, MOSI, SSEL are inputs; MISO is output
     const mp_hal_pin_af_config_t spi_pins_config[] = {
-        MP_HAL_PIN_AF_CONF(sck,
+        MP_HAL_PIN_AF_CONF_INIT(sck,
             CY_GPIO_DM_HIGHZ, 0,
             MACHINE_PIN_AF_SIGNAL_SPI_CLK),
-        MP_HAL_PIN_AF_CONF(mosi,
+        MP_HAL_PIN_AF_CONF_INIT(mosi,
             CY_GPIO_DM_HIGHZ, 0,
             MACHINE_PIN_AF_SIGNAL_SPI_MOSI),
-        MP_HAL_PIN_AF_CONF(miso,
+        MP_HAL_PIN_AF_CONF_INIT(miso,
             CY_GPIO_DM_STRONG_IN_OFF, 1,
             MACHINE_PIN_AF_SIGNAL_SPI_MISO),
-        MP_HAL_PIN_AF_CONF(ssel,
+        MP_HAL_PIN_AF_CONF_INIT(ssel,
             CY_GPIO_DM_HIGHZ, 0,
             MACHINE_PIN_AF_SIGNAL_SPI_SELECT0),
     };
     uint8_t scb_unit = spi_pins_config[0].af->unit;
-    mp_hal_periph_pins_af_config(spi_pins_config, 4);
+    mp_hal_periph_pins_af_init(spi_pins_config, 4);
     return scb_unit;
 }
 

--- a/ports/psoc-edge/machine_uart.c
+++ b/ports/psoc-edge/machine_uart.c
@@ -189,7 +189,7 @@ static void machine_uart_scb_isr(mp_obj_t hw_uart_obj) {
     #endif
 }
 
-void machine_uart_obj_make_or_reuse(machine_uart_obj_t **self_ptr, uint8_t id, bool *is_new) {
+static void machine_uart_obj_make_or_reuse(machine_uart_obj_t **self_ptr, uint8_t id, bool *is_new) {
     /**
      * UART() constructor path:
      *
@@ -446,11 +446,11 @@ static void machine_uart_init_impl(machine_uart_obj_t **self_ptr, int uart_id, s
     }
 
     /* -- Resolve ID - pin match -- */
-    uint8_t fn_unit = uart_id;
-    mp_hal_periph_pins_af_resolve_fn_unit(uart_pins_af_config, pin_num, MACHINE_PIN_AF_FN_UART, (machine_pin_af_unit_t *)&fn_unit);
+    machine_pin_af_unit_t fn_unit = (machine_pin_af_unit_t)uart_id;
+    mp_hal_periph_pins_af_resolve_fn_unit(uart_pins_af_config, pin_num, MACHINE_PIN_AF_FN_UART, &fn_unit);
 
     /* -- Resolve not provided AF pins -- */
-    mp_hal_periph_pins_af_resolve_pin_af(uart_pins_af_config, pin_num, (machine_pin_af_unit_t)fn_unit);
+    mp_hal_periph_pins_af_resolve_pin_af(uart_pins_af_config, pin_num, fn_unit);
 
     /* -- Baudrate -- */
     uint32_t baudrate = (uint32_t)args[ARG_baudrate].u_int;
@@ -495,15 +495,15 @@ static void machine_uart_init_impl(machine_uart_obj_t **self_ptr, int uart_id, s
     }
 
     /* -- Timeouts -- */
-    uint32_t timeout_ms = args[ARG_timeout].u_int;
-    if (timeout_ms < 0) {
+    if (args[ARG_timeout].u_int < 0) {
         mp_raise_ValueError(MP_ERROR_TEXT("timeout must be non-negative"));
     }
+    uint32_t timeout_ms = args[ARG_timeout].u_int;
 
-    uint32_t timeout_char_ms = args[ARG_timeout_char].u_int;
-    if (timeout_char_ms < 0) {
+    if (args[ARG_timeout_char].u_int < 0) {
         mp_raise_ValueError(MP_ERROR_TEXT("timeout_char must be non-negative"));
     }
+    uint32_t timeout_char_ms = args[ARG_timeout_char].u_int;
     /* Make sure timeout_char is at least as long as a whole character (13 bits to be safe). */
     uint32_t min_timeout_char = 13000 / baudrate + 1;
     if (timeout_char_ms < min_timeout_char) {
@@ -513,7 +513,7 @@ static void machine_uart_init_impl(machine_uart_obj_t **self_ptr, int uart_id, s
     machine_uart_obj_t *self = *self_ptr;
 
     /* -- Object allocation -- */
-    bool is_new;
+    bool is_new = false;
     bool is_make_obj_required = (*self_ptr == NULL) ? true : false;
     if (is_make_obj_required) {
         machine_uart_obj_make_or_reuse(self_ptr, fn_unit, &is_new);

--- a/ports/psoc-edge/machine_uart.c
+++ b/ports/psoc-edge/machine_uart.c
@@ -40,7 +40,7 @@
 #include "py/ringbuf.h"
 #include "py/mphal.h"
 #include "py/mperrno.h"
-#include "py/misc.h"
+#include "py/nlr.h"
 #include "py/stream.h"
 
 // Port-specific includes
@@ -57,25 +57,24 @@
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT(msg), ret); \
 }
 
+// Flow control macros not part of PSOC Edge PDL
+#define UART_FLOW_CONTROL_NONE    (0)
+#define UART_FLOW_CONTROL_RTS     (1)
+#define UART_FLOW_CONTROL_CTS     (2)
+
 // Class-level constants exposed to Python
 #define MICROPY_PY_MACHINE_UART_CLASS_CONSTANTS \
     { MP_ROM_QSTR(MP_QSTR_IRQ_RXIDLE), MP_ROM_INT(CY_SCB_RX_INTR_NOT_EMPTY) }, \
     { MP_ROM_QSTR(MP_QSTR_IRQ_BREAK), MP_ROM_INT(CY_SCB_RX_INTR_UART_BREAK_DETECT) }, \
     { MP_ROM_QSTR(MP_QSTR_IRQ_TXIDLE), MP_ROM_INT(CY_SCB_TX_INTR_UART_DONE) }, \
-
-/**
- * TODO: Enable CTS/RTS class constants and flow control settings
-
     { MP_ROM_QSTR(MP_QSTR_RTS), MP_ROM_INT(UART_FLOW_CONTROL_RTS) }, \
     { MP_ROM_QSTR(MP_QSTR_CTS), MP_ROM_INT(UART_FLOW_CONTROL_CTS) }, \
- */
 
 /******************************************************************************/
-// Object type
 
 typedef struct _machine_uart_obj_t {
     mp_obj_base_t base;
-    uint8_t id;                       // Private variable in this port. ID not associated to any port pin UART group.
+    int id;                         // id matches the SCB id.
     machine_scb_obj_t *scb_obj;
     mp_hal_pin_obj_t tx;
     mp_hal_pin_obj_t rx;
@@ -97,14 +96,23 @@ typedef struct _machine_uart_obj_t {
     #endif
 } machine_uart_obj_t;
 
-static machine_uart_obj_t *mp_machine_uart_alloc(uint8_t uart_id) {
-    (void)uart_id;
+static machine_uart_obj_t *mp_machine_uart_obj_get(uint8_t id) {
+    for (uint8_t i = 0; i < MICROPY_PY_MACHINE_UART_NUM_ENTRIES; i++) {
+        if (MP_STATE_PORT(machine_uart_obj[i]) != NULL) {
+            if (MP_STATE_PORT(machine_uart_obj[i])->id == id) {
+                return MP_STATE_PORT(machine_uart_obj[i]);
+            }
+        }
+    }
+    return NULL;
+}
+
+static machine_uart_obj_t *mp_machine_uart_obj_alloc(void) {
     machine_uart_obj_t *self = NULL;
     for (uint8_t i = 0; i < MICROPY_PY_MACHINE_UART_NUM_ENTRIES; i++) {
         if (MP_STATE_PORT(machine_uart_obj[i]) == NULL) {
             self = mp_obj_malloc(machine_uart_obj_t, &machine_uart_type);
             MP_STATE_PORT(machine_uart_obj[i]) = self;
-            self->id = i;
             break;
         }
     }
@@ -116,8 +124,13 @@ static machine_uart_obj_t *mp_machine_uart_alloc(uint8_t uart_id) {
     return self;
 }
 
-static void mp_machine_uart_free(machine_uart_obj_t *self) {
-    MP_STATE_PORT(machine_uart_obj[self->id]) = NULL;
+static void mp_machine_uart_obj_free(machine_uart_obj_t *self) {
+    for (uint8_t i = 0; i < MICROPY_PY_MACHINE_UART_NUM_ENTRIES; i++) {
+        if (MP_STATE_PORT(machine_uart_obj[i]) == self) {
+            MP_STATE_PORT(machine_uart_obj[i]) = NULL;
+            break;
+        }
+    }
 }
 
 MP_REGISTER_ROOT_POINTER(struct _machine_uart_obj_t *machine_uart_obj[MICROPY_PY_MACHINE_UART_NUM_ENTRIES]);
@@ -174,6 +187,34 @@ static void machine_uart_scb_isr(mp_obj_t hw_uart_obj) {
         Cy_SCB_ClearTxInterrupt(self->scb_obj->scb, CY_SCB_TX_INTR_UART_DONE);
     }
     #endif
+}
+
+void machine_uart_obj_make_or_reuse(machine_uart_obj_t **self_ptr, uint8_t id, bool *is_new) {
+    /**
+     * UART() constructor path:
+     *
+     * Create or reuse and object based on the id.
+     * If the object for the given id already exists,
+     * reuse it and reinit the hardware with the new params.
+     * If the object is being created for the first time,
+     * allocate it and the associated SCB object.
+     */
+
+    /* Use object if it already exists */
+    (*self_ptr) = mp_machine_uart_obj_get(id);
+    (*is_new) = false;
+
+    if (*self_ptr == NULL) {
+        /* Create a new object and allocate the scb instance if free.*/
+        if (machine_scb_is_free(id)) {
+            (*self_ptr) = mp_machine_uart_obj_alloc();
+            (*self_ptr)->id = id;
+            (*self_ptr)->scb_obj = machine_scb_obj_alloc(id, *self_ptr, machine_uart_scb_isr);
+        } else {
+            mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("SCB %u is already in use by a machine.I2C or machine.SPI instance."), id);
+        }
+        (*is_new) = true;
+    }
 }
 
 static void machine_uart_baudrate_set(machine_uart_obj_t *self) {
@@ -247,6 +288,11 @@ static void machine_uart_hw_init(machine_uart_obj_t *self) {
     Cy_SCB_UART_Enable(self->scb_obj->scb);
 }
 
+static void machine_uart_hw_deinit(machine_uart_obj_t *self) {
+    Cy_SCB_UART_Disable(self->scb_obj->scb, &self->ctx);
+    sys_int_deinit(&self->scb_obj->irq);
+}
+
 static bool machine_uart_rx_wait(machine_uart_obj_t *self, uint32_t timeout_ms) {
     uint32_t timeout_time_ms = mp_hal_ticks_ms() + timeout_ms;
 
@@ -291,8 +337,6 @@ static void mp_machine_uart_print(const mp_print_t *print, mp_obj_t self_in, mp_
         self->stop
         );
 
-    /**
-     * TODO: Implement RTS/CTS flow control print
     if (self->rts != NULL) {
         mp_printf(print, "rts="MP_HAL_PIN_FMT ", ", mp_hal_pin_name(self->rts));
     }
@@ -301,197 +345,200 @@ static void mp_machine_uart_print(const mp_print_t *print, mp_obj_t self_in, mp_
         mp_printf(print, "cts="MP_HAL_PIN_FMT ", ", mp_hal_pin_name(self->cts));
     }
 
-     mp_printf(print, "flow=%u, "
-    */
-
-    mp_printf(print, "timeout=%ld, "
+    mp_printf(print, "flow=%u, "
+        "timeout=%ld, "
         "timeout_char=%ld, "
         "rxbuf=%d)",
-        /* self->flow, */
+        self->flow,
         self->timeout_ms,
         self->timeout_char_ms,
         self->rx_ringbuf.size
         );
 }
 
-
-static mp_obj_t mp_machine_uart_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    mp_arg_check_num(n_args, n_kw, 0, MP_OBJ_FUN_ARGS_MAX, true);
-
-    machine_uart_obj_t *self = mp_machine_uart_alloc(0);
-
-    mp_map_t kw_args;
-    mp_map_init_fixed_table(&kw_args, n_kw, args + n_args);
-    mp_machine_uart_init_helper(self, n_args, args, &kw_args);
-
-    return MP_OBJ_FROM_PTR(self);
-}
-
-static void mp_machine_uart_deinit(machine_uart_obj_t *self) {
-    Cy_SCB_UART_Disable(self->scb_obj->scb, &self->ctx);
-    sys_int_deinit(&self->scb_obj->irq);
-
-    m_del(uint8_t, self->rx_ringbuf.buf, self->rx_ringbuf.size);
-
-    machine_scb_obj_free(self->scb_obj);
-    mp_machine_uart_free(self);
-}
-
 #define DEFAULT_UART_BAUDRATE     (115200)
 #define DEFAULT_UART_BITS         (8)
 #define DEFAULT_UART_STOP         (1)
 #define DEFAULT_UART_RXBUF_SIZE   (256)
-/**
- * TODO: Enable CTS/RTS flow control settings and pins
- * Hardware flow control flags (compatible with machine.UART.RTS / machine.UART.CTS)
- *
-#define UART_FLOW_CONTROL_NONE    (0)
-#define UART_FLOW_CONTROL_RTS     (1)
-#define UART_FLOW_CONTROL_CTS     (2)
-*/
 
 enum {
     ARG_tx, ARG_rx,
     ARG_baudrate, ARG_bits, ARG_parity, ARG_stop,
-    /* ARG_rts, ARG_cts, ARG_flow, */
+    ARG_rts, ARG_cts, ARG_flow,
     ARG_timeout, ARG_timeout_char, ARG_rxbuf
 };
 
 static const mp_arg_t allowed_args[] = {
-    { MP_QSTR_tx,           MP_ARG_REQUIRED | MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
-    { MP_QSTR_rx,           MP_ARG_REQUIRED | MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
+    { MP_QSTR_tx,           MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
+    { MP_QSTR_rx,           MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
     { MP_QSTR_baudrate,     MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = DEFAULT_UART_BAUDRATE} },
     { MP_QSTR_bits,         MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = DEFAULT_UART_BITS} },
     { MP_QSTR_parity,       MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
     { MP_QSTR_stop,         MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = DEFAULT_UART_STOP} },
-    /* TODO: Enable rts and cts flow control
     { MP_QSTR_rts,          MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
     { MP_QSTR_cts,          MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
     { MP_QSTR_flow,         MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = UART_FLOW_CONTROL_NONE} },
-    */
     { MP_QSTR_timeout,      MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
     { MP_QSTR_timeout_char, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
     { MP_QSTR_rxbuf,        MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = DEFAULT_UART_RXBUF_SIZE} },
 };
 
-static void mp_machine_uart_init_helper(machine_uart_obj_t *self, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+/**
+ * Core init implementation. Accepts a pointer-to-pointer for self so it can
+ * allocate a new object when *self_ptr is NULL (constructor path). When called
+ * from init() the object is already allocated so *self_ptr is non-NULL.
+ */
+static void machine_uart_init_impl(machine_uart_obj_t **self_ptr, int uart_id, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     /* -- TX / RX pins -- */
-    self->tx = mp_hal_get_pin_obj(args[ARG_tx].u_obj);
-    self->rx = mp_hal_get_pin_obj(args[ARG_rx].u_obj);
-
+    uint8_t pin_num = 2U;
     #define MAX_MACHINE_UART_OBJ_AF_PINS 4
-    mp_hal_pin_af_config_t uart_pins_config[MAX_MACHINE_UART_OBJ_AF_PINS];
+    mp_hal_pin_af_config_t uart_pins_af_config[MAX_MACHINE_UART_OBJ_AF_PINS] = {
+        /* TX */ MP_HAL_PIN_AF_CONF_INIT_GPIO_SIGNAL(CY_GPIO_DM_STRONG_IN_OFF, 1, MACHINE_PIN_AF_SIGNAL_UART_TX),
+        /* RX */ MP_HAL_PIN_AF_CONF_INIT_GPIO_SIGNAL(CY_GPIO_DM_HIGHZ, 0, MACHINE_PIN_AF_SIGNAL_UART_RX),
+    };
 
-    MP_HAL_PIN_AF_INIT(uart_pins_config[0], self->tx, CY_GPIO_DM_STRONG_IN_OFF, 1, MACHINE_PIN_AF_SIGNAL_UART_TX);
-    MP_HAL_PIN_AF_INIT(uart_pins_config[1], self->rx, CY_GPIO_DM_HIGHZ, 0, MACHINE_PIN_AF_SIGNAL_UART_RX);
-
-    uint8_t scb_unit = uart_pins_config[0].af->unit;
-
-    if (self->scb_obj != NULL) {
-        mp_machine_uart_deinit(self);
+    if (args[ARG_tx].u_obj != mp_const_none) {
+        mp_hal_pin_obj_t tx_pin = mp_hal_get_pin_obj(args[ARG_tx].u_obj);
+        MP_HAL_PIN_AF_CONF_SET_PIN_AF(uart_pins_af_config[0], tx_pin);
     }
-    self->scb_obj = machine_scb_obj_alloc(scb_unit, self, machine_uart_scb_isr);
 
-    uint8_t num_af_pins = 2U; // TX and RX are always present, RTS and CTS are optional depending on flow control settings
+    if (args[ARG_rx].u_obj != mp_const_none) {
+        mp_hal_pin_obj_t rx_pin = mp_hal_get_pin_obj(args[ARG_rx].u_obj);
+        MP_HAL_PIN_AF_CONF_SET_PIN_AF(uart_pins_af_config[1], rx_pin);
+    }
 
     /* -- Flow control pins -- */
-    self->flow = 0; // Default to no flow control
-    self->rts = NULL;
-    self->cts = NULL;
+    uint32_t flow = (uint32_t)args[ARG_flow].u_int;
 
-    /**
-     * TODO: Enable CTS/RTS
-    self->flow = (uint32_t)args[ARG_flow].u_int;
+    /** TODO: Currently throw error if flow is not NONE.
+     * This needs to be implemented
+     * {
+     */
+    if (flow != UART_FLOW_CONTROL_NONE) {
+        mp_raise_ValueError(MP_ERROR_TEXT("flow control not supported yet. Keep flow=0"));
+    }
+    /** } */
 
-    if (self->flow & UART_FLOW_CONTROL_RTS) {
-        if (args[ARG_rts].u_obj == mp_const_none) {
-            mp_raise_ValueError(MP_ERROR_TEXT("rts pin required for RTS flow control"));
+    #define PIN_AF_CONFIG_INDEX_NONE (0xFF)
+    uint8_t pin_af_conf_rts_index = PIN_AF_CONFIG_INDEX_NONE;
+    if (flow & UART_FLOW_CONTROL_RTS) {
+        pin_af_conf_rts_index = pin_num;
+        pin_num++;
+        uart_pins_af_config[pin_af_conf_rts_index] = MP_HAL_PIN_AF_CONF_INIT_GPIO_SIGNAL(CY_GPIO_DM_STRONG_IN_OFF, 1, MACHINE_PIN_AF_SIGNAL_UART_RTS);
+        if (args[ARG_rts].u_obj != mp_const_none) {
+            mp_hal_pin_obj_t rts_pin = mp_hal_get_pin_obj(args[ARG_rts].u_obj);
+            MP_HAL_PIN_AF_CONF_SET_PIN_AF(uart_pins_af_config[pin_af_conf_rts_index], rts_pin);
         }
-        self->rts = mp_hal_get_pin_obj(args[ARG_rts].u_obj);
-        MP_HAL_PIN_AF_INIT(uart_pins_config[num_af_pins], self->rts, CY_GPIO_DM_STRONG_IN_OFF, 1, MACHINE_PIN_AF_SIGNAL_UART_RTS);
-        num_af_pins += 1U;
-    } else {
-        self->rts = NULL;
     }
 
-    if (self->flow & UART_FLOW_CONTROL_CTS) {
-        if (args[ARG_cts].u_obj == mp_const_none) {
-            mp_raise_ValueError(MP_ERROR_TEXT("cts pin required for CTS flow control"));
+    uint8_t pin_af_conf_cts_index = PIN_AF_CONFIG_INDEX_NONE;
+    if (flow & UART_FLOW_CONTROL_CTS) {
+        pin_af_conf_cts_index = pin_num;
+        pin_num++;
+        uart_pins_af_config[pin_af_conf_cts_index] = MP_HAL_PIN_AF_CONF_INIT_GPIO_SIGNAL(CY_GPIO_DM_HIGHZ, 0, MACHINE_PIN_AF_SIGNAL_UART_CTS);
+        if (args[ARG_cts].u_obj != mp_const_none) {
+            mp_hal_pin_obj_t cts_pin = mp_hal_get_pin_obj(args[ARG_cts].u_obj);
+            MP_HAL_PIN_AF_CONF_SET_PIN_AF(uart_pins_af_config[pin_af_conf_cts_index], cts_pin);
         }
-        self->cts = mp_hal_get_pin_obj(args[ARG_cts].u_obj);
-        MP_HAL_PIN_AF_INIT(uart_pins_config[num_af_pins], self->cts, CY_GPIO_DM_HIGHZ, 0, MACHINE_PIN_AF_SIGNAL_UART_CTS);
-        num_af_pins += 1U;
-    } else {
-        self->cts = NULL;
     }
-    */
 
-    /* Configure the alternate functions for the selected pins */
-    mp_hal_periph_pins_af_config(uart_pins_config, num_af_pins);
+    /* -- Resolve ID - pin match -- */
+    uint8_t fn_unit = uart_id;
+    mp_hal_periph_pins_af_resolve_fn_unit(uart_pins_af_config, pin_num, MACHINE_PIN_AF_FN_UART, (machine_pin_af_unit_t *)&fn_unit);
+
+    /* -- Resolve not provided AF pins -- */
+    mp_hal_periph_pins_af_resolve_pin_af(uart_pins_af_config, pin_num, (machine_pin_af_unit_t)fn_unit);
 
     /* -- Baudrate -- */
-    self->baudrate = (uint32_t)args[ARG_baudrate].u_int;
-    if (self->baudrate == 0U) {
+    uint32_t baudrate = (uint32_t)args[ARG_baudrate].u_int;
+    if (baudrate == 0U) {
         mp_raise_ValueError(MP_ERROR_TEXT("baudrate must be non-zero"));
     }
-    machine_uart_baudrate_set(self);
 
     /* -- Data bits -- */
-    int bits = args[ARG_bits].u_int;
+    uint8_t bits = args[ARG_bits].u_int;
     /**
      * TODO: Add support for 7 (or below <8 bits) and 9 bits.
      */
     if (bits != 8) {
         mp_raise_ValueError(MP_ERROR_TEXT("bits must be 8"));
     }
-    self->bits = (uint8_t)bits;
 
     /* -- Parity -- */
     mp_obj_t parity_arg = args[ARG_parity].u_obj;
+    uint8_t parity;
     if (parity_arg == mp_const_none) {
-        self->parity = (uint8_t)CY_SCB_UART_PARITY_NONE;
+        parity = (uint8_t)CY_SCB_UART_PARITY_NONE;
     } else {
         int p = mp_obj_get_int(parity_arg);
         if (p == 0) {
-            self->parity = (uint8_t)CY_SCB_UART_PARITY_EVEN;
+            parity = (uint8_t)CY_SCB_UART_PARITY_EVEN;
         } else if (p == 1) {
-            self->parity = (uint8_t)CY_SCB_UART_PARITY_ODD;
+            parity = (uint8_t)CY_SCB_UART_PARITY_ODD;
         } else {
             mp_raise_ValueError(MP_ERROR_TEXT("parity must be None, 0 (even) or 1 (odd)"));
         }
     }
 
     /* -- Stop bits -- */
-    int stop = args[ARG_stop].u_int;
-    if (stop == 1) {
-        self->stop = (uint8_t)CY_SCB_UART_STOP_BITS_1;
-    } else if (stop == 2) {
-        self->stop = (uint8_t)CY_SCB_UART_STOP_BITS_2;
+    int stop_arg = args[ARG_stop].u_int;
+    uint8_t stop;
+    if (stop_arg == 1) {
+        stop = (uint8_t)CY_SCB_UART_STOP_BITS_1;
+    } else if (stop_arg == 2) {
+        stop = (uint8_t)CY_SCB_UART_STOP_BITS_2;
     } else {
         mp_raise_ValueError(MP_ERROR_TEXT("stop bits must be 1 or 2"));
     }
 
     /* -- Timeouts -- */
-    if (args[ARG_timeout].u_int < 0) {
+    uint32_t timeout_ms = args[ARG_timeout].u_int;
+    if (timeout_ms < 0) {
         mp_raise_ValueError(MP_ERROR_TEXT("timeout must be non-negative"));
     }
-    self->timeout_ms = (uint32_t)args[ARG_timeout].u_int;
 
-    if (args[ARG_timeout_char].u_int < 0) {
+    uint32_t timeout_char_ms = args[ARG_timeout_char].u_int;
+    if (timeout_char_ms < 0) {
         mp_raise_ValueError(MP_ERROR_TEXT("timeout_char must be non-negative"));
     }
-    self->timeout_char_ms = (uint32_t)args[ARG_timeout_char].u_int;
     /* Make sure timeout_char is at least as long as a whole character (13 bits to be safe). */
-    uint32_t min_timeout_char = 13000 / self->baudrate + 1;
-    if (self->timeout_char_ms < min_timeout_char) {
-        self->timeout_char_ms = min_timeout_char;
+    uint32_t min_timeout_char = 13000 / baudrate + 1;
+    if (timeout_char_ms < min_timeout_char) {
+        timeout_char_ms = min_timeout_char;
     }
 
-    /* -- RX software ring buffer -- */
-    ringbuf_alloc(&self->rx_ringbuf, args[ARG_rxbuf].u_int);
+    machine_uart_obj_t *self = *self_ptr;
+
+    /* -- Object allocation -- */
+    bool is_new;
+    bool is_make_obj_required = (*self_ptr == NULL) ? true : false;
+    if (is_make_obj_required) {
+        machine_uart_obj_make_or_reuse(self_ptr, fn_unit, &is_new);
+        self = *self_ptr;
+    }
+
+    /* -- Reinitialization reset -- */
+    /* For reused UART() object or init() path */
+    if (!is_new) {
+        machine_uart_hw_deinit(self);
+        m_del(uint8_t, self->rx_ringbuf.buf, self->rx_ringbuf.size);
+    }
+
+    /* -- UART params init -- */
+    self->tx = uart_pins_af_config[0].pin;
+    self->rx = uart_pins_af_config[1].pin;
+    self->rts = (pin_af_conf_rts_index != PIN_AF_CONFIG_INDEX_NONE) ? uart_pins_af_config[pin_af_conf_rts_index].pin : MP_OBJ_NULL;
+    self->cts = (pin_af_conf_cts_index != PIN_AF_CONFIG_INDEX_NONE) ? uart_pins_af_config[pin_af_conf_cts_index].pin : MP_OBJ_NULL;
+    self->flow = flow;
+    self->baudrate = baudrate;
+    self->bits = bits;
+    self->parity = parity;
+    self->stop = stop;
+    self->timeout_ms = timeout_ms;
+    self->timeout_char_ms = timeout_char_ms;
 
     /* -- IRQ init -- */
     #if MICROPY_PY_MACHINE_UART_IRQ
@@ -501,7 +548,60 @@ static void mp_machine_uart_init_helper(machine_uart_obj_t *self, size_t n_args,
     #endif
 
     /* -- Initialise hardware -- */
-    machine_uart_hw_init(self);
+    nlr_buf_t nlr;
+    if (nlr_push(&nlr) == 0) {
+        ringbuf_alloc(&self->rx_ringbuf, args[ARG_rxbuf].u_int);
+        mp_hal_periph_pins_af_init(uart_pins_af_config, pin_num);
+        machine_uart_baudrate_set(self);
+        machine_uart_hw_init(self);
+        nlr_pop();
+    } else {
+        // Ensure partially-initialized instances are fully released on init failure.
+        machine_uart_hw_deinit(self);
+        m_del(uint8_t, self->rx_ringbuf.buf, self->rx_ringbuf.size);
+        nlr_raise(nlr.ret_val);
+    }
+}
+
+static mp_obj_t mp_machine_uart_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+    mp_arg_check_num(n_args, n_kw, 0, MP_OBJ_FUN_ARGS_MAX, true);
+
+    /**
+     * Only the constructor takes the id.
+     * Its validation together with the rest of the arguments is
+     * delegated to machine_uart_init_implt() which also allocates
+     * the object self = NULL.
+    */
+    int uart_id = MACHINE_PIN_AF_UNIT_NONE;
+    size_t init_n_args = n_args;
+    const mp_obj_t *init_args = args;
+    if (n_args > 0 && mp_obj_is_int(args[0])) {
+        uart_id = mp_obj_get_int(args[0]);
+        if (uart_id < 0 || uart_id >= MICROPY_PY_MACHINE_SCB_NUM_ENTRIES) {
+            mp_raise_ValueError(MP_ERROR_TEXT("UART id out of range"));
+        }
+        init_n_args = n_args - 1;
+        init_args = args + 1;
+    } else if (n_args > 0) {
+        mp_raise_TypeError(MP_ERROR_TEXT("UART id must be an integer"));
+    }
+
+    machine_uart_obj_t *self = NULL;
+    mp_map_t kw_args;
+    mp_map_init_fixed_table(&kw_args, n_kw, args + n_args);
+    machine_uart_init_impl(&self, uart_id, init_n_args, init_args, &kw_args);
+    return MP_OBJ_FROM_PTR(self);
+}
+
+static void mp_machine_uart_deinit(machine_uart_obj_t *self) {
+    machine_uart_hw_deinit(self);
+    m_del(uint8_t, self->rx_ringbuf.buf, self->rx_ringbuf.size);
+    machine_scb_obj_free(self->scb_obj);
+    mp_machine_uart_obj_free(self);
+}
+
+static void mp_machine_uart_init_helper(machine_uart_obj_t *self, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    machine_uart_init_impl(&self, self->id, n_args, pos_args, kw_args);
 }
 
 static mp_int_t mp_machine_uart_any(machine_uart_obj_t *self) {
@@ -621,6 +721,15 @@ static mp_uint_t mp_machine_uart_ioctl(mp_obj_t self_in, mp_uint_t request, uint
         ret = MP_STREAM_ERROR;
     }
     return ret;
+}
+
+void machine_uart_deinit_all() {
+    for (uint8_t i = 0; i < MICROPY_PY_MACHINE_UART_NUM_ENTRIES; i++) {
+        machine_uart_obj_t *self = MP_STATE_PORT(machine_uart_obj[i]);
+        if (self != NULL) {
+            mp_machine_uart_deinit(self);
+        }
+    }
 }
 
 #if MICROPY_PY_MACHINE_UART_IRQ

--- a/ports/psoc-edge/main.c
+++ b/ports/psoc-edge/main.c
@@ -90,6 +90,7 @@ typedef enum {
 
 extern void machine_rtc_init_all(void);
 extern void machine_pin_irq_deinit_all(void);
+extern void machine_uart_deinit_all(void);
 extern void machine_hw_i2c_deinit_all(void);
 extern void machine_spi_deinit_all(void);
 #if MICROPY_PY_MACHINE_SPI_TARGET
@@ -236,6 +237,7 @@ soft_reset:
     mp_printf(&mp_plat_print, "MPY: soft reboot\n");
 
     machine_pin_irq_deinit_all();
+    machine_uart_deinit_all();
     machine_hw_i2c_deinit_all();
     machine_spi_deinit_all();
     #if MICROPY_PY_MACHINE_SPI_TARGET

--- a/ports/psoc-edge/mphalport.c
+++ b/ports/psoc-edge/mphalport.c
@@ -118,7 +118,7 @@ mp_hal_pin_af_obj_t mp_hal_pin_af_find(mp_hal_pin_obj_t pin, machine_pin_af_sign
     mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("Pin '%q' does not support '%s'."), pin->name, machine_pin_af_signal_str[af_signal]);
 }
 
-machine_pin_af_unit_t mp_hal_periph_pins_af_get_af_unit(const mp_hal_pin_af_config_t *periph_pins_config, uint8_t num_pins) {
+machine_pin_af_unit_t mp_hal_periph_pins_af_get_af_unit(const mp_hal_pin_af_config_t *periph_pins_config, uint8_t num_pins, machine_pin_af_fn_t fn) {
     bool found_first_valid_pin = false;
     machine_pin_af_periph_t periph_ptr = NULL;
     uint32_t unit = MACHINE_PIN_AF_UNIT_NONE;
@@ -132,6 +132,9 @@ machine_pin_af_unit_t mp_hal_periph_pins_af_get_af_unit(const mp_hal_pin_af_conf
             unit = pin_cfg->af->unit;
             found_first_valid_pin = true;
         } else {
+            if (pin_cfg->af->fn != fn) {
+                mp_raise_msg(&mp_type_ValueError, MP_ERROR_TEXT("all pins must belong to the same function."));
+            }
             if (pin_cfg->af->periph != periph_ptr) {
                 mp_raise_msg(&mp_type_ValueError, MP_ERROR_TEXT("all pins must belong to the same peripheral."));
             }
@@ -154,7 +157,7 @@ void mp_hal_periph_pins_af_resolve_fn_unit(const mp_hal_pin_af_config_t *periph_
      * any pin AF assigned.
      * Therefore, its AF unit is not yet determined.
      */
-    machine_pin_af_unit_t pin_af_unit = mp_hal_periph_pins_af_get_af_unit(periph_pins_config, pin_num);
+    machine_pin_af_unit_t pin_af_unit = mp_hal_periph_pins_af_get_af_unit(periph_pins_config, pin_num, fn);
 
     /* No pins have been defined. */
     if (pin_af_unit == MACHINE_PIN_AF_UNIT_NONE) {

--- a/ports/psoc-edge/mphalport.c
+++ b/ports/psoc-edge/mphalport.c
@@ -107,7 +107,7 @@ void mp_hal_pin_write(mp_hal_pin_obj_t pin, uint8_t polarity) {
     Cy_GPIO_Write(Cy_GPIO_PortToAddr(pin->port), pin->pin, polarity);
 }
 
-mp_hal_pin_af_obj_t mp_hal_pin_af_find(mp_hal_pin_obj_t pin, uint32_t af_signal) {
+mp_hal_pin_af_obj_t mp_hal_pin_af_find(mp_hal_pin_obj_t pin, machine_pin_af_signal_t af_signal) {
     for (uint8_t i = 0; i < pin->af_num; i++) {
         const machine_pin_af_obj_t *af = &pin->af[i];
         if (af->signal == af_signal) {
@@ -118,18 +118,20 @@ mp_hal_pin_af_obj_t mp_hal_pin_af_find(mp_hal_pin_obj_t pin, uint32_t af_signal)
     mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("Pin '%q' does not support '%s'."), pin->name, machine_pin_af_signal_str[af_signal]);
 }
 
-mp_hal_af_periph_t mp_hal_periph_pins_af_config(const mp_hal_pin_af_config_t *periph_pins_config, uint8_t num_pins) {
-    /**
-     * If there is more than one pin,
-     * validate if all pins share
-     * the same AF peripheral pointer and unit
-     */
-    if (num_pins > 1) {
-        const mp_hal_pin_af_config_t *first_pin_cfg = &periph_pins_config[0];
-        mp_hal_af_periph_t periph_ptr = first_pin_cfg->af->periph;
-        uint32_t unit = first_pin_cfg->af->unit;
-        for (uint8_t i = 1; i < num_pins; i++) {
-            const mp_hal_pin_af_config_t *pin_cfg = &periph_pins_config[i];
+machine_pin_af_unit_t mp_hal_periph_pins_af_get_af_unit(const mp_hal_pin_af_config_t *periph_pins_config, uint8_t num_pins) {
+    bool found_first_valid_pin = false;
+    machine_pin_af_periph_t periph_ptr = NULL;
+    uint32_t unit = MACHINE_PIN_AF_UNIT_NONE;
+    for (uint8_t i = 0; i < num_pins; i++) {
+        const mp_hal_pin_af_config_t *pin_cfg = &periph_pins_config[i];
+        if (pin_cfg->pin == NULL || pin_cfg->af == NULL) {
+            continue;
+        }
+        if (!found_first_valid_pin) {
+            periph_ptr = pin_cfg->af->periph;
+            unit = pin_cfg->af->unit;
+            found_first_valid_pin = true;
+        } else {
             if (pin_cfg->af->periph != periph_ptr) {
                 mp_raise_msg(&mp_type_ValueError, MP_ERROR_TEXT("all pins must belong to the same peripheral."));
             }
@@ -139,6 +141,68 @@ mp_hal_af_periph_t mp_hal_periph_pins_af_config(const mp_hal_pin_af_config_t *pe
         }
     }
 
+    return unit;
+}
+
+void mp_hal_periph_pins_af_resolve_fn_unit(const mp_hal_pin_af_config_t *periph_pins_config, uint8_t pin_num, machine_pin_af_fn_t fn, machine_pin_af_unit_t *fn_unit) {
+    uint8_t resolved_fn_unit;
+    uint8_t suggested_fn_unit = *fn_unit;
+
+    /**
+     * Resolve the AF unit for the provided pins.
+     * It can be that the configuration still don't have
+     * any pin AF assigned.
+     * Therefore, its AF unit is not yet determined.
+     */
+    machine_pin_af_unit_t pin_af_unit = mp_hal_periph_pins_af_get_af_unit(periph_pins_config, pin_num);
+
+    /* No pins have been defined. */
+    if (pin_af_unit == MACHINE_PIN_AF_UNIT_NONE) {
+        /* The suggested AF unit candidate is chosen if defined. */
+        if (suggested_fn_unit != MACHINE_PIN_AF_UNIT_NONE) {
+            resolved_fn_unit = (uint8_t)suggested_fn_unit;
+        } else {
+            mp_raise_ValueError(MP_ERROR_TEXT("no id or pins have been provided. At least one of them must be specified."));
+        }
+    } else {
+        /* The pins have been defined. */
+        /* The suggested AF unit has been also defined.*/
+        if (suggested_fn_unit != MACHINE_PIN_AF_UNIT_NONE) {
+            if (suggested_fn_unit == pin_af_unit) {
+                /* The suggested AF unit matches the AF unit discovered from the passed pins */
+                resolved_fn_unit = (uint8_t)suggested_fn_unit;
+            } else {
+                mp_raise_ValueError(MP_ERROR_TEXT("the id does not match the discovered id from the provided pins."));
+            }
+        } else {
+            /* No suggested AF unit has been passed */
+            resolved_fn_unit = pin_af_unit;
+        }
+    }
+
+    (*fn_unit) = resolved_fn_unit;
+}
+
+void mp_hal_periph_pins_af_resolve_pin_af(mp_hal_pin_af_config_t *periph_pins_config, uint8_t pin_num, machine_pin_af_unit_t fn_unit) {
+    for (uint8_t i = 0; i < pin_num; i++) {
+        if (periph_pins_config[i].af == NULL && periph_pins_config[i].pin == NULL) {
+            periph_pins_config[i].pin = machine_pin_get_af_pin(fn_unit, periph_pins_config[i].signal);
+            if (periph_pins_config[i].pin == NULL) {
+                mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("no signal '%s' available for id %d."), machine_pin_af_signal_str[periph_pins_config[i].signal], fn_unit);
+            }
+            periph_pins_config[i].af = mp_hal_pin_af_find(periph_pins_config[i].pin, periph_pins_config[i].signal);
+        } else {
+            /**
+             * It should not enter here. As this function should
+             * be only called after pin - AF unit matching */
+            if (periph_pins_config[i].af->unit != fn_unit && periph_pins_config[i].pin != NULL) {
+                mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("the pin '%q' does not match the AF unit %d."), periph_pins_config[i].pin->name, fn_unit);
+            }
+        }
+    }
+}
+
+machine_pin_af_periph_t mp_hal_periph_pins_af_init(const mp_hal_pin_af_config_t *periph_pins_config, uint8_t num_pins) {
     for (uint8_t i = 0; i < num_pins; i++) {
         const mp_hal_pin_af_config_t *pin_cfg = &periph_pins_config[i];
         Cy_GPIO_Pin_FastInit(Cy_GPIO_PortToAddr(pin_cfg->pin->port), pin_cfg->pin->pin, pin_cfg->cy_drive_mode, pin_cfg->init_value, pin_cfg->af->idx);

--- a/ports/psoc-edge/mphalport.h
+++ b/ports/psoc-edge/mphalport.h
@@ -84,9 +84,11 @@ uint32_t mp_hal_pin_read(mp_hal_pin_obj_t pin);
 uint32_t mp_hal_pin_get_drive(mp_hal_pin_obj_t pin);
 void mp_hal_pin_set_drive(mp_hal_pin_obj_t pin, uint32_t drive);
 
-#define mp_hal_pin_af_obj_t const machine_pin_af_obj_t *
+/**
+ * HAL Pin AF helper functions and types
+ */
 
-mp_hal_pin_af_obj_t mp_hal_pin_af_find(mp_hal_pin_obj_t pin, uint32_t af_signal);
+#define mp_hal_pin_af_obj_t const machine_pin_af_obj_t *
 
 typedef struct {
     mp_hal_pin_obj_t pin;
@@ -96,23 +98,32 @@ typedef struct {
     mp_hal_pin_af_obj_t af;
 }mp_hal_pin_af_config_t;
 
-#define MP_HAL_PIN_AF_CONF(_pin, _cy_drive_mode, _init_value, _af_signal) { \
+#define MP_HAL_PIN_AF_CONF_INIT(_pin, _cy_drive_mode, _init_value, _af_signal) (mp_hal_pin_af_config_t) { \
         .pin = _pin, \
+        .signal = _af_signal, \
         .cy_drive_mode = _cy_drive_mode, \
         .init_value = _init_value, \
         .af = mp_hal_pin_af_find(_pin, _af_signal) \
 }
 
-#define MP_HAL_PIN_AF_INIT(conf_obj, _pin, _cy_drive_mode, _init_value, _af_signal) \
+#define MP_HAL_PIN_AF_CONF_INIT_GPIO_SIGNAL(_cy_drive_mode, _init_value, _af_signal) (mp_hal_pin_af_config_t) { \
+        .pin = NULL, \
+        .signal = _af_signal, \
+        .cy_drive_mode = _cy_drive_mode, \
+        .init_value = _init_value, \
+        .af = NULL \
+}
+
+#define MP_HAL_PIN_AF_CONF_SET_PIN_AF(conf_obj, _pin) \
     conf_obj.pin = _pin; \
-    conf_obj.cy_drive_mode = _cy_drive_mode; \
-    conf_obj.init_value = _init_value; \
-    conf_obj.af = mp_hal_pin_af_find(_pin, _af_signal);
+    conf_obj.af = mp_hal_pin_af_find(_pin, conf_obj.signal);
 
-typedef void *mp_hal_af_periph_t;
 
-mp_hal_af_periph_t mp_hal_periph_pins_af_config(const mp_hal_pin_af_config_t *periph_pins_config, uint8_t num_pins);
+mp_hal_pin_af_obj_t mp_hal_pin_af_find(mp_hal_pin_obj_t pin, machine_pin_af_signal_t af_signal);
 
 void mp_hal_get_random(size_t n, uint8_t *buf);
+void mp_hal_periph_pins_af_resolve_fn_unit(const mp_hal_pin_af_config_t *periph_pins_config, uint8_t pin_num, machine_pin_af_fn_t fn, machine_pin_af_unit_t *fn_unit);
+void mp_hal_periph_pins_af_resolve_pin_af(mp_hal_pin_af_config_t *periph_pins_config, uint8_t pin_num, machine_pin_af_unit_t fn_unit);
+machine_pin_af_periph_t mp_hal_periph_pins_af_init(const mp_hal_pin_af_config_t *periph_pins_config, uint8_t num_pins);
 
 #endif // MICROPY_INCLUDED_PSOC_EDGE_HALPORT_H


### PR DESCRIPTION
This PR enables `machine.UART` to support construction based on:

- `id` only 
- `pins` only 
- both `id` and `pins`

* The parameters are validated for their availability and compatibility. 
* All pins need to be UART capable, and belong to the same SCB group.
* The `id` matches the SCB group. When both `id` and `pins` are passed, they have to match the same group.
* When only `id` or `pins` are passed, the other objects are discovered automatically. Passing a single UART capable `pin` is sufficient to automatically allocate the other mandatory pin. 
For example, if we pass `tx_pin` only, the SCB group will be resolved and the `rx_pin` will be automatically discovered.
* The constructor can be recalled on the same instance without calling `deinit()`. It will return the existing object instance.

These `id`-`pins` resolve helpers implementation is intended to be reusable for the rest of the `machine` using `Pin` alternate functions with multiple _unit/channels. 

The clock related `machine_scb` parameter are now redundant after the SPI merge. But such clock related features will be moved soon to a new `clk` module.  Which needs to be also resolved to solve the UART clock, which is still pending. 
Also the `machine_scb` will be then renamed.

The changes on the rest of the machine class goes a bit further than a rename. Now the `mp_hal_periph_pins_init()` does not validate that all pins belong to the same `fn_unit`. 
That is done now via `mp_hal_periph_pins_af_resolve_fn_unit()`.
We will refactor in future, if the same `make/init()` behavior is required for the different machine class.  