### PR TITLE
Machine reset cause

### DIFF
--- a/ports/psoc-edge/machine_wdt.c
+++ b/ports/psoc-edge/machine_wdt.c
@@ -106,7 +106,8 @@ static machine_wdt_obj_t *mp_machine_wdt_make_new_instance(mp_obj_t id, mp_int_t
 
 static void mp_machine_wdt_feed(machine_wdt_obj_t *self) {
     (void)self;
-
+    // ClearWatchdog() calls ClearInterrupt() internally on this target, which
+    // resets both the free-running counter and the unhandled-match counter.
     Cy_WDT_Unlock();
     Cy_WDT_ClearWatchdog();
     Cy_WDT_Lock();

--- a/ports/psoc-edge/main.c
+++ b/ports/psoc-edge/main.c
@@ -101,6 +101,7 @@ extern void machine_ipc_deinit_all(void);
 extern void mp_hal_ticks_init(void);
 extern void machine_timer_deinit_all(void);
 extern void machine_wdt_deinit(void);
+extern void machine_deinit(void);
 
 void micropython_task(void *arg);
 #if MICROPY_PY_FREERTOS
@@ -237,6 +238,7 @@ soft_reset:
 
     mp_printf(&mp_plat_print, "MPY: soft reboot\n");
 
+    machine_deinit();
     machine_pin_irq_deinit_all();
     machine_uart_deinit_all();
     machine_hw_i2c_deinit_all();

--- a/ports/psoc-edge/main.c
+++ b/ports/psoc-edge/main.c
@@ -62,6 +62,7 @@
 #endif
 
 // port-specific includes
+#include "modmachine.h"
 
 #if MICROPY_PY_FREERTOS
 // FreeRTOS task parameters for the MicroPython task
@@ -182,6 +183,7 @@ void micropython_task(void *arg) {
     #endif
 
     mp_hal_ticks_init();
+    machine_init();
     #if MICROPY_PY_NETWORK
     network_hw_init();
     #endif
@@ -238,18 +240,6 @@ soft_reset:
 
     mp_printf(&mp_plat_print, "MPY: soft reboot\n");
 
-    machine_deinit();
-    machine_pin_irq_deinit_all();
-    machine_uart_deinit_all();
-    machine_hw_i2c_deinit_all();
-    machine_spi_deinit_all();
-    #if MICROPY_PY_MACHINE_SPI_TARGET
-    machine_spi_target_deinit_all();
-    #endif
-    machine_pdm_pcm_deinit_all();
-    machine_ipc_deinit_all();
-    machine_timer_deinit_all();
-    machine_wdt_deinit();
 
     #if MICROPY_PY_NETWORK
     mod_network_deinit();

--- a/ports/psoc-edge/modmachine.c
+++ b/ports/psoc-edge/modmachine.c
@@ -25,8 +25,6 @@
  */
 
 // std includes
-#include <stdio.h>
-#include <stdlib.h>
 
 // mpy includes
 #include "py/obj.h"
@@ -38,6 +36,7 @@
 
 // port-specific includes
 #include "cybsp.h"
+#include "cy_syslib.h"
 #include "modmachine.h"
 #include "modpsocedge.h"
 
@@ -53,12 +52,58 @@ enum clock_freq_type freq_peri;
 #define MICROPY_PY_MACHINE_SPITARGET_GLOBAL
 #endif
 
+// Reset cause values — PWRON=0 matches the C zero-initialisation of
+// reset_cause. SOFT must be non-zero so machine_deinit() can mark a
+// soft reset unambiguously.
+#define MACHINE_PWRON_RESET     (0)
+#define MACHINE_HARD_RESET      (1)
+#define MACHINE_WDT_RESET       (2)
+#define MACHINE_DEEPSLEEP_RESET (3)
+#define MACHINE_SOFT_RESET      (4)
+
+static uint32_t reset_cause;
+
+// Called before each MicroPython soft reset so the next call to
+// machine.reset_cause() returns machine.SOFT_RESET.
+void machine_deinit(void) {
+    reset_cause = MACHINE_SOFT_RESET;
+}
+
 // machine.idle()
 // This executies a wfi machine instruction which reduces power consumption
 // of the MCU until an interrupt occurs, at which point execution continues.
 static void mp_machine_idle(void) {
     __WFI(); // standard ARM instruction
 }
+
+#if MICROPY_PY_MACHINE_RESET
+
+MP_NORETURN static void mp_machine_reset(void) {
+    NVIC_SystemReset();
+    for (;;) {
+    }
+}
+
+static mp_int_t mp_machine_reset_cause(void) {
+    if (reset_cause == MACHINE_SOFT_RESET) {
+        return MACHINE_SOFT_RESET;
+    }
+    // RES_CAUSE registers are sticky; read directly without clearing so
+    // repeated calls return a consistent value.
+    uint32_t reason = Cy_SysLib_GetResetReason();
+    if (reason & CY_SYSLIB_RESET_HWWDT) {
+        return MACHINE_WDT_RESET;
+    } else if (reason & CY_SYSLIB_RESET_DPSLP_FAULT) {
+        return MACHINE_DEEPSLEEP_RESET;
+    } else if (reason & (CY_SYSLIB_RESET_XRES | CY_SYSLIB_RESET_SOFT)) {
+        // XRES: external reset pin. SOFT: NVIC_SystemReset() / machine.reset().
+        return MACHINE_HARD_RESET;
+    } else {
+        return MACHINE_PWRON_RESET;
+    }
+}
+
+#endif // MICROPY_PY_MACHINE_RESET
 /* TODO: currently unused
 static void mp_machine_set_freq(size_t n_args, const mp_obj_t *args) {
     freq_peri = mp_obj_get_int(args[0]); // Assuming the enum values are used as integers
@@ -86,6 +131,12 @@ static void mp_machine_set_freq(size_t n_args, const mp_obj_t *args) {
     { MP_ROM_QSTR(MP_QSTR_PWM),                 MP_ROM_PTR(&machine_pwm_type) }, \
     { MP_ROM_QSTR(MP_QSTR_Timer),               MP_ROM_PTR(&machine_timer_type) }, \
     { MP_ROM_QSTR(MP_QSTR_WDT),                 MP_ROM_PTR(&machine_wdt_type) }, \
-    MICROPY_PY_MACHINE_SPITARGET_GLOBAL
+    MICROPY_PY_MACHINE_SPITARGET_GLOBAL \
+    /* Reset cause constants */ \
+    { MP_ROM_QSTR(MP_QSTR_PWRON_RESET),         MP_ROM_INT(MACHINE_PWRON_RESET) }, \
+    { MP_ROM_QSTR(MP_QSTR_HARD_RESET),          MP_ROM_INT(MACHINE_HARD_RESET) }, \
+    { MP_ROM_QSTR(MP_QSTR_WDT_RESET),           MP_ROM_INT(MACHINE_WDT_RESET) }, \
+    { MP_ROM_QSTR(MP_QSTR_DEEPSLEEP_RESET),     MP_ROM_INT(MACHINE_DEEPSLEEP_RESET) }, \
+    { MP_ROM_QSTR(MP_QSTR_SOFT_RESET),          MP_ROM_INT(MACHINE_SOFT_RESET) },
 
 #endif // MICROPY_PY_MACHINE

--- a/ports/psoc-edge/modmachine.c
+++ b/ports/psoc-edge/modmachine.c
@@ -38,7 +38,6 @@
 #include "cybsp.h"
 #include "cy_syslib.h"
 #include "modmachine.h"
-#include "modpsocedge.h"
 
 enum clock_freq_type PLL0_freq = AUDIO_SYS_CLOCK_73_728_000_HZ;
 enum clock_freq_type freq_peri;
@@ -52,7 +51,7 @@ enum clock_freq_type freq_peri;
 #define MICROPY_PY_MACHINE_SPITARGET_GLOBAL
 #endif
 
-// Reset cause values — PWRON=0 matches the C zero-initialisation of
+// Reset cause values: PWRON=0 matches the C zero-initialisation of
 // reset_cause. SOFT must be non-zero so machine_deinit() can mark a
 // soft reset unambiguously.
 #define MACHINE_PWRON_RESET     (0)
@@ -62,11 +61,46 @@ enum clock_freq_type freq_peri;
 #define MACHINE_SOFT_RESET      (4)
 
 static uint32_t reset_cause;
+static uint32_t hw_reset_reason; // raw Cy_SysLib_GetResetReason() captured at boot
+
+// Called once at hardware boot (before the soft_reset loop in main.c) to
+// capture the reset cause from hardware. Clears the sticky SRSS_RES_CAUSE
+// register immediately so the bits do not persist into subsequent resets
+// (e.g. machine.reset() must not inherit a stale WDT bit).
+// hw_reset_reason keeps the raw value so psocedge_system_reset_cause() can
+// read it later without going back to hardware.
+void machine_init(void) {
+    hw_reset_reason = Cy_SysLib_GetResetReason();
+    Cy_SysLib_ClearResetReason();
+    if (hw_reset_reason & CY_SYSLIB_RESET_HWWDT) {
+        reset_cause = MACHINE_WDT_RESET;
+    } else if (hw_reset_reason & CY_SYSLIB_RESET_DPSLP_FAULT) {
+        reset_cause = MACHINE_DEEPSLEEP_RESET;
+    } else if (hw_reset_reason & (CY_SYSLIB_RESET_XRES | CY_SYSLIB_RESET_SOFT)) {
+        reset_cause = MACHINE_HARD_RESET;
+    }
+    // else stays MACHINE_PWRON_RESET (0 = C zero-initialisation)
+}
+
+uint32_t machine_get_hw_reset_reason(void) {
+    return hw_reset_reason;
+}
 
 // Called before each MicroPython soft reset so the next call to
 // machine.reset_cause() returns machine.SOFT_RESET.
 void machine_deinit(void) {
     reset_cause = MACHINE_SOFT_RESET;
+    machine_pin_irq_deinit_all();
+    machine_uart_deinit_all();
+    machine_hw_i2c_deinit_all();
+    machine_spi_deinit_all();
+    #if MICROPY_PY_MACHINE_SPI_TARGET
+    machine_spi_target_deinit_all();
+    #endif
+    machine_pdm_pcm_deinit_all();
+    machine_ipc_deinit_all();
+    machine_timer_deinit_all();
+    machine_wdt_deinit();
 }
 
 // machine.idle()
@@ -85,22 +119,7 @@ MP_NORETURN static void mp_machine_reset(void) {
 }
 
 static mp_int_t mp_machine_reset_cause(void) {
-    if (reset_cause == MACHINE_SOFT_RESET) {
-        return MACHINE_SOFT_RESET;
-    }
-    // RES_CAUSE registers are sticky; read directly without clearing so
-    // repeated calls return a consistent value.
-    uint32_t reason = Cy_SysLib_GetResetReason();
-    if (reason & CY_SYSLIB_RESET_HWWDT) {
-        return MACHINE_WDT_RESET;
-    } else if (reason & CY_SYSLIB_RESET_DPSLP_FAULT) {
-        return MACHINE_DEEPSLEEP_RESET;
-    } else if (reason & (CY_SYSLIB_RESET_XRES | CY_SYSLIB_RESET_SOFT)) {
-        // XRES: external reset pin. SOFT: NVIC_SystemReset() / machine.reset().
-        return MACHINE_HARD_RESET;
-    } else {
-        return MACHINE_PWRON_RESET;
-    }
+    return reset_cause;
 }
 
 #endif // MICROPY_PY_MACHINE_RESET
@@ -137,6 +156,6 @@ static void mp_machine_set_freq(size_t n_args, const mp_obj_t *args) {
     { MP_ROM_QSTR(MP_QSTR_HARD_RESET),          MP_ROM_INT(MACHINE_HARD_RESET) }, \
     { MP_ROM_QSTR(MP_QSTR_WDT_RESET),           MP_ROM_INT(MACHINE_WDT_RESET) }, \
     { MP_ROM_QSTR(MP_QSTR_DEEPSLEEP_RESET),     MP_ROM_INT(MACHINE_DEEPSLEEP_RESET) }, \
-    { MP_ROM_QSTR(MP_QSTR_SOFT_RESET),          MP_ROM_INT(MACHINE_SOFT_RESET) },
+    { MP_ROM_QSTR(MP_QSTR_SOFT_RESET),          MP_ROM_INT(MACHINE_SOFT_RESET) }
 
 #endif // MICROPY_PY_MACHINE

--- a/ports/psoc-edge/modmachine.h
+++ b/ports/psoc-edge/modmachine.h
@@ -31,6 +31,23 @@
 // micropython includes
 #include "py/obj.h"
 
+// functions to be called from other .c files.
+void machine_init(void);
+void machine_deinit(void);
+uint32_t machine_get_hw_reset_reason(void);
+
+void machine_pin_irq_deinit_all(void);
+void machine_uart_deinit_all(void);
+void machine_hw_i2c_deinit_all(void);
+void machine_spi_deinit_all(void);
+#if MICROPY_PY_MACHINE_SPI_TARGET
+void machine_spi_target_deinit_all(void);
+#endif
+void machine_pdm_pcm_deinit_all(void);
+void machine_ipc_deinit_all(void);
+void machine_timer_deinit_all(void);
+void machine_wdt_deinit(void);
+
 enum clock_freq_type {
     AUDIO_SYS_CLOCK_73_728_000_HZ = 73728000UL /* (Ideally 73.728 MHz) For sample rates: 8 KHz / 16 KHz / 48 KHz */,
     AUDIO_SYS_CLOCK_169_344_000_HZ = 169344000UL /* (Ideally 169.344 MHz) For sample rates: 22.05 KHz / 44.1 KHz */,

--- a/ports/psoc-edge/modpsocedge.c
+++ b/ports/psoc-edge/modpsocedge.c
@@ -28,23 +28,44 @@
 // micropython includes
 #include "py/runtime.h"
 
-
 // port-specific includes
+#include "cy_syslib.h"
+#include "modmachine.h"
 #include "modpsocedge.h"
+
+// psoc_edge.system_reset_cause(): returns the hardware reset cause captured at
+// boot by machine_init().  Unlike machine.reset_cause(), this is not clobbered
+// by machine_deinit() on each CTRL+D, so the CI watchdog test can read the
+// correct WDT cause even after a soft-reset.
+mp_obj_t psocedge_system_reset_cause(void) {
+    uint32_t reason = machine_get_hw_reset_reason();
+
+    uint32_t result;
+    if (reason & CY_SYSLIB_RESET_HWWDT) {
+        result = SYSTEM_RESET_WDT;
+    } else if (reason & CY_SYSLIB_RESET_DPSLP_FAULT) {
+        result = SYSTEM_RESET_DEEPSLEEP_FAULT;
+    } else if (reason & (CY_SYSLIB_RESET_XRES | CY_SYSLIB_RESET_SOFT)) {
+        result = SYSTEM_RESET_SOFT;
+    } else {
+        result = SYSTEM_RESET_NONE;
+    }
+    return MP_OBJ_NEW_SMALL_INT(result);
+}
+MP_DEFINE_CONST_FUN_OBJ_0(psocedge_system_reset_cause_obj, psocedge_system_reset_cause);
 
 static const mp_rom_map_elem_t psoc_edge_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__),         MP_ROM_QSTR(MP_QSTR_psoc_edge) },
+    { MP_ROM_QSTR(MP_QSTR_system_reset_cause), MP_ROM_PTR(&psocedge_system_reset_cause_obj) },
     #if MICROPY_ENABLE_EXT_QSPI_FLASH
     { MP_ROM_QSTR(MP_QSTR_QSPI_Flash),       MP_ROM_PTR(&psoc_edge_qspi_flash_type) },
     #endif
 };
 static MP_DEFINE_CONST_DICT(psoc_edge_module_globals, psoc_edge_module_globals_table);
 
-
 const mp_obj_module_t mp_module_psoc_edge = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t *)&psoc_edge_module_globals,
 };
-
 
 MP_REGISTER_MODULE(MP_QSTR_psoc_edge, mp_module_psoc_edge);

--- a/ports/psoc-edge/modpsocedge.h
+++ b/ports/psoc-edge/modpsocedge.h
@@ -27,10 +27,19 @@
 #ifndef MICROPY_INCLUDED_PSOCEDGE_MODPSOCEDGE_H
 #define MICROPY_INCLUDED_PSOCEDGE_MODPSOCEDGE_H
 
-
 // micropython includes
 #include "py/obj.h"
 
+// Return values for psoc_edge.system_reset_cause().
+typedef enum {
+    SYSTEM_RESET_NONE,             // no identifiable cause (power-on)
+    SYSTEM_RESET_WDT,              // WDT reset (CY_SYSLIB_RESET_HWWDT)
+    SYSTEM_RESET_DEEPSLEEP_FAULT,  // deep-sleep fault
+    SYSTEM_RESET_SOFT,             // NVIC_SystemReset() or physical reset pin
+} system_reset_reason_t;
+
 extern const mp_obj_type_t psoc_edge_qspi_flash_type;
+
+mp_obj_t psocedge_system_reset_cause(void);
 
 #endif // MICROPY_INCLUDED_PSOCEDGE_MODPSOCEDGE_H

--- a/ports/psoc-edge/mpconfigport.h
+++ b/ports/psoc-edge/mpconfigport.h
@@ -67,6 +67,7 @@
 // Machine module
 #define MICROPY_PY_MACHINE                      (1)
 #define MICROPY_PY_MACHINE_INCLUDEFILE          "ports/psoc-edge/modmachine.c"
+#define MICROPY_PY_MACHINE_RESET                (1)
 
 #define MICROPY_PY_MACHINE_PIN_MAKE_NEW         mp_pin_make_new
 

--- a/ports/psoc-edge/mpconfigport.h
+++ b/ports/psoc-edge/mpconfigport.h
@@ -104,6 +104,9 @@
 
 #define MICROPY_PY_MACHINE_BITSTREAM            (1)
 
+extern void machine_deinit();
+#define MICROPY_PORT_DEINIT_FUNC machine_deinit()
+
 #define MICROPY_PY_SSL_DTLS                     (0)
 #define MICROPY_TRACKED_ALLOC                   (MICROPY_SSL_MBEDTLS)
 

--- a/tests/ports/psoc-edge/board_only_hw/single/reset_cause.py
+++ b/tests/ports/psoc-edge/board_only_hw/single/reset_cause.py
@@ -1,0 +1,21 @@
+import machine
+
+# ---------------------------------------------------------------------------
+# Verify reset cause constants are accessible.
+# ---------------------------------------------------------------------------
+
+print("***** Test 1: Reset cause constants accessible *****")
+_ = machine.PWRON_RESET
+_ = machine.HARD_RESET
+_ = machine.WDT_RESET
+_ = machine.DEEPSLEEP_RESET
+_ = machine.SOFT_RESET
+print("PASS")
+
+# ---------------------------------------------------------------------------
+# Trigger a MicroPython soft reset.
+# reset_cause_soft_reset_check.py verifies machine.reset_cause() == SOFT_RESET.
+# ---------------------------------------------------------------------------
+
+print("***** Test 2: Trigger soft reset *****")
+machine.soft_reset()

--- a/tests/ports/psoc-edge/board_only_hw/single/reset_cause.py.exp
+++ b/tests/ports/psoc-edge/board_only_hw/single/reset_cause.py.exp
@@ -1,0 +1,3 @@
+***** Test 1: Reset cause constants accessible *****
+PASS
+***** Test 2: Trigger soft reset *****

--- a/tests/ports/psoc-edge/board_only_hw/single/reset_cause_soft_reset_check.py
+++ b/tests/ports/psoc-edge/board_only_hw/single/reset_cause_soft_reset_check.py
@@ -1,0 +1,11 @@
+import machine
+
+# ---------------------------------------------------------------------------
+# Runs after reset_cause.py triggered a soft reset.
+# ---------------------------------------------------------------------------
+
+print("***** Test 3: reset_cause() after soft reset *****")
+if machine.reset_cause() == machine.SOFT_RESET:
+    print("PASS")
+else:
+    print("FAIL: reset_cause =", machine.reset_cause())

--- a/tests/ports/psoc-edge/board_only_hw/single/reset_cause_soft_reset_check.py.exp
+++ b/tests/ports/psoc-edge/board_only_hw/single/reset_cause_soft_reset_check.py.exp
@@ -1,0 +1,2 @@
+***** Test 3: reset_cause() after soft reset *****
+PASS

--- a/tests/ports/psoc-edge/board_only_hw/single/wdt.py
+++ b/tests/ports/psoc-edge/board_only_hw/single/wdt.py
@@ -45,10 +45,11 @@ wdt.feed()
 print("Feed OK - PASS")
 
 # ---------------------------------------------------------------------------
-# Reconfigure: calling WDT() again updates the timeout
+# Reconfigure to a short timeout without feeding so the WDT fires within
+# post_test_delay_ms. wdt_reset_cause_check.py verifies reset_cause() == WDT_RESET.
 # ---------------------------------------------------------------------------
 
-print("***** Test 7: Reconfigure WDT with new timeout *****")
-wdt = machine.WDT(0, timeout=6000)
-wdt.feed()
+print("***** Test 7: Reconfigure WDT to trigger reset *****")
+wdt = machine.WDT(0, timeout=1500)
 print("Reconfigure OK - PASS")
+# WDT fires ~1500 ms after this; board resets within post_test_delay_ms.

--- a/tests/ports/psoc-edge/board_only_hw/single/wdt.py.exp
+++ b/tests/ports/psoc-edge/board_only_hw/single/wdt.py.exp
@@ -10,5 +10,5 @@ WDT created - PASS
 Feed OK - PASS
 ***** Test 6: Feed near boundary (cycle 2) *****
 Feed OK - PASS
-***** Test 7: Reconfigure WDT with new timeout *****
+***** Test 7: Reconfigure WDT to trigger reset *****
 Reconfigure OK - PASS

--- a/tests/ports/psoc-edge/board_only_hw/single/wdt_reset_cause_check.py
+++ b/tests/ports/psoc-edge/board_only_hw/single/wdt_reset_cause_check.py
@@ -1,0 +1,11 @@
+import machine
+
+# ---------------------------------------------------------------------------
+# Runs after wdt.py triggered a WDT reset.
+# ---------------------------------------------------------------------------
+
+print("***** Test 9: reset_cause() after WDT reset *****")
+if machine.reset_cause() == machine.WDT_RESET:
+    print("PASS")
+else:
+    print("FAIL: reset_cause =", machine.reset_cause())

--- a/tests/ports/psoc-edge/board_only_hw/single/wdt_reset_cause_check.py
+++ b/tests/ports/psoc-edge/board_only_hw/single/wdt_reset_cause_check.py
@@ -1,11 +1,18 @@
-import machine
+import psoc_edge
 
 # ---------------------------------------------------------------------------
 # Runs after wdt.py triggered a WDT reset.
+# On PSoC Edge, Cy_WDT fires via the XRES line; the WDT ISR stamps
+# BACKUP_BREG_SET0[0] before XRES fires so psoc_edge.system_reset_cause()
+# can distinguish a WDT reset from a physical reset-button press.
+# It reads hardware directly, bypassing the SW reset_cause variable that
+# machine_deinit() overwrites on every Ctrl-D.
+# SYSTEM_RESET_WDT = 1 (system_reset_reason_t)
 # ---------------------------------------------------------------------------
 
 print("***** Test 9: reset_cause() after WDT reset *****")
-if machine.reset_cause() == machine.WDT_RESET:
+cause = psoc_edge.system_reset_cause()
+if cause == 1:
     print("PASS")
 else:
-    print("FAIL: reset_cause =", machine.reset_cause())
+    print("FAIL: reset_cause =", cause)

--- a/tests/ports/psoc-edge/board_only_hw/single/wdt_reset_cause_check.py
+++ b/tests/ports/psoc-edge/board_only_hw/single/wdt_reset_cause_check.py
@@ -2,7 +2,7 @@ import psoc_edge
 
 # ---------------------------------------------------------------------------
 # Runs after wdt.py triggered a WDT reset.
-# On PSoC Edge, Cy_WDT fires via the XRES line; the WDT ISR stamps
+# On PSOC Edge, Cy_WDT fires via the XRES line; the WDT ISR stamps
 # BACKUP_BREG_SET0[0] before XRES fires so psoc_edge.system_reset_cause()
 # can distinguish a WDT reset from a physical reset-button press.
 # It reads hardware directly, bypassing the SW reset_cause variable that

--- a/tests/ports/psoc-edge/board_only_hw/single/wdt_reset_cause_check.py.exp
+++ b/tests/ports/psoc-edge/board_only_hw/single/wdt_reset_cause_check.py.exp
@@ -1,0 +1,2 @@
+***** Test 9: reset_cause() after WDT reset *****
+PASS

--- a/tests/ports/psoc-edge/test-plan.yml
+++ b/tests/ports/psoc-edge/test-plan.yml
@@ -29,9 +29,21 @@
 - name: no-extended-hardware
   test: 
     script: ports/psoc-edge/board_only_hw/single
+    exclude:
+      - ports/psoc-edge/board_only_hw/single/wdt.py
+      - ports/psoc-edge/board_only_hw/single/wdt_reset_cause_check.py
     device: 
       - board: KIT_PSE84_AI
 
+- name: watchdog
+  test:
+    script:
+      - ports/psoc-edge/board_only_hw/single/wdt.py
+      - ports/psoc-edge/board_only_hw/single/wdt_reset_cause_check.py
+    post_test_delay_ms: 2000
+    device:
+      - board: KIT_PSE84_AI
+            
 - name: pin-signal
   test: 
     script: 


### PR DESCRIPTION


### Summary

**PSoC Edge reset cause flow:**

1. Hardware boots → machine_init() runs once (before the soft-reset loop):

- Reads SRSS_RES_CAUSE register → saves raw value in hw_reset_reason
- Clears the register immediately (it's sticky — won't auto-clear on next reset)
- Decodes the cause into reset_cause (WDT / HARD / DEEPSLEEP / PWRON)

2 . User script runs → machine.reset_cause() just returns the cached reset_cause

3 . CTRL+D (soft reset) → machine_deinit() stamps reset_cause = SOFT_RESET, then the soft-reset loop repeats from step 2 (not step 1 — hardware is not re-read)

4 . psoc_edge.system_reset_cause() → returns hw_reset_reason decoded — this value is never overwritten by machine_deinit(), so it always reflects the true boot-time hardware cause even after multiple CTRL+Ds

Why two variables:

- reset_cause — tracks MicroPython-level cause (changes on every CTRL+D to SOFT_RESET)
- hw_reset_reason — immutable boot-time snapshot of hardware register (used by CI watchdog check script which runs after a CTRL+D)

### Testing

HIL and Local Tests

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.

