### PR TITLE
machine.SPI() uses clk library

### DIFF
--- a/ports/psoc-edge/machine_scb.c
+++ b/ports/psoc-edge/machine_scb.c
@@ -71,10 +71,7 @@ MICROPY_PY_MACHINE_FOR_ALL_SCB(DEFINE_SCB_IRQ_HANDLER)
             SCB##scb##_IRQ_Handler \
         }, \
         PCLK_SCB##scb##_CLOCK_SCB_EN, \
-        CY_MMIO_SCB##scb##_PERI_NR, \
-        CY_MMIO_SCB##scb##_GROUP_NR, \
         CY_MMIO_SCB##scb##_SLAVE_NR, \
-        CY_MMIO_SCB##scb##_CLK_HF_NR, \
         NULL, \
         NULL, \
     },
@@ -82,47 +79,6 @@ MICROPY_PY_MACHINE_FOR_ALL_SCB(DEFINE_SCB_IRQ_HANDLER)
 static machine_scb_obj_t machine_scb_obj[MICROPY_PY_MACHINE_SCB_NUM_ENTRIES] = {
     MICROPY_PY_MACHINE_FOR_ALL_SCB(MAP_SCB_IRQ_CONFIG)
 };
-
-typedef struct {
-    uint32_t peri_nr;
-    uint32_t group_nr;
-    uint32_t slave_nr;
-    uint32_t clk_hf_nr;
-} machine_scb_group_info_t;
-
-#define MAP_SCB_GROUP_INFO(scb) \
-    [scb] = { \
-        .peri_nr = CY_MMIO_SCB##scb##_PERI_NR, \
-        .group_nr = CY_MMIO_SCB##scb##_GROUP_NR, \
-        .slave_nr = CY_MMIO_SCB##scb##_SLAVE_NR, \
-        .clk_hf_nr = CY_MMIO_SCB##scb##_CLK_HF_NR, \
-    },
-
-static const machine_scb_group_info_t machine_scb_group_info[MICROPY_PY_MACHINE_SCB_NUM_ENTRIES] = {
-    MICROPY_PY_MACHINE_FOR_ALL_SCB(MAP_SCB_GROUP_INFO)
-};
-
-typedef struct {
-    const void *owner;
-    en_clk_dst_t clk_dst;
-    uint8_t div_num;
-} machine_scb_div8_alloc_t;
-
-static machine_scb_div8_alloc_t machine_scb_div8_alloc[MICROPY_PY_MACHINE_SCB_NUM_ENTRIES] = {0};
-
-static inline uint32_t machine_scb_div8_count_for_clk(en_clk_dst_t clk_dst) {
-    uint32_t grp_num = (((uint32_t)clk_dst) & PERI_PCLK_GR_NUM_Msk) >> PERI_PCLK_GR_NUM_Pos;
-    uint32_t inst_num = (((uint32_t)clk_dst) & PERI_PCLK_INST_NUM_Msk) >> PERI_PCLK_INST_NUM_Pos;
-    return PERI_PCLK_GR_DIV_8_NR(inst_num, grp_num);
-}
-
-static inline bool machine_scb_same_divider_group(en_clk_dst_t clk_a, en_clk_dst_t clk_b) {
-    uint32_t a_grp = (((uint32_t)clk_a) & PERI_PCLK_GR_NUM_Msk) >> PERI_PCLK_GR_NUM_Pos;
-    uint32_t a_inst = (((uint32_t)clk_a) & PERI_PCLK_INST_NUM_Msk) >> PERI_PCLK_INST_NUM_Pos;
-    uint32_t b_grp = (((uint32_t)clk_b) & PERI_PCLK_GR_NUM_Msk) >> PERI_PCLK_GR_NUM_Pos;
-    uint32_t b_inst = (((uint32_t)clk_b) & PERI_PCLK_INST_NUM_Msk) >> PERI_PCLK_INST_NUM_Pos;
-    return (a_grp == b_grp) && (a_inst == b_inst);
-}
 
 static void machine_scb_irq_handler(uint8_t scb) {
     machine_scb_obj_t *scb_obj = &machine_scb_obj[scb];
@@ -136,16 +92,8 @@ machine_scb_obj_t *machine_scb_obj_alloc(uint8_t scb, mp_obj_t parent, machine_s
     if (obj->parent != NULL) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("SCB %u is already in use by another I2C, SPI or UART instance."), scb);
     }
-    /*
-     * Enable the peripheral clock gate for this SCB. The BSP's
-     * cycfg_config_reservations() only does this for the SCBs that are
-     * configured in the board design (e.g. the debug UART). Any SCB
-     * that was not pre-configured will have its clock gate disabled, and
-     * attempting to read or write its registers stalls the AHB bus,
-     * causing a hard lock-up. Calling this for already-enabled SCBs is
-     * idempotent.
-     */
-    Cy_SysClk_PeriGroupSlaveInit(obj->peri_nr, obj->group_nr, obj->slave_nr, obj->clk_hf_nr);
+    ;
+
     obj->parent = parent;
     obj->parent_handler = handler;
     return &machine_scb_obj[scb];
@@ -154,92 +102,11 @@ machine_scb_obj_t *machine_scb_obj_alloc(uint8_t scb, mp_obj_t parent, machine_s
 void machine_scb_obj_free(machine_scb_obj_t *scb) {
     scb->parent = NULL;
     scb->parent_handler = NULL;
-    Cy_SysClk_PeriGroupSlaveDeinit(scb->peri_nr, scb->group_nr, scb->slave_nr);
 }
 
 bool machine_scb_is_free(uint8_t scb) {
     return machine_scb_obj[scb].parent == NULL;
 
-}
-
-void machine_scb_enable_group(uint8_t scb) {
-    const machine_scb_group_info_t *gi = &machine_scb_group_info[scb];
-    Cy_SysClk_PeriGroupSlaveInit(gi->peri_nr, gi->group_nr,
-        gi->slave_nr, gi->clk_hf_nr);
-}
-
-void machine_scb_peri_pclk_config_divider(en_clk_dst_t clk_dst,
-    cy_en_divider_types_t div_type, uint8_t div_num, uint32_t div_val) {
-    Cy_SysClk_PeriPclkDisableDivider(clk_dst, div_type, div_num);
-    Cy_SysClk_PeriPclkAssignDivider(clk_dst, div_type, div_num);
-    Cy_SysClk_PeriPclkSetDivider(clk_dst, div_type, div_num, div_val);
-    Cy_SysClk_PeriPclkEnableDivider(clk_dst, div_type, div_num);
-}
-
-bool machine_scb_div8_try_alloc(en_clk_dst_t clk_dst, uint8_t div_base, uint8_t div_invalid,
-    const void *owner, uint8_t *div_num_out) {
-    uint32_t max_div = machine_scb_div8_count_for_clk(clk_dst);
-    if (div_base >= max_div || div_num_out == NULL || owner == NULL) {
-        return false;
-    }
-
-    for (uint32_t div = div_base; div < max_div; ++div) {
-        if (div > div_invalid) {
-            break;
-        }
-
-        bool used = false;
-        for (uint8_t i = 0; i < MICROPY_PY_MACHINE_SCB_NUM_ENTRIES; i++) {
-            if (machine_scb_div8_alloc[i].owner == NULL) {
-                continue;
-            }
-            if (!machine_scb_same_divider_group(machine_scb_div8_alloc[i].clk_dst, clk_dst)) {
-                continue;
-            }
-            if (machine_scb_div8_alloc[i].div_num == (uint8_t)div) {
-                used = true;
-                break;
-            }
-        }
-
-        if (!used) {
-            for (uint8_t i = 0; i < MICROPY_PY_MACHINE_SCB_NUM_ENTRIES; i++) {
-                if (machine_scb_div8_alloc[i].owner == NULL) {
-                    machine_scb_div8_alloc[i].owner = owner;
-                    machine_scb_div8_alloc[i].clk_dst = clk_dst;
-                    machine_scb_div8_alloc[i].div_num = (uint8_t)div;
-                    *div_num_out = (uint8_t)div;
-                    return true;
-                }
-            }
-            return false;
-        }
-    }
-
-    return false;
-}
-
-void machine_scb_div8_free(en_clk_dst_t clk_dst, uint8_t div_num, const void *owner) {
-    if (owner == NULL) {
-        return;
-    }
-
-    for (uint8_t i = 0; i < MICROPY_PY_MACHINE_SCB_NUM_ENTRIES; i++) {
-        if (machine_scb_div8_alloc[i].owner != owner) {
-            continue;
-        }
-        if (machine_scb_div8_alloc[i].div_num != div_num) {
-            continue;
-        }
-        if (!machine_scb_same_divider_group(machine_scb_div8_alloc[i].clk_dst, clk_dst)) {
-            continue;
-        }
-
-        machine_scb_div8_alloc[i].owner = NULL;
-        machine_scb_div8_alloc[i].div_num = 0;
-        machine_scb_div8_alloc[i].clk_dst = 0;
-        return;
-    }
 }
 
 #endif // MICROPY_PY_MACHINE_I2C || MICROPY_PY_MACHINE_I2C_TARGET || MICROPY_PY_MACHINE_SPI || MICROPY_PY_MACHINE_SPI_TARGET || MICROPY_PY_MACHINE_UART

--- a/ports/psoc-edge/machine_scb.h
+++ b/ports/psoc-edge/machine_scb.h
@@ -37,10 +37,7 @@ typedef struct _machine_scb_obj_t {
     CySCB_Type *scb;
     sys_int_cfg_t irq;
     en_clk_dst_t clk;
-    uint8_t peri_nr;
-    uint8_t group_nr;
-    uint8_t slave_nr;
-    uint8_t clk_hf_nr;
+    uint8_t mmio_slave_nr;
     mp_obj_t parent;
     machine_scb_parent_irq_handler_t parent_handler;
 } machine_scb_obj_t;
@@ -48,11 +45,5 @@ typedef struct _machine_scb_obj_t {
 machine_scb_obj_t *machine_scb_obj_alloc(uint8_t scb, mp_obj_t parent, machine_scb_parent_irq_handler_t handler);
 void machine_scb_obj_free(machine_scb_obj_t *scb);
 bool machine_scb_is_free(uint8_t scb);
-void machine_scb_enable_group(uint8_t scb);
-void machine_scb_peri_pclk_config_divider(en_clk_dst_t clk_dst,
-    cy_en_divider_types_t div_type, uint8_t div_num, uint32_t div_val);
-bool machine_scb_div8_try_alloc(en_clk_dst_t clk_dst, uint8_t div_base, uint8_t div_invalid,
-    const void *owner, uint8_t *div_num_out);
-void machine_scb_div8_free(en_clk_dst_t clk_dst, uint8_t div_num, const void *owner);
 
 #endif // MICROPY_INCLUDED_PSOC_EDGE_MACHINE_SCB_H

--- a/ports/psoc-edge/machine_spi.c
+++ b/ports/psoc-edge/machine_spi.c
@@ -31,7 +31,7 @@
 #include "py/mperrno.h"
 #include "cybsp.h"
 #include "cy_scb_spi.h"
-#include "cy_sysclk.h"
+#include "clk.h"
 #include "genhdr/pins_af.h"
 #include "machine_scb.h"
 #include "modmachine.h"
@@ -44,9 +44,7 @@
 #define DEFAULT_SPI_TIMEOUT     (50000)
 
 #define SPI_OVERSAMPLE          (4U)
-#define SPI_CLK_DIV_TYPE        CY_SYSCLK_DIV_8_BIT
 #define SPI_CLK_DIV_BASE        (4U)
-#define SPI_CLK_DIV_INVALID      (0xFFU)
 
 typedef struct _machine_spi_obj_t {
     mp_obj_base_t base;
@@ -59,7 +57,7 @@ typedef struct _machine_spi_obj_t {
     uint8_t bits;
     uint8_t firstbit;
     uint32_t timeout;
-    uint8_t div_num;
+    pclk_div_obj_t *pclk_div;
     machine_scb_obj_t *scb_obj;
     cy_stc_scb_spi_config_t cfg;
     cy_stc_scb_spi_context_t ctx;
@@ -71,7 +69,6 @@ static inline machine_spi_obj_t *machine_hw_spi_obj_alloc(void) {
     for (uint8_t i = 0; i < MICROPY_PY_MACHINE_SPI_NUM_ENTRIES; i++) {
         if (machine_hw_spi_obj[i] == NULL) {
             machine_hw_spi_obj[i] = mp_obj_malloc(machine_spi_obj_t, &machine_spi_type);
-            machine_hw_spi_obj[i]->div_num = SPI_CLK_DIV_INVALID;
             return machine_hw_spi_obj[i];
         }
     }
@@ -141,32 +138,19 @@ static void machine_spi_hw_init(machine_spi_obj_t *self) {
     uint8_t scb_unit = machine_spi_pins_config_and_get_scb_unit(
         self->sck, self->mosi, self->miso);
 
-    // Power on the peripheral group that contains this SCB.
-    // Note: "Slave" in PeriGroupSlaveInit refers to the bus architecture
-    // (SCB is a slave on the internal PERI interconnect), not SPI slave mode.
-    machine_scb_enable_group(scb_unit);
-
     // Allocate SCB
     self->scb_obj = machine_scb_obj_alloc(scb_unit, self,
         machine_spi_scb_isr);
 
-    if (!machine_scb_div8_try_alloc(self->scb_obj->clk,
-        SPI_CLK_DIV_BASE,
-        SPI_CLK_DIV_INVALID,
-        self,
-        &self->div_num)) {
+    pclk_div_slave_init(self->scb_obj->clk, self->scb_obj->mmio_slave_nr);
+
+    uint32_t clk_hf_freq = pclk_div_get_input_freq(self->scb_obj->clk);
+    if (clk_hf_freq == 0U) {
+        pclk_div_slave_deinit(self->scb_obj->clk, self->scb_obj->mmio_slave_nr);
         machine_scb_obj_free(self->scb_obj);
         self->scb_obj = NULL;
-        mp_raise_ValueError(MP_ERROR_TEXT("SPI clock dividers exhausted"));
+        mp_raise_ValueError(MP_ERROR_TEXT("failed to get SPI input clock"));
     }
-
-    // Configure SPI clock divider
-    machine_scb_peri_pclk_config_divider(self->scb_obj->clk,
-        SPI_CLK_DIV_TYPE, self->div_num, 0U);
-
-    // Get HF clock frequency and calculate divider value for desired baudrate
-    uint32_t clk_hf_freq = Cy_SysClk_PeriPclkGetFrequency(
-        self->scb_obj->clk, SPI_CLK_DIV_TYPE, self->div_num);
 
     // Compute divider value for requested baudrate
     uint32_t div_val = clk_hf_freq / ((uint64_t)self->baudrate * SPI_OVERSAMPLE);
@@ -174,9 +158,18 @@ static void machine_spi_hw_init(machine_spi_obj_t *self) {
         div_val--;
     }
 
-    // Apply divider
-    machine_scb_peri_pclk_config_divider(self->scb_obj->clk,
-        SPI_CLK_DIV_TYPE, self->div_num, div_val);
+    if (div_val < SPI_CLK_DIV_BASE) {
+        div_val = SPI_CLK_DIV_BASE;
+    }
+
+    self->pclk_div = pclk_div_init(self->scb_obj->clk, div_val, 0);
+    if (self->pclk_div == NULL) {
+        pclk_div_slave_deinit(self->scb_obj->clk, self->scb_obj->mmio_slave_nr);
+        machine_scb_obj_free(self->scb_obj);
+        self->pclk_div = NULL;
+        self->scb_obj = NULL;
+        mp_raise_ValueError(MP_ERROR_TEXT("SPI clock dividers exhausted"));
+    }
 
     // Select SPI clock polarity and phase
     cy_en_scb_spi_sclk_mode_t sclk_mode;
@@ -226,8 +219,9 @@ static void machine_spi_hw_init(machine_spi_obj_t *self) {
         Cy_SCB_SPI_Init(self->scb_obj->scb, &self->cfg, &self->ctx);
 
     if (result != CY_SCB_SPI_SUCCESS) {
-        machine_scb_div8_free(self->scb_obj->clk, self->div_num, self);
-        self->div_num = SPI_CLK_DIV_INVALID;
+        pclk_div_deinit(self->pclk_div);
+        self->pclk_div = NULL;
+        pclk_div_slave_deinit(self->scb_obj->clk, self->scb_obj->mmio_slave_nr);
         machine_scb_obj_free(self->scb_obj);
         self->scb_obj = NULL;
         mp_raise_msg_varg(&mp_type_ValueError,
@@ -242,11 +236,9 @@ static void machine_spi_hw_deinit(machine_spi_obj_t *self) {
     Cy_SCB_SPI_Disable(self->scb_obj->scb, &self->ctx);
     Cy_SCB_SPI_DeInit(self->scb_obj->scb);
     sys_int_deinit(&self->scb_obj->irq);
-    if (self->div_num != SPI_CLK_DIV_INVALID) {
-        machine_scb_div8_free(self->scb_obj->clk, self->div_num, self);
-        Cy_SysClk_PeriPclkDisableDivider(self->scb_obj->clk, SPI_CLK_DIV_TYPE, self->div_num);
-        self->div_num = SPI_CLK_DIV_INVALID;
-    }
+    pclk_div_deinit(self->pclk_div);
+    self->pclk_div = NULL;
+    pclk_div_slave_deinit(self->scb_obj->clk, self->scb_obj->mmio_slave_nr);
     machine_scb_obj_free(self->scb_obj);
     self->scb_obj = NULL;
 }
@@ -429,6 +421,7 @@ mp_obj_t mp_machine_spi_make_new(const mp_obj_type_t *type, size_t n_args, size_
     self->bits = DEFAULT_SPI_BITS;
     self->firstbit = MICROPY_PY_MACHINE_SPI_MSB;
     self->timeout = DEFAULT_SPI_TIMEOUT;
+    self->pclk_div = NULL;
     self->scb_obj = NULL;
     self->sck = NULL;
     self->mosi = NULL;

--- a/ports/psoc-edge/machine_spi.c
+++ b/ports/psoc-edge/machine_spi.c
@@ -244,7 +244,7 @@ static void machine_spi_hw_deinit(machine_spi_obj_t *self) {
 }
 
 // Parse and validate user arguments shared by constructor and init().
-static void machine_spi_init_helper(machine_spi_obj_t *self, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
+static void machine_spi_init(mp_obj_base_t *self_in, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_id, ARG_baudrate, ARG_polarity, ARG_phase, ARG_bits,
            ARG_firstbit, ARG_sck, ARG_mosi, ARG_miso };
 
@@ -261,7 +261,9 @@ static void machine_spi_init_helper(machine_spi_obj_t *self, size_t n_args, size
     };
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    machine_spi_obj_t *self = (machine_spi_obj_t *)self_in;
 
     bool reinit = false;
 
@@ -310,29 +312,6 @@ static void machine_spi_init_helper(machine_spi_obj_t *self, size_t n_args, size
         }
         machine_spi_hw_init(self);
     }
-}
-
-// Thin protocol adapter for mp_machine_spi_p.init signature.
-static void machine_spi_init(mp_obj_base_t *self_in, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
-    machine_spi_obj_t *self = (machine_spi_obj_t *)self_in;
-
-    // Convert runtime pos/kw args into the kw-array form expected by init_helper.
-    size_t n_kw = kw_args->used;
-    size_t all_args_len = n_args + 2 * n_kw;
-    mp_obj_t all_args[all_args_len == 0 ? 1 : all_args_len];
-
-    size_t out = 0;
-    for (size_t i = 0; i < n_args; i++) {
-        all_args[out++] = pos_args[i];
-    }
-    for (size_t i = 0; i < kw_args->alloc; i++) {
-        if (mp_map_slot_is_filled(kw_args, i)) {
-            all_args[out++] = kw_args->table[i].key;
-            all_args[out++] = kw_args->table[i].value;
-        }
-    }
-
-    machine_spi_init_helper(self, n_args, n_kw, all_args);
 }
 
 static void machine_spi_deinit(mp_obj_base_t *self_in) {
@@ -414,6 +393,9 @@ mp_obj_t mp_machine_spi_make_new(const mp_obj_type_t *type, size_t n_args, size_
         mp_raise_ValueError(MP_ERROR_TEXT("machine.SPI: Maximum number of SPI instances reached"));
     }
 
+    mp_map_t kw_args;
+    mp_map_init_fixed_table(&kw_args, n_kw, all_args + n_args);
+
     // Set defaults
     self->baudrate = DEFAULT_SPI_BAUDRATE;
     self->polarity = DEFAULT_SPI_POLARITY;
@@ -430,7 +412,7 @@ mp_obj_t mp_machine_spi_make_new(const mp_obj_type_t *type, size_t n_args, size_
     // Delegate argument parsing and initialization to init_helper
     nlr_buf_t nlr;
     if (nlr_push(&nlr) == 0) {
-        machine_spi_init_helper(self, n_args, n_kw, all_args);
+        machine_spi_init((mp_obj_base_t *)self, n_args, all_args, &kw_args);
         nlr_pop();
     } else {
         machine_hw_spi_obj_free(self);

--- a/ports/psoc-edge/machine_spi_target.c
+++ b/ports/psoc-edge/machine_spi_target.c
@@ -30,7 +30,7 @@
 #include <string.h>
 #include "cybsp.h"
 #include "cy_scb_spi.h"
-#include "cy_sysclk.h"
+#include "clk.h"
 #include "genhdr/pins_af.h"
 #include "machine_scb.h"
 #include "modmachine.h"
@@ -43,9 +43,7 @@
 #define SPI_TARGET_TICKS_WRAP_MS       (15000U) // from mp_hal_ticks_ms source timer period in modtime.c
 #define DEFAULT_SPI_TARGET_TIMEOUT_MS  (5000U)  // must stay below SPI_TARGET_TICKS_WRAP_MS
 
-#define SPI_TARGET_CLK_DIV_TYPE        CY_SYSCLK_DIV_8_BIT
 #define SPI_TARGET_CLK_DIV_BASE        (4U)
-#define SPI_TARGET_CLK_DIV_INVALID      (0xFFU)
 
 // mp_hal_ticks_ms() on this port wraps every SPI_TARGET_TICKS_WRAP_MS.
 // This computes elapsed time across one wrap; caller keeps timeout < wrap period.
@@ -65,7 +63,7 @@ typedef struct _machine_spi_target_obj_t {
     uint8_t bits;
     uint8_t firstbit;
     uint32_t timeout;
-    uint8_t div_num;  // Clock divider number for PCLK
+    pclk_div_obj_t *pclk_div;
     machine_scb_obj_t *scb_obj;
     cy_stc_scb_spi_config_t cfg;
     cy_stc_scb_spi_context_t ctx;
@@ -77,7 +75,6 @@ static inline machine_spi_target_obj_t *machine_spi_target_obj_alloc(void) {
     for (uint8_t i = 0; i < MICROPY_PY_MACHINE_SPI_TARGET_MAX; i++) {
         if (machine_spi_target_obj[i] == NULL) {
             machine_spi_target_obj[i] = mp_obj_malloc(machine_spi_target_obj_t, &machine_spi_target_type);
-            machine_spi_target_obj[i]->div_num = SPI_TARGET_CLK_DIV_INVALID;
             return machine_spi_target_obj[i];
         }
     }
@@ -144,27 +141,19 @@ static void machine_spi_target_hw_init(machine_spi_target_obj_t *self) {
     uint8_t scb_unit = machine_spi_target_pins_config_and_get_scb_unit(
         self->sck, self->mosi, self->miso, self->ssel);
 
-    // Power on the peripheral group that contains this SCB.
-    machine_scb_enable_group(scb_unit);
 
     // Allocate SCB
     self->scb_obj = machine_scb_obj_alloc(scb_unit, self,
         machine_spi_target_scb_isr);
 
-    if (!machine_scb_div8_try_alloc(self->scb_obj->clk,
-        SPI_TARGET_CLK_DIV_BASE,
-        SPI_TARGET_CLK_DIV_INVALID,
-        self,
-        &self->div_num)) {
+    pclk_div_slave_init(self->scb_obj->clk, self->scb_obj->mmio_slave_nr);
+    self->pclk_div = pclk_div_init(self->scb_obj->clk, SPI_TARGET_CLK_DIV_BASE, 0);
+    if (self->pclk_div == NULL) {
+        pclk_div_slave_deinit(self->scb_obj->clk, self->scb_obj->mmio_slave_nr);
         machine_scb_obj_free(self->scb_obj);
         self->scb_obj = NULL;
         mp_raise_ValueError(MP_ERROR_TEXT("SPITarget clock dividers exhausted"));
     }
-
-    // Configure SPI PCLK divider (needed for slave's internal clock even though
-    // the bit clock comes from master's SCK)
-    machine_scb_peri_pclk_config_divider(self->scb_obj->clk,
-        SPI_TARGET_CLK_DIV_TYPE, self->div_num, 0U);
 
     // Select SPI clock polarity and phase
     cy_en_scb_spi_sclk_mode_t sclk_mode;
@@ -214,8 +203,9 @@ static void machine_spi_target_hw_init(machine_spi_target_obj_t *self) {
         Cy_SCB_SPI_Init(self->scb_obj->scb, &self->cfg, &self->ctx);
 
     if (result != CY_SCB_SPI_SUCCESS) {
-        machine_scb_div8_free(self->scb_obj->clk, self->div_num, self);
-        self->div_num = SPI_TARGET_CLK_DIV_INVALID;
+        pclk_div_deinit(self->pclk_div);
+        self->pclk_div = NULL;
+        pclk_div_slave_deinit(self->scb_obj->clk, self->scb_obj->mmio_slave_nr);
         machine_scb_obj_free(self->scb_obj);
         self->scb_obj = NULL;
         mp_raise_msg_varg(&mp_type_ValueError,
@@ -230,11 +220,9 @@ static void machine_spi_target_hw_deinit(machine_spi_target_obj_t *self) {
     Cy_SCB_SPI_Disable(self->scb_obj->scb, &self->ctx);
     Cy_SCB_SPI_DeInit(self->scb_obj->scb);
     sys_int_deinit(&self->scb_obj->irq);
-    if (self->div_num != SPI_TARGET_CLK_DIV_INVALID) {
-        machine_scb_div8_free(self->scb_obj->clk, self->div_num, self);
-        Cy_SysClk_PeriPclkDisableDivider(self->scb_obj->clk, SPI_TARGET_CLK_DIV_TYPE, self->div_num);
-        self->div_num = SPI_TARGET_CLK_DIV_INVALID;
-    }
+    pclk_div_deinit(self->pclk_div);
+    self->pclk_div = NULL;
+    pclk_div_slave_deinit(self->scb_obj->clk, self->scb_obj->mmio_slave_nr);
     machine_scb_obj_free(self->scb_obj);
     self->scb_obj = NULL;
 }
@@ -282,6 +270,7 @@ static mp_obj_t machine_spi_target_make_new(const mp_obj_type_t *type, size_t n_
     self->bits = args[ARG_bits].u_int;
     self->firstbit = args[ARG_firstbit].u_int;
     self->timeout = DEFAULT_SPI_TARGET_TIMEOUT_MS;
+    self->pclk_div = NULL;
     self->scb_obj = NULL;
 
     nlr_buf_t nlr;

--- a/ports/psoc-edge/machine_uart.c
+++ b/ports/psoc-edge/machine_uart.c
@@ -219,7 +219,7 @@ static void machine_uart_obj_make_or_reuse(machine_uart_obj_t **self_ptr, uint8_
             (*self_ptr)->id = id;
             (*self_ptr)->pclk_div = NULL;
             (*self_ptr)->scb_obj = machine_scb_obj_alloc(id, *self_ptr, machine_uart_scb_isr);
-            pclk_div_slave_init((*self_ptr)->scb_obj->clk, (*self_ptr)->scb_obj->slave_nr);
+            pclk_div_slave_init((*self_ptr)->scb_obj->clk, (*self_ptr)->scb_obj->mmio_slave_nr);
         } else {
             mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("SCB %u is already in use by a machine.I2C or machine.SPI instance."), id);
         }
@@ -670,7 +670,7 @@ static mp_obj_t mp_machine_uart_make_new(const mp_obj_type_t *type, size_t n_arg
 static void mp_machine_uart_deinit(machine_uart_obj_t *self) {
     machine_uart_hw_deinit(self);
     m_del(uint8_t, self->rx_ringbuf.buf, self->rx_ringbuf.size);
-    pclk_div_slave_deinit(self->scb_obj->clk, self->scb_obj->slave_nr);
+    pclk_div_slave_deinit(self->scb_obj->clk, self->scb_obj->mmio_slave_nr);
     machine_scb_obj_free(self->scb_obj);
     mp_machine_uart_obj_free(self);
 }


### PR DESCRIPTION
* Removed SCB clock divider functionality in `machine_scb` moved to the general `clk` lib.
* Implemented `machine_spi` and `machine_spi_target` based on new share clock peripheral divider library.
* Updated renamed `machin_scb_obj_t` attribute in `machine_uart`.