### PR TITLE
tests/ports/psoc-edge/test-plan: Disabled temporarity unittest tests.

### DIFF
--- a/tests/ports/psoc-edge/test-plan.yml
+++ b/tests/ports/psoc-edge/test-plan.yml
@@ -104,7 +104,9 @@
       - extmod/socket_badconstructor.py
       - extmod/socket_fileno.py
       - extmod/socket_tcp_basic.py
-      - extmod/socket_udp_nonblock.py
+      # TODO: Re-enable tests after effectively installing unittest 
+      # only for the target boards running the affected tests.
+      # - extmod/socket_udp_nonblock.py
       - net_hosted/accept_nonblock.py
       - net_hosted/accept_timeout.py
     device:


### PR DESCRIPTION
I just momentarily commented that test.
We just need to install unittest before running that test. 
We can do it for all boards, and maybe make sense because other tests also can o might use unittest. 
But that also will add some time in every ci run.
So I will create a ticket for that, and momentarily just comment it to keep this letting us when things fail. 