### PR TITLE
Clk+uart pr improvements

### DIFF
--- a/ports/psoc-edge/Makefile
+++ b/ports/psoc-edge/Makefile
@@ -551,6 +551,10 @@ LDFLAGS += -Wl,--defsym=__GcHeapStart=__HeapBase+$(MICROPY_C_HEAP_SIZE)
 LDFLAGS += -Wl,--defsym=__GcHeapEnd=__HeapLimit
 endif
 
+# Increase the default stack size from (4 KB) to (16 KB).
+APP_MSP_STACK_SIZE ?= 0x4000
+LDFLAGS +=-Wl,--defsym=APP_MSP_STACK_SIZE=$(APP_MSP_STACK_SIZE) \
+
 LIBS += -lm
 
 # PSOC Edge uses Cortex-M33 and Cortex-M55 (ARMv8-M architecture)

--- a/ports/psoc-edge/machine_pin_af.c
+++ b/ports/psoc-edge/machine_pin_af.c
@@ -26,6 +26,15 @@
 
 #include "machine_pin_af.h"
 
+const char *machine_pin_af_fn_str[] = {
+    [MACHINE_PIN_AF_FN_I2C] = "I2C",
+    [MACHINE_PIN_AF_FN_SPI] = "SPI",
+    [MACHINE_PIN_AF_FN_UART] = "UART",
+    [MACHINE_PIN_AF_FN_PDM] = "PDM",
+    [MACHINE_PIN_AF_FN_TCPWM] = "TCPWM",
+    /* TODO: Add additional functionalities */
+};
+
 const char *machine_pin_af_signal_str[] = {
     [MACHINE_PIN_AF_SIGNAL_I2C_SDA] = "I2C_SDA",
     [MACHINE_PIN_AF_SIGNAL_I2C_SCL] = "I2C_SCL",

--- a/ports/psoc-edge/machine_uart.c
+++ b/ports/psoc-edge/machine_uart.c
@@ -34,7 +34,6 @@
 #include "cybsp.h"
 #include "cy_scb_uart.h"
 #include "cy_scb_common.h"
-#include "cy_sysclk.h"
 
 // MicroPython includes
 #include "py/ringbuf.h"
@@ -42,6 +41,7 @@
 #include "py/mperrno.h"
 #include "py/nlr.h"
 #include "py/stream.h"
+#include "py/misc.h"
 
 // Port-specific includes
 #include "genhdr/pins_af.h"
@@ -58,14 +58,21 @@
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT(msg), ret); \
 }
 
+/**
+ * Integer ceil conversion from microseconds to milliseconds.
+ * (us + 999) / 1000 == ceil(us / 1000), so sub-ms durations do not become 0 ms.
+ */
+#define us_to_ms_ceil(us) (((us) + 999ULL) / 1000ULL)
+
 // Flow control macros not part of PSOC Edge PDL
 #define UART_FLOW_CONTROL_NONE    (0)
 #define UART_FLOW_CONTROL_RTS     (1)
 #define UART_FLOW_CONTROL_CTS     (2)
+#define UART_IRQ_RXIDLE           (CY_SCB_RX_INTR_NOT_EMPTY)
 
 // Class-level constants exposed to Python
 #define MICROPY_PY_MACHINE_UART_CLASS_CONSTANTS \
-    { MP_ROM_QSTR(MP_QSTR_IRQ_RXIDLE), MP_ROM_INT(CY_SCB_RX_INTR_NOT_EMPTY) }, \
+    { MP_ROM_QSTR(MP_QSTR_IRQ_RXIDLE), MP_ROM_INT(UART_IRQ_RXIDLE) }, \
     { MP_ROM_QSTR(MP_QSTR_IRQ_BREAK), MP_ROM_INT(CY_SCB_RX_INTR_UART_BREAK_DETECT) }, \
     { MP_ROM_QSTR(MP_QSTR_IRQ_TXIDLE), MP_ROM_INT(CY_SCB_TX_INTR_UART_DONE) }, \
     { MP_ROM_QSTR(MP_QSTR_RTS), MP_ROM_INT(UART_FLOW_CONTROL_RTS) }, \
@@ -85,7 +92,7 @@ typedef struct _machine_uart_obj_t {
     uint32_t baudrate;
     uint32_t flow;
     uint8_t bits;
-    uint8_t parity;
+    mp_obj_t parity;
     uint8_t stop;
     uint32_t timeout_ms;
     uint32_t timeout_char_ms;
@@ -95,6 +102,8 @@ typedef struct _machine_uart_obj_t {
     uint32_t mp_irq_trigger;
     uint32_t mp_irq_flags;
     mp_irq_obj_t *mp_irq_obj;
+    bool rx_idle_irq_pending;
+    uint32_t rx_idle_timeout;
     #endif
 } machine_uart_obj_t;
 
@@ -159,9 +168,6 @@ static void machine_uart_fill_rx_ring_buff(machine_uart_obj_t *self) {
 
 static void machine_uart_scb_isr(mp_obj_t hw_uart_obj) {
     machine_uart_obj_t *self = MP_OBJ_TO_PTR(hw_uart_obj);
-    #if MICROPY_PY_MACHINE_UART_IRQ
-    self->mp_irq_flags = 0; // Clear flags at the beginning of the ISR.
-    #endif
 
     if (0UL != (CY_SCB_RX_INTR & Cy_SCB_GetInterruptCause(self->scb_obj->scb))) {
         if (0UL != (CY_SCB_RX_INTR_NOT_EMPTY & Cy_SCB_GetRxInterruptStatusMasked(self->scb_obj->scb))) {
@@ -226,12 +232,24 @@ static void machine_uart_obj_make_or_reuse(machine_uart_obj_t **self_ptr, uint8_
 static inline uint8_t machine_uart_break_width(machine_uart_obj_t *self) {
     return 1 +  // Start bit
            self->bits +
-           (self->parity != CY_SCB_UART_PARITY_NONE ? 1 : 0) +
-           (self->stop == CY_SCB_UART_STOP_BITS_1 ? 1 : 2) +
+           (self->parity != mp_const_none ? 1 : 0) +
+           (self->stop) +
            1; // Extra bit, make the frame longer
 }
 
-static uint32_t machine_uart_baudrate_get_divider(machine_uart_obj_t *self) {
+static inline uint32_t machine_uart_frame_time_us(machine_uart_obj_t *self) {
+    /**
+     * Integer ceil division:
+     * (num + den - 1) / den == ceil(num / den).
+     * Here it computes ceil((bits_per_frame * 1e6) / baudrate), so frame time does
+     * not round down too aggressively when baudrate is high.
+     */
+    uint32_t bits_per_frame = machine_uart_break_width(self) - 1;
+    uint64_t num = (uint64_t)bits_per_frame * 1000000ULL;
+    return (uint32_t)((num + self->baudrate - 1) / self->baudrate);
+}
+
+static inline uint32_t machine_uart_baudrate_get_divider(machine_uart_obj_t *self) {
     uint32_t clock_freq = pclk_div_get_input_freq(self->scb_obj->clk);
     if (clock_freq == 0) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("failed to get clock frequency for UART(%u)"), self->id);
@@ -253,6 +271,51 @@ static uint32_t machine_uart_baudrate_get_divider(machine_uart_obj_t *self) {
     return divider;
 }
 
+static inline cy_en_scb_uart_parity_t machine_uart_get_pdl_parity(mp_obj_t parity) {
+    if (parity == mp_const_none) {
+        return CY_SCB_UART_PARITY_NONE;
+    }
+    switch (mp_obj_get_int(parity)) {
+        case 0:
+            return CY_SCB_UART_PARITY_EVEN;
+        case 1:
+            return CY_SCB_UART_PARITY_ODD;
+    }
+
+    return CY_SCB_UART_PARITY_NONE;
+}
+
+static inline char *machine_uart_get_parity_str(mp_obj_t parity) {
+    static char *parity_str[] = {
+        "0",
+        "1",
+        "None"
+    };
+
+    if (parity == mp_const_none) {
+        return parity_str[2];
+    }
+    switch (mp_obj_get_int(parity)) {
+        case 0:
+            return parity_str[0];
+        case 1:
+            return parity_str[1];
+    }
+
+    return parity_str[2];
+}
+
+static inline cy_en_scb_uart_stop_bits_t machine_uart_get_pdl_stop(uint8_t stop) {
+    switch (stop) {
+        case 1:
+            return CY_SCB_UART_STOP_BITS_1;
+        case 2:
+            return CY_SCB_UART_STOP_BITS_2;
+    }
+
+    return CY_SCB_UART_STOP_BITS_1;
+}
+
 static void machine_uart_hw_init(machine_uart_obj_t *self) {
     cy_stc_scb_uart_config_t config =
     {
@@ -266,8 +329,8 @@ static void machine_uart_hw_init(machine_uart_obj_t *self) {
 
         .enableMsbFirst = false,
         .dataWidth = self->bits,
-        .parity = self->parity,
-        .stopBits = self->stop,
+        .parity = machine_uart_get_pdl_parity(self->parity),
+        .stopBits = machine_uart_get_pdl_stop(self->stop),
         .enableInputFilter = false,
         .breakWidth = machine_uart_break_width(self),
         .dropOnFrameError = false,
@@ -348,14 +411,14 @@ static void mp_machine_uart_print(const mp_print_t *print, mp_obj_t self_in, mp_
         "rx="MP_HAL_PIN_FMT ", "
         "baudrate=%ld, "
         "bits=%u, "
-        "parity=%u, "
+        "parity=%s, "
         "stop=%u, ",
         self->id,
         mp_hal_pin_name(self->tx),
         mp_hal_pin_name(self->rx),
         self->baudrate,
         self->bits,
-        self->parity,
+        machine_uart_get_parity_str(self->parity),
         self->stop
         );
 
@@ -490,29 +553,17 @@ static void machine_uart_init_impl(machine_uart_obj_t **self_ptr, int uart_id, s
     }
 
     /* -- Parity -- */
-    mp_obj_t parity_arg = args[ARG_parity].u_obj;
-    uint8_t parity;
-    if (parity_arg == mp_const_none) {
-        parity = (uint8_t)CY_SCB_UART_PARITY_NONE;
-    } else {
-        int p = mp_obj_get_int(parity_arg);
-        if (p == 0) {
-            parity = (uint8_t)CY_SCB_UART_PARITY_EVEN;
-        } else if (p == 1) {
-            parity = (uint8_t)CY_SCB_UART_PARITY_ODD;
-        } else {
+    mp_obj_t parity = args[ARG_parity].u_obj;
+    if (parity != mp_const_none) {
+        int p = mp_obj_get_int(parity);
+        if (p != 0 && p != 1) {
             mp_raise_ValueError(MP_ERROR_TEXT("parity must be None, 0 (even) or 1 (odd)"));
         }
     }
 
     /* -- Stop bits -- */
-    int stop_arg = args[ARG_stop].u_int;
-    uint8_t stop;
-    if (stop_arg == 1) {
-        stop = (uint8_t)CY_SCB_UART_STOP_BITS_1;
-    } else if (stop_arg == 2) {
-        stop = (uint8_t)CY_SCB_UART_STOP_BITS_2;
-    } else {
+    uint8_t stop = args[ARG_stop].u_int;
+    if (stop != 1 && stop != 2) {
         mp_raise_ValueError(MP_ERROR_TEXT("stop bits must be 1 or 2"));
     }
 
@@ -567,6 +618,8 @@ static void machine_uart_init_impl(machine_uart_obj_t **self_ptr, int uart_id, s
     self->mp_irq_obj = NULL;
     self->mp_irq_trigger = 0;
     self->mp_irq_flags = 0;
+    self->rx_idle_irq_pending = false;
+    self->rx_idle_timeout = 0;
     #endif
 
     /* -- Initialise hardware -- */
@@ -719,17 +772,14 @@ static mp_uint_t mp_machine_uart_ioctl(mp_obj_t self_in, mp_uint_t request, uint
         }
     } else if (request == MP_STREAM_FLUSH) {
         /**
-         * Estimate the time required to shift out all remaining bytes from the TX hardware pipeline.
-         * Cy_SCB_UART_GetNumInTxFifo() returns the exact byte count in the TX FIFO but explicitly
-         * excludes the TX shifter register (1 byte). Adding 1 accounts for that shifter. The sum is
-         * multiplied by 13 bits per symbol (1 start + 8 data + 2 stop, 1 parity), and multiplied by 2
-         * (for safety margin) and divided by the baudrate to get the duration in milliseconds.
-         * uint32_t is sufficient: max FIFO is < 256 bytes, so the worst-case duration is well within
-         * the uint32_t range even at the lowest supported baud rates.
+         * Calculate the timeout based on the number of TX FIFO frame
+         * left (+ some margin) and the frame time.
+         * This is to avoid waiting too long for the flush to complete.
          */
-        uint32_t timeout = mp_hal_ticks_ms() + (1
-            + Cy_SCB_UART_GetNumInTxFifo(self->scb_obj->scb)
-            ) * 13000 * 2 / self->baudrate;
+        #define MACHINE_UART_FLUSH_EXTRA_FRAMES_MARGIN 10
+        uint64_t flush_time_us = (uint64_t)(MACHINE_UART_FLUSH_EXTRA_FRAMES_MARGIN + Cy_SCB_UART_GetNumInTxFifo(self->scb_obj->scb)) * machine_uart_frame_time_us(self);
+        uint32_t flush_time_ms = us_to_ms_ceil(flush_time_us);
+        uint32_t timeout = mp_hal_ticks_ms() + flush_time_ms;
         do {
             if (mp_machine_uart_txdone(self)) {
                 return 0;
@@ -756,23 +806,60 @@ void machine_uart_deinit_all() {
 
 #if MICROPY_PY_MACHINE_UART_IRQ
 
-#define MP_UART_ALLOWED_FLAGS (CY_SCB_RX_INTR_NOT_EMPTY | \
+#define MP_UART_ALLOWED_FLAGS (UART_IRQ_RXIDLE | \
     CY_SCB_RX_INTR_UART_BREAK_DETECT | \
     CY_SCB_TX_INTR_UART_DONE)
 
+static mp_obj_t machine_uart_rx_idle_soft(mp_obj_t self_in);
+static MP_DEFINE_CONST_FUN_OBJ_1(machine_uart_rx_idle_soft_obj, machine_uart_rx_idle_soft);
+
+
+static mp_obj_t machine_uart_rx_idle_soft(mp_obj_t self_in) {
+    /**
+     * The irq handle is only scheduled when no bytes
+     * have been received within the frame time.
+     * This avoid calling the irq handler for every NOT_EMPTY
+     * interrupt when a burst of bytes is received.
+     *  */
+    machine_uart_obj_t *self = MP_OBJ_TO_PTR(self_in);
+
+    if (self->rx_idle_irq_pending) {
+        if (mp_hal_ticks_ms() >= self->rx_idle_timeout) {
+            if (ringbuf_avail(&self->rx_ringbuf) > 0) {
+                mp_irq_handler(self->mp_irq_obj);
+            }
+            self->rx_idle_irq_pending = false;
+        } else {
+            mp_sched_schedule(MP_OBJ_FROM_PTR(&machine_uart_rx_idle_soft_obj), MP_OBJ_FROM_PTR(self));
+        }
+    }
+
+    return mp_const_none;
+}
+
 static void machine_uart_irq_rx_idle(machine_uart_obj_t *self) {
     /**
-     * Use CY_SCB_RX_INTR_NOT_EMPTY as RX_IDLE combined with
-     * checking if the RX FIFO is empty. Therefore this function
-     * will be called after reading all the data in the
-     * RX FIFO.
+     * If an IRQ_IDLE is pending, the timeout is just updated
+     * after a NOT_EMPTY interrupt has triggered a RX FIFO buffer
+     * read.
+     * Otherwise, the soft irq handler is scheduled. The
+     * soft irq handler checks if the timeout is expired, and
+     * if so, calls the user irq handler. If not, it reschedules itself
+     * to check again after the timeout.
      */
     if ((self->mp_irq_obj != NULL) &&
         (self->mp_irq_obj->handler != NULL) &&
-        (self->mp_irq_trigger & CY_SCB_RX_INTR_NOT_EMPTY) &&
-        (Cy_SCB_UART_GetNumInRxFifo(self->scb_obj->scb) == 0)) {
-        self->mp_irq_flags |= CY_SCB_RX_INTR_NOT_EMPTY;
-        mp_irq_handler(self->mp_irq_obj);
+        (self->mp_irq_trigger & UART_IRQ_RXIDLE)) {
+        self->mp_irq_flags |= UART_IRQ_RXIDLE;
+
+        /* Number of frame times to wait before triggering RX idle IRQ */
+        #define RX_IDLE_NUM_OF_FRAMES_MARGIN 5
+        uint32_t frame_time_ms = us_to_ms_ceil(machine_uart_frame_time_us(self));
+        self->rx_idle_timeout = mp_hal_ticks_ms() + frame_time_ms * RX_IDLE_NUM_OF_FRAMES_MARGIN;
+        if (!self->rx_idle_irq_pending) {
+            self->rx_idle_irq_pending = true;
+            mp_sched_schedule(MP_OBJ_FROM_PTR(&machine_uart_rx_idle_soft_obj), MP_OBJ_FROM_PTR(self));
+        }
     }
 }
 
@@ -804,7 +891,7 @@ static void machine_uart_irq_scb_config(machine_uart_obj_t *self, bool enable) {
              * Clear any stale sticky status before unmasking to prevent a
              * spurious ISR from a break that occurred before this irq() call.
              */
-            Cy_SCB_ClearRxInterrupt(self->scb_obj->scb, CY_SCB_RX_INTR_UART_BREAK_DETECT);
+            Cy_SCB_ClearRxInterrupt(self->scb_obj->scb, CY_SCB_RX_INTR_UART_BREAK_DETECT | CY_SCB_RX_INTR_NOT_EMPTY);
             Cy_SCB_SetRxInterruptMask(self->scb_obj->scb, CY_SCB_RX_INTR_UART_BREAK_DETECT | CY_SCB_RX_INTR_NOT_EMPTY);
         }
         if (self->mp_irq_trigger & CY_SCB_TX_INTR_UART_DONE) {
@@ -836,7 +923,9 @@ static mp_uint_t uart_irq_trigger(mp_obj_t self_in, mp_uint_t new_trigger) {
 static mp_uint_t uart_irq_info(mp_obj_t self_in, mp_uint_t info_type) {
     machine_uart_obj_t *self = MP_OBJ_TO_PTR(self_in);
     if (info_type == MP_IRQ_INFO_FLAGS) {
-        return self->mp_irq_flags;
+        mp_uint_t flags = self->mp_irq_flags;
+        self->mp_irq_flags = 0;
+        return flags;
     } else if (info_type == MP_IRQ_INFO_TRIGGERS) {
         return self->mp_irq_trigger;
     }

--- a/ports/psoc-edge/systick.c
+++ b/ports/psoc-edge/systick.c
@@ -128,6 +128,7 @@ mp_uint_t mp_hal_ticks_cpu(void) {
 
 void mp_hal_delay_ms(mp_uint_t ms) {
     mp_uint_t start = mp_hal_ticks_ms();
+    mp_event_handle_nowait();
     while (mp_hal_ticks_ms() - start < ms) {
         mp_event_handle_nowait();
     }
@@ -135,6 +136,7 @@ void mp_hal_delay_ms(mp_uint_t ms) {
 
 void mp_hal_delay_us(mp_uint_t us) {
     mp_uint_t start = mp_hal_ticks_us();
+    mp_event_handle_nowait();
     while (mp_hal_ticks_us() - start < us) {
         mp_event_handle_nowait();
     }

--- a/tests/extmod/machine_uart_irq_txidle.py
+++ b/tests/extmod/machine_uart_irq_txidle.py
@@ -19,6 +19,11 @@ def irq(u):
 
 text = "Hello World" * 20
 
+char_margin = 10  # number of characters to wait before and after the expected IRQ firing
+
+if "psoc-edge" in sys.platform:
+    char_margin = 100
+
 # Test that the IRQ is called after the write has completed.
 for bits_per_s in (2400, 9600, 115200):
     uart = UART(*uart_loopback_args, baudrate=bits_per_s, **uart_loopback_kwargs)
@@ -27,12 +32,12 @@ for bits_per_s in (2400, 9600, 115200):
     # The IRQ_TXIDLE shall trigger after the message has been sent. Thus
     # the test marks a time window close to the expected of the sending
     # and the time at which the IRQ should have been fired.
-    # It is just a rough estimation of 10 characters before and
-    # 20 characters after the data's end.
+    # It is just a rough estimation of 'char_margin' characters before and
+    # '2 x char_margin' characters after the data's end.
 
     bits_per_char = 10  # 1(startbit) + 8(bits) + 1(stopbit) + 0(parity)
-    start_time_us = (len(text) - 10) * bits_per_char * 1_000_000 // bits_per_s
-    window_ms = 20 * bits_per_char * 1_000 // bits_per_s + 1
+    start_time_us = (len(text) - char_margin) * bits_per_char * 1_000_000 // bits_per_s
+    window_ms = (2 * char_margin) * bits_per_char * 1_000 // bits_per_s + 1
 
     print("write", bits_per_s)
     uart.write(text)

--- a/tests/extmod/machine_uart_tx.py
+++ b/tests/extmod/machine_uart_tx.py
@@ -26,6 +26,8 @@ elif "mimxrt" in sys.platform:
     bit_margin = 1
 elif "nrf" in sys.platform:
     timing_margin_us = 130
+elif "psoc-edge" in sys.platform:
+    timing_margin_us = 190
 elif "pyboard" in sys.platform:
     initial_delay_ms = 50  # UART sends idle frame after init, so wait for that
     bit_margin = 1  # first start-bit must wait to sync with the UART clock

--- a/tests/extmod_hardware/machine_uart_irq_break.py
+++ b/tests/extmod_hardware/machine_uart_irq_break.py
@@ -31,7 +31,7 @@ for bits_per_s in (2400, 9600, 57600):
         time.sleep_ms(10)
         uart.sendbreak()
         time.sleep_ms(10)
-        if "esp32" in sys.platform:
-            # On esp32 a read is needed to read in the break byte.
+        if "esp32" in sys.platform or "psoc-edge" in sys.platform:
+            # On these platforms a read is needed to read in the break byte.
             uart.read()
     print("done")


### PR DESCRIPTION
Synching changes from upstream PR improvements:

- Fixed print for parity and stop bits. Moved conversion of values to PDL to just during hw_init stage.
- Refined timeout for flush avoiding 0 rounding for high baud rate integer arithmetic.
- Implemented `IRQ_RXIDLE` based on UART frame timeout, instead direct mapping to NOT_EMPTY_RX_FIFO. That was generating multiple some false IRQ triggers. 
- Increase stack size (stack was consumed by some test running unittest lib). 