### PR TITLE
ADC doc update : quickref notes.

### DIFF
--- a/docs/psoc-edge/quickref.rst
+++ b/docs/psoc-edge/quickref.rst
@@ -230,21 +230,9 @@ Port-specific behavior
   - Extra keyword arguments are forwarded to ``ADC.init()``.
 
 - ``sample_ns`` constraints:
-  - Must be in valid hardware range for this port.
-  - All active ADC objects in the same block must use the same ``sample_ns``.
-  - A mismatch raises ``ValueError``.
-
-- Channel ownership:
-  - Opening the same ADC channel twice raises ``ValueError``.
-  - Deinitialized ADC objects cannot be used for reads or reconfiguration.
-
-- Read methods:
-  - ``read_u16()`` returns a 16-bit scaled value (0..65535).
-  - ``read_uv()`` returns the measured input in microvolts.
-
-.. note::
-    Current default ADC pin map for this port is P15_0 through P15_7 (channels
-    0 through 7).
+    - Must be in range ``1`` to ``12800`` ns for this port.
+    - All active ADC objects in the same block must use the same ``sample_ns``.
+    - A mismatch raises ``ValueError``.
 
 Real time clock (RTC)
 ---------------------


### PR DESCRIPTION
Summary
Updated PSOC Edge ADC quickref docs:
1. Added explicit [sample_ns] range (1..12800 ns).
2. Removed generic/board-specific notes that don’t belong in this port-quickref section.

Testing
Docs-only update. No code or behavior changes.