### PR TITLE
Machine adc csv bsp int conversion warning

### DIFF
--- a/extmod/machine_adc_block.c
+++ b/extmod/machine_adc_block.c
@@ -87,7 +87,7 @@ static MP_DEFINE_CONST_FUN_OBJ_KW(machine_adc_block_init_obj, 1, machine_adc_blo
 static mp_obj_t machine_adc_block_connect(size_t n_pos_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     machine_adc_block_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
     mp_int_t channel_id = -1;
-    mp_hal_pin_obj_t pin = -1;
+    mp_hal_pin_obj_t pin = MP_HAL_PIN_OBJ_NULL;
     if (n_pos_args == 2) {
         if (mp_obj_is_int(pos_args[1])) {
             channel_id = mp_obj_get_int(pos_args[1]);

--- a/ports/esp32/mphalport.h
+++ b/ports/esp32/mphalport.h
@@ -110,6 +110,7 @@ void mp_hal_wake_main_task_from_isr(void);
 #include "py/obj.h"
 #include "driver/gpio.h"
 #define MP_HAL_PIN_FMT "%u"
+#define MP_HAL_PIN_OBJ_NULL ((mp_hal_pin_obj_t)-1)
 #define mp_hal_pin_obj_t gpio_num_t
 mp_hal_pin_obj_t machine_pin_get_id(mp_obj_t pin_in);
 #define mp_hal_get_pin_obj(o) machine_pin_get_id(o)

--- a/ports/psoc-edge/Makefile
+++ b/ports/psoc-edge/Makefile
@@ -510,10 +510,6 @@ endif
 
 CFLAGS += $(INC)
 
-# Keep extmod shared code unchanged: suppress this pointer/int sentinel warning
-# only for machine_adc_block.c in this port.
-$(BUILD)/extmod/machine_adc_block.o: CFLAGS += -Wno-int-conversion
-
 ifeq ($(MICROPY_PY_FREERTOS),1)
 CFLAGS += -DMICROPY_PY_FREERTOS=1
 endif

--- a/ports/psoc-edge/mphalport.h
+++ b/ports/psoc-edge/mphalport.h
@@ -66,6 +66,7 @@ void mp_hal_set_interrupt_char(int c); // -1 to disable
 
 
 #define MP_HAL_PIN_FMT          "\'%q\'"
+#define MP_HAL_PIN_OBJ_NULL     ((mp_hal_pin_obj_t)NULL)
 #define mp_hal_pin_obj_t        const machine_pin_obj_t *
 #define mp_hal_get_pin_obj(o)   machine_pin_get_pin_obj(o)
 #define mp_hal_pin_name(p)      ((p)->name)


### PR DESCRIPTION
I would not suppress the warning during compilation. That -1 is not a valid value in our case, and add ignore to any other warning for this type of conversion.
 
The `extmod/machine_adc_block` is only used by esp32, therefore it has some port specific initialization.
That should be fixed somehow in the `extmod` itself, as each port implements a different `mp_hal_pin_obj_t`  type. 

I though of just adding a macro which each port needs to define for itself. Maybe other ways would minimize adding changes to ports... That pin need to be initialized to -1? 
But maybe a point for discussion when pushing to the upstream.



