### PR TITLE
Shared clk

### DIFF
--- a/ports/psoc-edge/Makefile
+++ b/ports/psoc-edge/Makefile
@@ -593,7 +593,6 @@ MOD_SRC_C += \
 	machine_rtc.c \
 	machine_ipc.c \
 	machine_scb.c \
-	tcpwm.c \
 	machine_timer.c \
 	machine_bitstream.c \
 	modpsocedge.c \
@@ -609,11 +608,14 @@ MOD_SRC_C += \
 endif
 
 SRC_C += \
+	clk.c \
 	help.c \
 	main.c \
 	mphalport.c \
 	systick.c \
 	sys_int.c \
+	tcpwm.c \
+
 
 # List of sources for qstr extraction
 SRC_QSTR += $(SRC_C) $(SHARED_SRC_C) $(MOD_SRC_C) $(GEN_PINS_SRC)

--- a/ports/psoc-edge/boards/KIT_PSE84_AI/bsp-cfg/cycfg.c
+++ b/ports/psoc-edge/boards/KIT_PSE84_AI/bsp-cfg/cycfg.c
@@ -36,6 +36,11 @@ void init_cycfg_all(void) {
 }
 void cycfg_config_init(void) {
     init_cycfg_clocks();
+    /**
+     * TODO: Comment init_cycfg_peripheral_clocks()
+     * & init_cycfg_peripherals() out once all machine peripherals
+     * are implemented based on `clk` lib.
+     */
     init_cycfg_peripheral_clocks();
     init_cycfg_system();
     init_cycfg_peripherals();

--- a/ports/psoc-edge/clk.c
+++ b/ports/psoc-edge/clk.c
@@ -1,0 +1,317 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2026 Infineon Technologies AG
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "pse84_config.h"
+#include "cy_device.h"
+#include "cy_sysclk.h"
+#include "py/misc.h"
+#include "py/runtime.h"
+
+#include "clk.h"
+
+#define DEBUG_printf(...) // printf(__VA_ARGS__)
+#define clk_assert_raise_val(msg, ret)   if (ret != CY_SYSCLK_SUCCESS) { \
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT(msg), ret); \
+}
+
+/**
+  * Value extracted from TRM.
+  */
+ #define PERI_PCLK_DIVIDER_MAX_NUM 26
+
+#define CLK_DEST_PERI(clk_dest) ((clk_dest) & PERI_PCLK_PERI_NUM_Msk)
+#define CLK_DEST_GROUP(clk_dest) (((clk_dest) & PERI_PCLK_GR_NUM_Msk) >> PERI_PCLK_GR_NUM_Pos)
+#define CLK_DEST_INST(clk_dest) (((clk_dest) & PERI_PCLK_INST_NUM_Msk) >> PERI_PCLK_INST_NUM_Pos)
+
+#define PCLK_DIV_NO_FREE_DIVIDER 0xFF
+
+typedef struct _pclk_div_obj_t {
+    uint32_t peri_inst;
+    uint32_t group;
+    cy_en_divider_types_t type;
+    uint32_t number;
+    uint32_t value;
+    uint8_t value_frac;
+    uint8_t owner_count;
+} pclk_div_obj_t;
+
+pclk_div_obj_t *pclk_div_obj[PERI_PCLK_DIVIDER_MAX_NUM] = {NULL};
+
+static pclk_div_obj_t *pclk_div_obj_alloc(void) {
+    pclk_div_obj_t *clk = NULL;
+    for (int i = 0; i < PERI_PCLK_DIVIDER_MAX_NUM; i++) {
+        if (pclk_div_obj[i] == NULL) {
+            clk = m_new_obj(pclk_div_obj_t);
+            pclk_div_obj[i] = clk;
+            break;
+        }
+    }
+    return clk;
+}
+
+static void pclk_div_obj_free(pclk_div_obj_t *clk) {
+    for (int i = 0; i < PERI_PCLK_DIVIDER_MAX_NUM; i++) {
+        if (pclk_div_obj[i] == clk) {
+            m_del_obj(pclk_div_obj_t, clk);
+            pclk_div_obj[i] = NULL;
+            break;
+        }
+    }
+}
+
+static pclk_div_obj_t *pclk_div_find(en_clk_dst_t clk_dst, uint32_t divider_value, uint8_t divider_value_frac) {
+    pclk_div_obj_t *clk = NULL;
+    for (int i = 0; i < PERI_PCLK_DIVIDER_MAX_NUM; i++) {
+        if (pclk_div_obj[i] != NULL) {
+            if (pclk_div_obj[i]->value == divider_value &&
+                pclk_div_obj[i]->value_frac == divider_value_frac &&
+                pclk_div_obj[i]->peri_inst == CLK_DEST_INST(clk_dst) &&
+                pclk_div_obj[i]->group == CLK_DEST_GROUP(clk_dst)) {
+                DEBUG_printf("DEBUG: pclk_div_obj found for peri_inst=%u, group=%u, number=%u, divider=%u, divider_frac=%u\n", CLK_DEST_INST(clk_dst), CLK_DEST_GROUP(clk_dst), pclk_div_obj[i]->number, divider_value, divider_value_frac);
+                return pclk_div_obj[i];
+            }
+        }
+    }
+    return clk;
+}
+
+static void pclk_div_share(en_clk_dst_t clk_dst, pclk_div_obj_t *clk) {
+    cy_en_sysclk_status_t ret = Cy_SysClk_PeriphAssignDivider(clk_dst, clk->type, clk->number);
+    clk_assert_raise_val("failed to share divider (PDL err: %lu)", ret);
+    DEBUG_printf("DEBUG: pclk_div_obj shared for dest = %u\n", clk_dst);
+    clk->owner_count++;
+}
+
+static pclk_div_obj_t *pclk_div_new_assign_set_enable(en_clk_dst_t clk_dst, cy_en_divider_types_t div_type, uint32_t div_num, uint32_t divider, uint8_t divider_frac) {
+    uint32_t peri_inst = CLK_DEST_INST(clk_dst);
+    uint32_t group = CLK_DEST_GROUP(clk_dst);
+
+    pclk_div_obj_t *pclk = pclk_div_obj_alloc();
+    if (pclk == NULL) {
+        return NULL;
+    }
+
+    pclk->peri_inst = peri_inst;
+    pclk->group = group;
+    pclk->type = div_type;
+    pclk->number = div_num;
+    pclk->value = divider;
+    pclk->value_frac = divider_frac;
+    pclk->owner_count = 1;
+
+    DEBUG_printf("DEBUG: pclk_div_obj(peri_inst=%u, group=%u, div_type=%u, div_num=%u, divider=%u, divider_frac=%u)\n",
+        peri_inst, group, div_type, div_num, divider, divider_frac);
+
+    cy_en_sysclk_status_t ret = Cy_SysClk_PeriphAssignDivider(clk_dst, div_type, div_num);
+    clk_assert_raise_val("failed to assign divider (PDL err: %lu)", ret);
+
+    if (div_type == CY_SYSCLK_DIV_16_5_BIT || div_type == CY_SYSCLK_DIV_24_5_BIT) {
+        ret = Cy_SysClk_PeriPclkSetFracDivider(clk_dst, div_type, div_num, divider, divider_frac);
+        clk_assert_raise_val("failed to set fractional divider (PDL err: %lu)", ret);
+    } else {
+        ret = Cy_SysClk_PeriPclkSetDivider(clk_dst, div_type, div_num, divider);
+        clk_assert_raise_val("failed to set divider (PDL err: %lu)", ret);
+    }
+    ret = Cy_SysClk_PeriPclkEnableDivider(clk_dst, div_type, div_num);
+    clk_assert_raise_val("failed to enable divider (PDL err: %lu)", ret);
+
+    DEBUG_printf("DEBUG: pclk_div_obj assigned, set, enabled on dest=%u.\n", clk_dst);
+
+    return pclk;
+}
+
+static cy_en_divider_types_t pclk_div_get_type(uint32_t divider, uint8_t divider_frac) {
+    /* If fractional part is needed, use fractional divider types */
+    if (divider_frac != 0) {
+        if (divider <= 0xFFFFU) {
+            return CY_SYSCLK_DIV_16_5_BIT;
+        } else {
+            return CY_SYSCLK_DIV_24_5_BIT;
+        }
+    }
+
+    /* No fractional part needed, use integer dividers */
+    if (divider <= 0xFFU) {
+        return CY_SYSCLK_DIV_8_BIT;
+    } else if (divider <= 0xFFFFU) {
+        return CY_SYSCLK_DIV_16_BIT;
+    } else {
+        return CY_SYSCLK_DIV_24_5_BIT;
+    }
+}
+
+static uint8_t  pclk_div_get_max_num_for_peri_group(en_clk_dst_t clk_dst, cy_en_divider_types_t div_type) {
+    uint32_t peri_inst = CLK_DEST_INST(clk_dst);
+    uint32_t group_num = CLK_DEST_GROUP(clk_dst);
+    uint8_t max_num = 0;
+
+    if (div_type == CY_SYSCLK_DIV_8_BIT) {
+        max_num = PERI_PCLK_GR_DIV_8_NR(peri_inst, group_num);
+    } else if (div_type == CY_SYSCLK_DIV_16_BIT) {
+        max_num = PERI_PCLK_GR_DIV_16_NR(peri_inst, group_num);
+    } else if (div_type == CY_SYSCLK_DIV_16_5_BIT) {
+        max_num = PERI_PCLK_GR_DIV_16_5_NR(peri_inst, group_num);
+    } else if (div_type == CY_SYSCLK_DIV_24_5_BIT) {
+        max_num = PERI_PCLK_GR_DIV_24_5_NR(peri_inst, group_num);
+    }
+
+    return max_num;
+}
+
+static uint8_t pclk_div_get_free_num(en_clk_dst_t clk_dst, cy_en_divider_types_t div_type) {
+    uint8_t peri_gr_div_max_num = pclk_div_get_max_num_for_peri_group(clk_dst, div_type);
+
+    for (uint8_t i = 0; i < peri_gr_div_max_num; i++) {
+        bool used = false;
+        for (uint8_t j = 0; j < PERI_PCLK_DIVIDER_MAX_NUM; j++) {
+            if (pclk_div_obj[j] != NULL) {
+                if (pclk_div_obj[j]->peri_inst == CLK_DEST_INST(clk_dst) &&
+                    pclk_div_obj[j]->group == CLK_DEST_GROUP(clk_dst) &&
+                    pclk_div_obj[j]->type == div_type &&
+                    pclk_div_obj[j]->number == i) {
+                    used = true;
+                    break;
+                }
+            }
+        }
+        if (!used) {
+            return i;
+        }
+    }
+
+    return PCLK_DIV_NO_FREE_DIVIDER;
+}
+
+/******************************************************************************/
+/** -- Peripheral Clock Divider API -- **/
+
+void pclk_div_slave_init(en_clk_dst_t clk_dst, pclk_mmio_slave_num_t clk_slave_num) {
+    uint32_t peri_inst = CLK_DEST_INST(clk_dst);
+    uint32_t group = CLK_DEST_GROUP(clk_dst);
+    if (!Cy_SysClk_IsPeriGroupSlaveEnabled(peri_inst, group, clk_slave_num)) {
+        Cy_SysClk_PeriGroupSlaveInit(peri_inst, group, clk_slave_num, Cy_Sysclk_PeriPclkGetClkHfNum(clk_dst));
+    }
+}
+
+void pclk_div_slave_deinit(en_clk_dst_t clk_dst, pclk_mmio_slave_num_t clk_slave_num) {
+    uint32_t peri_inst = CLK_DEST_INST(clk_dst);
+    uint32_t group = CLK_DEST_GROUP(clk_dst);
+    if (Cy_SysClk_IsPeriGroupSlaveEnabled(peri_inst, group, clk_slave_num)) {
+        Cy_SysClk_PeriGroupSlaveDeinit(peri_inst, group, clk_slave_num);
+    }
+}
+
+uint32_t pclk_div_get_input_freq(en_clk_dst_t clk_dst) {
+    uint32_t hf_clk_source = Cy_Sysclk_PeriPclkGetClkHfNum(clk_dst);
+
+    if (!Cy_SysClk_ClkHfIsEnabled(hf_clk_source)) {
+        /**
+         * TODO:
+         * Currently all this is initialized in "cycfg_clocks.c".
+         * Therefore, we assume that this is initialized and enabled.
+         * In the future, maybe the clock management is exposed to
+         * the user.
+         */
+        return 0;
+    }
+
+    return Cy_SysClk_ClkHfGetFrequency(hf_clk_source);
+}
+
+pclk_div_obj_t *pclk_div_init(en_clk_dst_t clk_dst, uint32_t divider, uint8_t divider_frac) {
+    pclk_div_obj_t *pclk = NULL;
+
+    /**
+     * Look for an existing peripheral clock divider
+     * which could be reused.
+     * If found, share it with the caller.
+     */
+    pclk = pclk_div_find(clk_dst, divider, divider_frac);
+    if (pclk != NULL) {
+        pclk_div_share(clk_dst, pclk);
+        return pclk;
+    }
+
+    /* Get the required divider type base on its value + fractional value */
+    cy_en_divider_types_t div_type = pclk_div_get_type(divider, divider_frac);
+
+    /* Get the a free peri-group divider number*/
+    uint8_t div_num = pclk_div_get_free_num(clk_dst, div_type);
+    if (div_num == PCLK_DIV_NO_FREE_DIVIDER) {
+        return NULL;
+    }
+
+    return pclk_div_new_assign_set_enable(clk_dst, div_type, div_num, divider, divider_frac);
+}
+
+void pclk_div_deinit(pclk_div_obj_t *clk) {
+    if (clk == NULL) {
+        return;
+    }
+
+    clk->owner_count--;
+
+    /* Still in use by other peripherals */
+    if (clk->owner_count > 0) {
+        return;
+    }
+
+    uint32_t ip_block = (clk->peri_inst << PERI_PCLK_INST_NUM_Pos) | (clk->group << PERI_PCLK_GR_NUM_Pos);
+    cy_en_sysclk_status_t ret = Cy_SysClk_PeriPclkDisableDivider(ip_block, clk->type, clk->number);
+    clk_assert_raise_val("failed to disable divider (PDL err: %lu)", ret);
+    DEBUG_printf("DEBUG: pclk_div_obj disabled for peri_inst=%u, group=%u, div_type=%u, div_num=%u\n", clk->peri_inst, clk->group, clk->type, clk->number);
+
+    pclk_div_obj_free(clk);
+}
+
+
+/******************************************************************************/
+/** -- Static PCLK Divider instance enablement for REPL UART-- **/
+
+/**
+ * TODO: This needs to be reviewed when we reuse machine_uart static object
+ * for REPL.
+ */
+static pclk_div_obj_t pclk_div_obj_repl_uart;
+void pclk_div_repl_uart_init(void) {
+    pclk_div_obj_t *pclk = &pclk_div_obj_repl_uart;
+    pclk->group = CLK_DEST_GROUP(PCLK_SCB2_CLOCK_SCB_EN);
+    pclk->peri_inst = CLK_DEST_INST(PCLK_SCB2_CLOCK_SCB_EN);
+    pclk->type = CY_SYSCLK_DIV_8_BIT;
+    pclk->number = 0;
+    pclk->value = 86U; // From retarget-io: floor(10000000/(115200*10)) - 1 = 86
+    pclk->value_frac = 0;
+    pclk->owner_count = 1;
+
+    pclk_div_obj[0] = pclk;
+
+    Cy_SysClk_PeriGroupSlaveInit(CY_MMIO_SCB2_PERI_NR, CY_MMIO_SCB2_GROUP_NR, CY_MMIO_SCB2_SLAVE_NR, CY_MMIO_SCB2_CLK_HF_NR);
+    Cy_SysClk_PeriPclkAssignDivider(PCLK_SCB2_CLOCK_SCB_EN, CY_SYSCLK_DIV_8_BIT, 0U);
+
+    uint32_t ip_block = (pclk->peri_inst << PERI_PCLK_INST_NUM_Pos) | (pclk->group << PERI_PCLK_GR_NUM_Pos);
+    Cy_SysClk_PeriPclkSetDivider(ip_block, CY_SYSCLK_DIV_8_BIT, 0U, 86U);
+    Cy_SysClk_PeriPclkEnableDivider(ip_block, CY_SYSCLK_DIV_8_BIT, 0U);
+}

--- a/ports/psoc-edge/clk.c
+++ b/ports/psoc-edge/clk.c
@@ -58,7 +58,7 @@ typedef struct _pclk_div_obj_t {
     uint8_t owner_count;
 } pclk_div_obj_t;
 
-pclk_div_obj_t *pclk_div_obj[PERI_PCLK_DIVIDER_MAX_NUM] = {NULL};
+static pclk_div_obj_t *pclk_div_obj[PERI_PCLK_DIVIDER_MAX_NUM] = {NULL};
 
 static pclk_div_obj_t *pclk_div_obj_alloc(void) {
     pclk_div_obj_t *clk = NULL;

--- a/ports/psoc-edge/clk.h
+++ b/ports/psoc-edge/clk.h
@@ -1,0 +1,42 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2026 Infineon Technologies AG
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef MICROPY_INCLUDED_PSOC_EDGE_CLK_H
+#define MICROPY_INCLUDED_PSOC_EDGE_CLK_H
+
+/* Forward declare pclk_div_obj_t */
+typedef struct _pclk_div_obj_t pclk_div_obj_t;
+
+typedef uint32_t pclk_mmio_slave_num_t;
+
+void pclk_div_slave_init(en_clk_dst_t clk_dst, pclk_mmio_slave_num_t clk_slave_num);
+void pclk_div_slave_deinit(en_clk_dst_t clk_dst, pclk_mmio_slave_num_t clk_slave_num);
+
+uint32_t pclk_div_get_input_freq(en_clk_dst_t clk_dst);
+pclk_div_obj_t *pclk_div_init(en_clk_dst_t clk_dst, uint32_t divider, uint8_t divider_frac);
+void pclk_div_deinit(pclk_div_obj_t *clk);
+
+#endif // MICROPY_INCLUDED_PSOC_EDGE_CLK_H

--- a/ports/psoc-edge/machine_uart.c
+++ b/ports/psoc-edge/machine_uart.c
@@ -49,6 +49,7 @@
 #include "mphalport.h"
 #include "machine_scb.h"
 #include "sys_int.h"
+#include "clk.h"
 
 /******************************************************************************/
 // Defaults and constants
@@ -76,6 +77,7 @@ typedef struct _machine_uart_obj_t {
     mp_obj_base_t base;
     int id;                         // id matches the SCB id.
     machine_scb_obj_t *scb_obj;
+    pclk_div_obj_t *pclk_div;
     mp_hal_pin_obj_t tx;
     mp_hal_pin_obj_t rx;
     mp_hal_pin_obj_t rts;
@@ -209,7 +211,9 @@ static void machine_uart_obj_make_or_reuse(machine_uart_obj_t **self_ptr, uint8_
         if (machine_scb_is_free(id)) {
             (*self_ptr) = mp_machine_uart_obj_alloc();
             (*self_ptr)->id = id;
+            (*self_ptr)->pclk_div = NULL;
             (*self_ptr)->scb_obj = machine_scb_obj_alloc(id, *self_ptr, machine_uart_scb_isr);
+            pclk_div_slave_init((*self_ptr)->scb_obj->clk, (*self_ptr)->scb_obj->slave_nr);
         } else {
             mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("SCB %u is already in use by a machine.I2C or machine.SPI instance."), id);
         }
@@ -217,21 +221,7 @@ static void machine_uart_obj_make_or_reuse(machine_uart_obj_t **self_ptr, uint8_
     }
 }
 
-static void machine_uart_baudrate_set(machine_uart_obj_t *self) {
-    /**
-     * TODO: Review clock configuration and formula to calculate the divider value.
-     *       Clock sources, path and proper divider configuration.
-     * Given the clock peripheral = 100 MHz
-     * Oversampling = 12 (fixed for now)
-     * The formula to calculate the divider value is: divider = clock / (baudrate * oversample)
-     */
-    #define CLOCK_PERIPHERAL_FREQ_HZ (100000000UL)
-
-    Cy_SysClk_PeriphAssignDivider(self->scb_obj->clk, CY_SYSCLK_DIV_16_BIT, 0UL);
-    uint32_t divider = CLOCK_PERIPHERAL_FREQ_HZ / (self->baudrate * 12UL);
-    Cy_SysClk_PeriphSetDivider(CY_SYSCLK_DIV_16_BIT, 0UL, divider);
-    Cy_SysClk_PeriphEnableDivider(CY_SYSCLK_DIV_16_BIT, 0UL);
-}
+#define MACHINER_UART_OVERSAMPLING (12UL)
 
 static inline uint8_t machine_uart_break_width(machine_uart_obj_t *self) {
     return 1 +  // Start bit
@@ -239,6 +229,28 @@ static inline uint8_t machine_uart_break_width(machine_uart_obj_t *self) {
            (self->parity != CY_SCB_UART_PARITY_NONE ? 1 : 0) +
            (self->stop == CY_SCB_UART_STOP_BITS_1 ? 1 : 2) +
            1; // Extra bit, make the frame longer
+}
+
+static uint32_t machine_uart_baudrate_get_divider(machine_uart_obj_t *self) {
+    uint32_t clock_freq = pclk_div_get_input_freq(self->scb_obj->clk);
+    if (clock_freq == 0) {
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("failed to get clock frequency for UART(%u)"), self->id);
+    }
+
+    uint32_t divider = (uint32_t)(clock_freq / (self->baudrate * MACHINER_UART_OVERSAMPLING));
+    /*
+     * No fractional divider should be required:
+     * Experimentally:
+     * - baud rates 2400, 4800, 9600, 19200 bps:
+     *   The error between the actual baud rate
+     *   and the requested is < 1% for 16 bits divider
+     * - baud rates 115200, 230400, 460800 bps:
+     *   The error between the actual baud rate and
+     *   the requested is < 1% for 8 bits divider
+     *
+     */
+
+    return divider;
 }
 
 static void machine_uart_hw_init(machine_uart_obj_t *self) {
@@ -250,7 +262,7 @@ static void machine_uart_hw_init(machine_uart_obj_t *self) {
         .irdaInvertRx = false,
         .irdaEnableLowPowerReceiver = false,
 
-        .oversample = 12UL,
+        .oversample = MACHINER_UART_OVERSAMPLING,
 
         .enableMsbFirst = false,
         .dataWidth = self->bits,
@@ -279,6 +291,12 @@ static void machine_uart_hw_init(machine_uart_obj_t *self) {
         .txFifoIntEnableMask = 0UL,
     };
 
+    uint32_t divider = machine_uart_baudrate_get_divider(self);
+    self->pclk_div = pclk_div_init(self->scb_obj->clk, divider, 0);
+    if (self->pclk_div == NULL) {
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("failed to initialize clock divider for UART(%u)"), self->id);
+    }
+
     cy_en_scb_uart_status_t rslt = Cy_SCB_UART_Init(self->scb_obj->scb, &config, &self->ctx);
     uart_assert_raise_val("failed to initialize UART hardware, error code: %d", rslt);
 
@@ -291,6 +309,8 @@ static void machine_uart_hw_init(machine_uart_obj_t *self) {
 static void machine_uart_hw_deinit(machine_uart_obj_t *self) {
     Cy_SCB_UART_Disable(self->scb_obj->scb, &self->ctx);
     sys_int_deinit(&self->scb_obj->irq);
+    pclk_div_deinit(self->pclk_div);
+    self->pclk_div = NULL;
 }
 
 static bool machine_uart_rx_wait(machine_uart_obj_t *self, uint32_t timeout_ms) {
@@ -552,7 +572,6 @@ static void machine_uart_init_impl(machine_uart_obj_t **self_ptr, int uart_id, s
     if (nlr_push(&nlr) == 0) {
         ringbuf_alloc(&self->rx_ringbuf, args[ARG_rxbuf].u_int);
         mp_hal_periph_pins_af_init(uart_pins_af_config, pin_num);
-        machine_uart_baudrate_set(self);
         machine_uart_hw_init(self);
         nlr_pop();
     } else {
@@ -596,6 +615,7 @@ static mp_obj_t mp_machine_uart_make_new(const mp_obj_type_t *type, size_t n_arg
 static void mp_machine_uart_deinit(machine_uart_obj_t *self) {
     machine_uart_hw_deinit(self);
     m_del(uint8_t, self->rx_ringbuf.buf, self->rx_ringbuf.size);
+    pclk_div_slave_deinit(self->scb_obj->clk, self->scb_obj->slave_nr);
     machine_scb_obj_free(self->scb_obj);
     mp_machine_uart_obj_free(self);
 }

--- a/ports/psoc-edge/machine_uart.c
+++ b/ports/psoc-edge/machine_uart.c
@@ -221,7 +221,7 @@ static void machine_uart_obj_make_or_reuse(machine_uart_obj_t **self_ptr, uint8_
     }
 }
 
-#define MACHINER_UART_OVERSAMPLING (12UL)
+#define MACHINE_UART_OVERSAMPLING (12UL)
 
 static inline uint8_t machine_uart_break_width(machine_uart_obj_t *self) {
     return 1 +  // Start bit
@@ -237,7 +237,7 @@ static uint32_t machine_uart_baudrate_get_divider(machine_uart_obj_t *self) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("failed to get clock frequency for UART(%u)"), self->id);
     }
 
-    uint32_t divider = (uint32_t)(clock_freq / (self->baudrate * MACHINER_UART_OVERSAMPLING));
+    uint32_t divider = (uint32_t)(clock_freq / (self->baudrate * MACHINE_UART_OVERSAMPLING));
     /*
      * No fractional divider should be required:
      * Experimentally:
@@ -262,7 +262,7 @@ static void machine_uart_hw_init(machine_uart_obj_t *self) {
         .irdaInvertRx = false,
         .irdaEnableLowPowerReceiver = false,
 
-        .oversample = MACHINER_UART_OVERSAMPLING,
+        .oversample = MACHINE_UART_OVERSAMPLING,
 
         .enableMsbFirst = false,
         .dataWidth = self->bits,
@@ -343,12 +343,14 @@ static bool machine_uart_tx_wait(machine_uart_obj_t *self, uint32_t timeout_ms) 
 
 static void mp_machine_uart_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     machine_uart_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_printf(print, "UART(tx="MP_HAL_PIN_FMT ", "
+    mp_printf(print, "UART(id=%u, "
+        "tx="MP_HAL_PIN_FMT ", "
         "rx="MP_HAL_PIN_FMT ", "
         "baudrate=%ld, "
         "bits=%u, "
         "parity=%u, "
         "stop=%u, ",
+        self->id,
         mp_hal_pin_name(self->tx),
         mp_hal_pin_name(self->rx),
         self->baudrate,

--- a/ports/psoc-edge/main.c
+++ b/ports/psoc-edge/main.c
@@ -102,6 +102,12 @@ extern void mp_hal_ticks_init(void);
 extern void machine_timer_deinit_all(void);
 extern void machine_wdt_deinit(void);
 
+/**
+ * TODO: This will later directly handled by
+ * the static machine_uart REPL UART instance.
+ */
+extern void pclk_div_repl_uart_init(void);
+
 void micropython_task(void *arg);
 #if MICROPY_PY_FREERTOS
 static TaskHandle_t mpy_task_handle;
@@ -150,6 +156,10 @@ int main(void) {
     __enable_irq();
 
     /* Initialize retarget-io middleware */
+    /**
+     * TODO: Enable once not relying on bsp initialization
+     * pclk_div_repl_uart_init();
+     */
     init_retarget_io();
 
     #if MICROPY_PY_FREERTOS


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant,
     especially links to open issues. -->

Peripheral clocks dividers are now handled by a reusable library. 
In this PR only  `machine.UART` is using it. 
I will open a new PR updating the rest of the `machine.xxx` modules. 

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this section empty then your Pull Request may be closed. -->

As you can see here (with DEBUG enabled) now I can instantiate the UART class 
with different baud rates (on the same instance even), and it will handle the whole peripheral clock divider setup. 
It will reuse an existing if it can be reused (i.e. Two UART instances with the same baud rate):

```
>>> MicroPython v1.29.0-preview.1018.gd32752ff98.dirty on 2026-06-23; KIT_PSE84_AI with PSOCE84                                    
Type "help()" for more information.                                                                                                
>>> from machine import UART                                                                                                       
>>> uart = UART(5)                                                                                                                 
DEBUG: pclk_div_obj found for peri_inst=0, group=1, number=3, divider=72, divider_frac=0                                           
DEBUG: pclk_div_obj shared for dest = 260                                                                                          
>>> uart.deinit()                                                                                                                  
>>> uart = UART(5, baudrate=9600)                                                                                                  
DEBUG: pclk_div_obj(peri_inst=0, group=1, div_type=1, div_num=0, divider=868, divider_frac=0)                                      
DEBUG: pclk_div_obj assigned, set, enabled on dest=260.                                                                            
>>> uart2 = UART(7, baudrate=9600)                                                                                                 
DEBUG: pclk_div_obj found for peri_inst=0, group=1, number=0, divider=868, divider_frac=0                                          
DEBUG: pclk_div_obj shared for dest = 262                                                                                          
>>> uart2.deinit()                                                                                                                 
>>> uart.deinit()                                                                                                                  
DEBUG: pclk_div_obj disabled for peri_inst=0, group=1, div_type=1, div_num=0
```

Also you can see that the `pclk_div_obj` is only disabled after no `machine` instance longer requires it. After the second instance `deinit()`.

### Trade-offs and Alternatives

<!-- If the Pull Request has some negative impact (i.e. increased code size)
     then please explain why you think the trade-off improvement is worth it.
     If you can think of alternative ways to do this, please explain that here too.

     Delete this heading if not relevant (i.e. small fixes) -->


### Generative AI

<!-- Please delete the answer below which doesn't apply, or write your own
     answer with more details. -->

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.

<!-- We require everyone to answer this question. If you delete this section or
     ignore it then your PR may be closed.

     For more information, consult the MicroPython Generative AI Policy:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines#generative-ai-policy
     -->
