### PR TITLE
Counter Init() parameters, cycles() and IRQ()

### DIFF
--- a/docs/psoc-edge/quickref.rst
+++ b/docs/psoc-edge/quickref.rst
@@ -940,9 +940,9 @@ Complete example
 Counter
 -------
 
-Hardware edge counter using TCPWM0 on PSOC\ |trade|\ Edge. See :ref:`machine.Counter <machine.Counter>` for the common API.
+Hardware edge counter using TCPWM0 on PSOC-Edge. See :ref:`machine.Counter <machine.Counter>` for the common API.
 
-This section lists only PSOC\ |trade|\ Edge specifics and deviations.
+This section lists only PSOC-Edge specifics and deviations.
 
 .. note::
 

--- a/docs/psoc-edge/quickref.rst
+++ b/docs/psoc-edge/quickref.rst
@@ -948,7 +948,7 @@ This section lists only PSOC-Edge specifics and deviations.
 
     - IDs ``0`` to ``31`` are available (same TCPWM mapping as ``Timer``: 32-bit IDs ``0-7``, 16-bit IDs ``8-31``).
     - ``src`` must be a pin with ``PERI_TR_IO_INPUT`` routing. On KIT_PSE84_AI these are: ``P11_1``, ``P11_3``, ``P7_7``, ``P8_0``.
-    - ``min`` and ``max`` must both be ``>= 0``, and ``min`` must be ``< max``.
+    - ``min`` must be ``< max``. Both can be negative (e.g., ``min=-100, max=100``).
     - ``max`` and ``match`` must fit the selected counter width/range.
     - ``filter_ns`` is currently not supported.
     - ``match_pin`` is currently not supported.
@@ -977,10 +977,10 @@ Complete example
         edge=Counter.RISING,
         direction=Counter.UP,
         max=100,
-        min=0,
+        min=-50,
         index=Pin("P11_3"),
         reset=Pin("P11_3"),
-        match=10,
+        match=-25,
     )
 
     # value()/cycles()/match() read-write API.

--- a/docs/psoc-edge/quickref.rst
+++ b/docs/psoc-edge/quickref.rst
@@ -947,6 +947,7 @@ This section lists only PSOC-Edge specifics and deviations.
 .. note::
 
     - IDs ``0`` to ``31`` are available (same TCPWM mapping as ``Timer``: 32-bit IDs ``0-7``, 16-bit IDs ``8-31``).
+    - Constructing ``Counter(id)`` again while that instance is active raises ValueError instead of returning/reinitialising the existing instance. Call ``deinit()`` first.
     - ``src`` must be a pin with ``PERI_TR_IO_INPUT`` routing. On KIT_PSE84_AI these are: ``P11_1``, ``P11_3``, ``P7_7``, ``P8_0``.
     - ``min`` must be ``< max``. Both can be negative (e.g., ``min=-100, max=100``).
     - ``max`` and ``match`` must fit the selected counter width/range.

--- a/docs/psoc-edge/quickref.rst
+++ b/docs/psoc-edge/quickref.rst
@@ -950,7 +950,7 @@ This section lists only PSOC-Edge specifics and deviations.
     - Constructing ``Counter(id)`` again while that instance is active raises ValueError instead of returning/reinitialising the existing instance. Call ``deinit()`` first.
     - ``src`` must be a pin with ``PERI_TR_IO_INPUT`` routing. On KIT_PSE84_AI these are: ``P11_1``, ``P11_3``, ``P7_7``, ``P8_0``.
     - ``min`` must be ``< max``. Both can be negative (e.g., ``min=-100, max=100``).
-    - ``max`` and ``match`` must fit the selected counter width/range.
+    - ``match`` is an init-only parameter. It cannot be changed at runtime.
     - ``filter_ns`` is currently not supported.
     - ``match_pin`` is currently not supported.
 
@@ -983,12 +983,10 @@ Complete example
         match=-25,
     )
 
-    # value()/cycles()/match() read-write API.
+    # value()/cycles() read-write API.
     print("value:", c.value())
     print("cycles:", c.cycles())
-    print("match:", c.match())
     c.cycles(2)
-    c.match(20)
 
     irq_events = 0
 
@@ -1011,9 +1009,6 @@ Complete example
     print("cycles after pulses:", c.cycles())
     print("irq flags:", irq.flags())
     print("irq calls:", irq_events)
-
-    # Disable match dynamically.
-    c.match(None)
 
     c.deinit()
 

--- a/docs/psoc-edge/quickref.rst
+++ b/docs/psoc-edge/quickref.rst
@@ -953,7 +953,6 @@ This section lists only PSOC-Edge specifics and deviations.
     - ``max`` and ``match`` must fit the selected counter width/range.
     - ``filter_ns`` is currently not supported.
     - ``match_pin`` is currently not supported.
-    - Under RTOS-aware builds, ``Counter.irq(..., hard=True)`` is forced to soft IRQ callbacks.
 
 Complete example
 ^^^^^^^^^^^^^^^^

--- a/docs/psoc-edge/quickref.rst
+++ b/docs/psoc-edge/quickref.rst
@@ -937,6 +937,86 @@ Complete example
     tim.deinit()
     print("hard fired:", fired[0])
 
+Counter
+-------
+
+Hardware edge counter using TCPWM0 on PSOC\ |trade|\ Edge. See :ref:`machine.Counter <machine.Counter>` for the common API.
+
+This section lists only PSOC\ |trade|\ Edge specifics and deviations.
+
+.. note::
+
+    - IDs ``0`` to ``31`` are available (same TCPWM mapping as ``Timer``: 32-bit IDs ``0-7``, 16-bit IDs ``8-31``).
+    - ``src`` must be a pin with ``PERI_TR_IO_INPUT`` routing. On KIT_PSE84_AI these are: ``P11_1``, ``P11_3``, ``P7_7``, ``P8_0``.
+    - ``min`` and ``max`` must both be ``>= 0``, and ``min`` must be ``< max``.
+    - ``max`` and ``match`` must fit the selected counter width/range.
+    - ``filter_ns`` is currently not supported.
+    - ``match_pin`` is currently not supported.
+    - Under RTOS-aware builds, ``Counter.irq(..., hard=True)`` is forced to soft IRQ callbacks.
+
+Complete example
+^^^^^^^^^^^^^^^^
+
+::
+
+    # Setup on KIT_PSE84_AI:
+    #   P16_7 -> P11_1  (pulse source -> counter src)
+    # Optional for index/reset demo:
+    #   P16_6 -> P11_3
+
+    from machine import Counter, Pin
+    import time
+
+    src = Pin("P11_1")
+    pulse_out = Pin("P16_7", Pin.OUT, value=0)
+
+    # Uses edge/direction/max/min/index/reset/match in one init.
+    c = Counter(
+        0,
+        src=src,
+        edge=Counter.RISING,
+        direction=Counter.UP,
+        max=100,
+        min=0,
+        index=Pin("P11_3"),
+        reset=Pin("P11_3"),
+        match=10,
+    )
+
+    # value()/cycles()/match() read-write API.
+    print("value:", c.value())
+    print("cycles:", c.cycles())
+    print("match:", c.match())
+    c.cycles(2)
+    c.match(20)
+
+    irq_events = 0
+
+    def on_counter_irq(_counter):
+        global irq_events
+        irq_events += 1
+
+    # Subscribe to multiple trigger sources (bitmask).
+    irq = c.irq(handler=on_counter_irq,
+                trigger=Counter.IRQ_ROLL_OVER | Counter.IRQ_MATCH | Counter.IRQ_INDEX | Counter.IRQ_RESET)
+
+    # Generate a few pulses on src.
+    for _ in range(30):
+        pulse_out(1)
+        time.sleep_us(100)
+        pulse_out(0)
+        time.sleep_us(100)
+
+    print("value after pulses:", c.value())
+    print("cycles after pulses:", c.cycles())
+    print("irq flags:", irq.flags())
+    print("irq calls:", irq_events)
+
+    # Disable match dynamically.
+    c.match(None)
+
+    c.deinit()
+
 Network Module
 --------------
 

--- a/ports/psoc-edge/machine_counter.c
+++ b/ports/psoc-edge/machine_counter.c
@@ -1044,12 +1044,6 @@ static mp_obj_t machine_counter_irq(size_t n_args, const mp_obj_t *pos_args, mp_
         self->mp_irq_obj->handler = handler;
         self->mp_irq_obj->ishard = args[MP_IRQ_ARG_INIT_hard].u_bool;
 
-        #if defined(CY_RTOS_AWARE)
-        if (self->mp_irq_obj->ishard) {
-            self->mp_irq_obj->ishard = false;
-        }
-        #endif
-
         self->mp_irq_flags = 0;
         self->mp_irq_trigger = trigger;
 

--- a/ports/psoc-edge/machine_counter.c
+++ b/ports/psoc-edge/machine_counter.c
@@ -519,8 +519,9 @@ static void machine_counter_init_helper_impl(machine_counter_obj_t *self,
         mp_raise_NotImplementedError(MP_ERROR_TEXT("filter_ns not supported"));
     }
 
-    mp_int_t min = args[ARG_min].u_int;
-    if (min < 0) {
+    uint32_t min = args[ARG_min].u_int;
+    // TODO: support negative min/max values (similar to MIMXRT port)
+    if ((mp_int_t)min < 0) {
         mp_raise_ValueError(MP_ERROR_TEXT("min must be >= 0"));
     }
 
@@ -541,6 +542,7 @@ static void machine_counter_init_helper_impl(machine_counter_obj_t *self,
     uint32_t range_max = max_hw;
     if (args[ARG_max].u_obj != mp_const_none) {
         mp_int_t max = mp_obj_get_int(args[ARG_max].u_obj);
+        // TODO: support negative max values (similar to MIMXRT port)
         if (max < 0) {
             mp_raise_ValueError(MP_ERROR_TEXT("max must be >= 0"));
         }
@@ -553,7 +555,7 @@ static void machine_counter_init_helper_impl(machine_counter_obj_t *self,
         }
     }
 
-    if ((uint64_t)min >= (uint64_t)range_max) {
+    if (min >= range_max) {
         mp_raise_ValueError(MP_ERROR_TEXT("min must be < max"));
     }
 
@@ -564,7 +566,7 @@ static void machine_counter_init_helper_impl(machine_counter_obj_t *self,
 
     if (args[ARG_match].u_obj != mp_const_none) {
         mp_int_t match = mp_obj_get_int(args[ARG_match].u_obj);
-        if (match < min || (uint64_t)match > (uint64_t)range_max) {
+        if (match < (mp_int_t)min || match > (mp_int_t)range_max) {
             mp_raise_ValueError(MP_ERROR_TEXT("match out of range"));
         }
         match_enabled = true;
@@ -916,7 +918,7 @@ static mp_obj_t machine_counter_match(size_t n_args, const mp_obj_t *args) {
     }
 
     mp_obj_t prev = self->match_enabled
-        ? mp_obj_new_int_from_uint(self->range_min + self->match_value)
+        ? mp_obj_new_int_from_ll(self->range_min + self->match_value)
         : mp_const_none;
 
     if (n_args == 2) {
@@ -929,11 +931,11 @@ static mp_obj_t machine_counter_match(size_t n_args, const mp_obj_t *args) {
             MICROPY_END_ATOMIC_SECTION(irq_state);
         } else {
             mp_int_t match = mp_obj_get_int(args[1]);
-            if (match < (mp_int_t)self->range_min || (uint64_t)match > (uint64_t)self->range_max) {
+            if (match < (mp_int_t)self->range_min || match > (mp_int_t)self->range_max) {
                 mp_raise_ValueError(MP_ERROR_TEXT("match out of range"));
             }
 
-            uint32_t match_value = (uint32_t)((mp_uint_t)match - self->range_min);
+            uint32_t match_value = (uint32_t)((mp_uint_t)match - (mp_uint_t)self->range_min);
             mp_uint_t irq_state = MICROPY_BEGIN_ATOMIC_SECTION();
             self->match_enabled = true;
             self->match_value = match_value;

--- a/ports/psoc-edge/machine_counter.c
+++ b/ports/psoc-edge/machine_counter.c
@@ -47,6 +47,9 @@
 // Reuse machine.Pin IRQ API to implement Counter index input callbacks.
 extern mp_obj_t machine_pin_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args);
 
+// Forward declaration so init-failure path can reuse deinit logic.
+static mp_obj_t machine_counter_deinit(mp_obj_t self_in);
+
 // Number of Counter object slots supported by this port.
 #define MACHINE_COUNTER_NUM_INSTANCES  (32)
 // Shared TCPWM source clock frequency used by Counter.
@@ -71,6 +74,7 @@ typedef enum {
 #define MACHINE_COUNTER_IRQ_ROLL_OVER  (1U << 4)
 #define MACHINE_COUNTER_ALLOWED_FLAGS  (MACHINE_COUNTER_IRQ_RESET \
     | MACHINE_COUNTER_IRQ_INDEX \
+    | MACHINE_COUNTER_IRQ_MATCH \
     | MACHINE_COUNTER_IRQ_ROLL_UNDER \
     | MACHINE_COUNTER_IRQ_ROLL_OVER)
 
@@ -82,6 +86,8 @@ typedef struct _machine_counter_obj_t {
     mp_hal_pin_obj_t src_pin;
     const machine_pin_obj_t *index_pin;
     const machine_pin_obj_t *reset_pin;
+    uint32_t match_value;
+    bool match_enabled;
     uint8_t edge;
     uint8_t direction;
     uint32_t range_min;
@@ -228,6 +234,18 @@ static inline int16_t machine_counter_cycles_get(const machine_counter_obj_t *se
     return (int16_t)self->cycles_u16;
 }
 
+static inline uint32_t machine_counter_interrupt_mask(const machine_counter_obj_t *self) {
+    return CY_TCPWM_INT_ON_TC | (self->match_enabled ? CY_TCPWM_INT_ON_CC0 : 0U);
+}
+
+static inline void machine_counter_apply_interrupt_mask(const machine_counter_obj_t *self) {
+    Cy_TCPWM_SetInterruptMask(TCPWM0, self->counter_num, machine_counter_interrupt_mask(self));
+}
+
+static inline void clear_counter_irqs(const machine_counter_obj_t *self, uint32_t mask) {
+    Cy_TCPWM_ClearInterrupt(TCPWM0, self->counter_num, mask);
+}
+
 // Increment/decrement cycles counter with 16-bit wrap semantics.
 static inline void machine_counter_cycles_step(machine_counter_obj_t *self) {
     if (self->direction == COUNTER_DIR_DOWN) {
@@ -274,10 +292,33 @@ static inline void machine_counter_irq_raise(machine_counter_obj_t *self, mp_uin
     }
 }
 
+static mp_obj_t machine_counter_enable_aux_irq(const machine_pin_obj_t *pin, mp_obj_t handler_obj) {
+    mp_hal_pin_input(pin);
+
+    mp_obj_t pos_args[] = {
+        MP_OBJ_FROM_PTR((machine_pin_obj_t *)pin),
+        handler_obj,
+    };
+    mp_obj_t kw_table[] = {
+        MP_OBJ_NEW_QSTR(MP_QSTR_trigger), MP_OBJ_NEW_SMALL_INT(CY_GPIO_INTR_RISING),
+        MP_OBJ_NEW_QSTR(MP_QSTR_hard), mp_const_true,
+    };
+    mp_map_t kw_args;
+    mp_map_init_fixed_table(&kw_args, MP_ARRAY_SIZE(kw_table) / 2, kw_table);
+    return machine_pin_irq(2, pos_args, &kw_args);
+}
+
 // Counter terminal-count ISR: track wrap events in software cycles.
 static void machine_counter_isr(machine_counter_obj_t *self) {
-    if (Cy_TCPWM_GetInterruptStatus(TCPWM0, self->counter_num) & CY_TCPWM_INT_ON_TC) {
-        Cy_TCPWM_ClearInterrupt(TCPWM0, self->counter_num, CY_TCPWM_INT_ON_TC);
+    uint32_t status = Cy_TCPWM_GetInterruptStatus(TCPWM0, self->counter_num);
+
+    if (status & CY_TCPWM_INT_ON_CC0) {
+        clear_counter_irqs(self, CY_TCPWM_INT_ON_CC0);
+        machine_counter_irq_raise(self, MACHINE_COUNTER_IRQ_MATCH);
+    }
+
+    if (status & CY_TCPWM_INT_ON_TC) {
+        clear_counter_irqs(self, CY_TCPWM_INT_ON_TC);
         machine_counter_cycles_step(self);
         machine_counter_irq_raise(self,
             (self->direction == COUNTER_DIR_DOWN)
@@ -301,7 +342,7 @@ static inline void machine_counter_on_aux_event(machine_counter_obj_t *self, boo
         machine_counter_cycles_step(self);
     }
     Cy_TCPWM_Counter_SetCounter(TCPWM0, self->counter_num, 0);
-    Cy_TCPWM_ClearInterrupt(TCPWM0, self->counter_num, CY_TCPWM_INT_ON_TC);
+    clear_counter_irqs(self, CY_TCPWM_INT_ON_TC | CY_TCPWM_INT_ON_CC0);
     MICROPY_END_ATOMIC_SECTION(irq_state);
     machine_counter_irq_raise(self, irq_flag);
 }
@@ -416,25 +457,6 @@ static const mp_obj_t machine_counter_index_reset_handler_obj[MACHINE_COUNTER_NU
 
 // -------------------------------------------------------------------------- //
 
-// Roll back Counter state and release channel ownership after init failure.
-static void machine_counter_init_fail_cleanup(machine_counter_obj_t *self) {
-    machine_counter_stop_hw(self);
-    machine_counter_stop_irq(self);
-    machine_counter_disable_aux_irqs(self);
-    machine_counter_restore_src_pin(self);
-    self->configured = false;
-    self->cycles_u16 = 0;
-    self->offset = 0;
-    self->mp_irq_flags = 0;
-    self->mp_irq_trigger = 0;
-    if (self->mp_irq_obj != NULL) {
-        self->mp_irq_obj->handler = mp_const_none;
-    }
-
-    machine_tcpwm_counter_free(self->counter_num, MP_OBJ_FROM_PTR(self));
-    counter_obj[self->id] = NULL;
-}
-
 // Parse init args and configure routing, trigger mux, and TCPWM hardware.
 static void machine_counter_init_helper_impl(machine_counter_obj_t *self,
     size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
@@ -499,9 +521,7 @@ static void machine_counter_init_helper_impl(machine_counter_obj_t *self,
     if (args[ARG_reset].u_obj != mp_const_none) {
         reset_pin = mp_hal_get_pin_obj(args[ARG_reset].u_obj);
     }
-    if (args[ARG_match].u_obj != mp_const_none) {
-        mp_raise_NotImplementedError(MP_ERROR_TEXT("match not supported"));
-    }
+
     if (args[ARG_match_pin].u_obj != mp_const_none) {
         mp_raise_NotImplementedError(MP_ERROR_TEXT("match_pin not supported"));
     }
@@ -528,6 +548,17 @@ static void machine_counter_init_helper_impl(machine_counter_obj_t *self,
 
     uint32_t range_min = (uint32_t)min;
     uint32_t period = range_max - range_min;
+    bool match_enabled = false;
+    uint32_t match_value = 0;
+
+    if (args[ARG_match].u_obj != mp_const_none) {
+        mp_int_t match = mp_obj_get_int(args[ARG_match].u_obj);
+        if (match < min || (uint64_t)match > (uint64_t)range_max) {
+            mp_raise_ValueError(MP_ERROR_TEXT("match out of range"));
+        }
+        match_enabled = true;
+        match_value = (uint32_t)((mp_uint_t)match - range_min);
+    }
 
     // Resolve source pin object and validate it exposes Counter input AF.
     mp_hal_pin_obj_t src_pin = mp_hal_get_pin_obj(args[ARG_src].u_obj);
@@ -574,40 +605,20 @@ static void machine_counter_init_helper_impl(machine_counter_obj_t *self,
         && self->index_pin == self->reset_pin);
 
     if (self->index_pin != NULL) {
-        mp_hal_pin_input(self->index_pin);
-
-        mp_obj_t pos_args[] = {
-            MP_OBJ_FROM_PTR((machine_pin_obj_t *)self->index_pin),
+        self->index_irq_obj = machine_counter_enable_aux_irq(
+            self->index_pin,
             index_reset_same_pin
                 ? machine_counter_index_reset_handler_obj[self->id]
-                : machine_counter_index_handler_obj[self->id],
-        };
-        mp_obj_t kw_table[] = {
-            MP_OBJ_NEW_QSTR(MP_QSTR_trigger), MP_OBJ_NEW_SMALL_INT(CY_GPIO_INTR_RISING),
-            MP_OBJ_NEW_QSTR(MP_QSTR_hard), mp_const_true,
-        };
-        mp_map_t kw_args;
-        mp_map_init_fixed_table(&kw_args, MP_ARRAY_SIZE(kw_table) / 2, kw_table);
-        self->index_irq_obj = machine_pin_irq(2, pos_args, &kw_args);
+                : machine_counter_index_handler_obj[self->id]);
         if (index_reset_same_pin) {
             self->reset_irq_obj = self->index_irq_obj;
         }
     }
 
     if (self->reset_pin != NULL && !index_reset_same_pin) {
-        mp_hal_pin_input(self->reset_pin);
-
-        mp_obj_t pos_args[] = {
-            MP_OBJ_FROM_PTR((machine_pin_obj_t *)self->reset_pin),
-            machine_counter_reset_handler_obj[self->id],
-        };
-        mp_obj_t kw_table[] = {
-            MP_OBJ_NEW_QSTR(MP_QSTR_trigger), MP_OBJ_NEW_SMALL_INT(CY_GPIO_INTR_RISING),
-            MP_OBJ_NEW_QSTR(MP_QSTR_hard), mp_const_true,
-        };
-        mp_map_t kw_args;
-        mp_map_init_fixed_table(&kw_args, MP_ARRAY_SIZE(kw_table) / 2, kw_table);
-        self->reset_irq_obj = machine_pin_irq(2, pos_args, &kw_args);
+        self->reset_irq_obj = machine_counter_enable_aux_irq(
+            self->reset_pin,
+            machine_counter_reset_handler_obj[self->id]);
     }
 
     cy_stc_tcpwm_counter_config_t cfg = {0};
@@ -616,10 +627,10 @@ static void machine_counter_init_helper_impl(machine_counter_obj_t *self,
     cfg.runMode = CY_TCPWM_COUNTER_CONTINUOUS;
     cfg.countDirection = CY_TCPWM_COUNTER_COUNT_UP;
     cfg.compareOrCapture = CY_TCPWM_COUNTER_MODE_COMPARE;
-    cfg.compare0 = 0;
+    cfg.compare0 = match_value;
     cfg.compare1 = 0;
     cfg.enableCompareSwap = false;
-    cfg.interruptSources = CY_TCPWM_INT_ON_TC;
+    cfg.interruptSources = CY_TCPWM_INT_ON_TC | (match_enabled ? CY_TCPWM_INT_ON_CC0 : 0U);
     cfg.captureInputMode = COUNTER_INPUT_DISABLED & 0x3U;
     cfg.captureInput = CY_TCPWM_INPUT_0;
     cfg.reloadInputMode = COUNTER_INPUT_DISABLED & 0x3U;
@@ -651,7 +662,7 @@ static void machine_counter_init_helper_impl(machine_counter_obj_t *self,
     }
 
     Cy_TCPWM_Counter_SetCounter(TCPWM0, self->counter_num, 0);
-    Cy_TCPWM_ClearInterrupt(TCPWM0, self->counter_num, CY_TCPWM_INT_ON_TC);
+    clear_counter_irqs(self, CY_TCPWM_INT_ON_TC | CY_TCPWM_INT_ON_CC0);
 
     self->irq_cfg.priority = SYS_INT_IRQ_LOWEST_PRIORITY;
     self->irq_cfg.handler = machine_counter_irq_handlers[self->id];
@@ -665,8 +676,11 @@ static void machine_counter_init_helper_impl(machine_counter_obj_t *self,
     self->direction = direction;
     self->range_min = range_min;
     self->range_max = range_max;
+    self->match_enabled = match_enabled;
+    self->match_value = match_value;
     self->cycles_u16 = 0;
     self->offset = 0;
+    machine_counter_apply_interrupt_mask(self);
     self->configured = true;
 }
 
@@ -679,7 +693,7 @@ static void machine_counter_init_helper(machine_counter_obj_t *self,
         machine_counter_init_helper_impl(self, n_args, pos_args, kw_args);
         nlr_pop();
     } else {
-        machine_counter_init_fail_cleanup(self);
+        machine_counter_deinit(MP_OBJ_FROM_PTR(self));
         nlr_jump(nl.ret_val);
     }
 }
@@ -715,6 +729,8 @@ static mp_obj_t machine_counter_make_new(const mp_obj_type_t *type,
     self->src_pin = NULL;
     self->index_pin = NULL;
     self->reset_pin = NULL;
+    self->match_value = 0;
+    self->match_enabled = false;
     self->edge = COUNTER_EDGE_RISING;
     self->direction = COUNTER_DIR_UP;
     self->range_min = 0;
@@ -775,6 +791,8 @@ static mp_obj_t machine_counter_deinit(mp_obj_t self_in) {
     self->configured = false;
     self->cycles_u16 = 0;
     self->offset = 0;
+    self->match_enabled = false;
+    self->match_value = 0;
     self->mp_irq_flags = 0;
     self->mp_irq_trigger = 0;
     if (self->mp_irq_obj != NULL) {
@@ -831,7 +849,7 @@ static mp_obj_t machine_counter_value(size_t n_args, const mp_obj_t *args) {
         self->offset = mp_obj_get_int(args[1]);
         self->cycles_u16 = 0;
         Cy_TCPWM_Counter_SetCounter(TCPWM0, self->counter_num, 0);
-        Cy_TCPWM_ClearInterrupt(TCPWM0, self->counter_num, CY_TCPWM_INT_ON_TC);
+        clear_counter_irqs(self, CY_TCPWM_INT_ON_TC | CY_TCPWM_INT_ON_CC0);
         Cy_TCPWM_Counter_Enable(TCPWM0, self->counter_num);
         Cy_TCPWM_TriggerReloadOrIndex_Single(TCPWM0, self->counter_num);
     }
@@ -865,6 +883,47 @@ static mp_obj_t machine_counter_cycles(size_t n_args, const mp_obj_t *args) {
     return mp_obj_new_int(prev);
 }
 static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_counter_cycles_obj, 1, 2, machine_counter_cycles);
+
+// Get or set compare-match value; pass None to disable match.
+static mp_obj_t machine_counter_match(size_t n_args, const mp_obj_t *args) {
+    machine_counter_obj_t *self = MP_OBJ_TO_PTR(args[0]);
+
+    if (!self->configured) {
+        mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("not initialised"));
+    }
+
+    mp_obj_t prev = self->match_enabled
+        ? mp_obj_new_int_from_uint(self->range_min + self->match_value)
+        : mp_const_none;
+
+    if (n_args == 2) {
+        if (args[1] == mp_const_none) {
+            mp_uint_t irq_state = MICROPY_BEGIN_ATOMIC_SECTION();
+            self->match_enabled = false;
+            self->match_value = 0;
+            machine_counter_apply_interrupt_mask(self);
+            clear_counter_irqs(self, CY_TCPWM_INT_ON_CC0);
+            MICROPY_END_ATOMIC_SECTION(irq_state);
+        } else {
+            mp_int_t match = mp_obj_get_int(args[1]);
+            if (match < (mp_int_t)self->range_min || (uint64_t)match > (uint64_t)self->range_max) {
+                mp_raise_ValueError(MP_ERROR_TEXT("match out of range"));
+            }
+
+            uint32_t match_value = (uint32_t)((mp_uint_t)match - self->range_min);
+            mp_uint_t irq_state = MICROPY_BEGIN_ATOMIC_SECTION();
+            self->match_enabled = true;
+            self->match_value = match_value;
+            Cy_TCPWM_Counter_SetCompare0(TCPWM0, self->counter_num, match_value);
+            machine_counter_apply_interrupt_mask(self);
+            clear_counter_irqs(self, CY_TCPWM_INT_ON_CC0);
+            MICROPY_END_ATOMIC_SECTION(irq_state);
+        }
+    }
+
+    return prev;
+}
+static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_counter_match_obj, 1, 2, machine_counter_match);
 
 // counter.irq(handler=None, trigger=0, hard=False)
 static mp_obj_t machine_counter_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
@@ -935,6 +994,7 @@ static const mp_rom_map_elem_t machine_counter_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_irq), MP_ROM_PTR(&machine_counter_irq_obj) },
     { MP_ROM_QSTR(MP_QSTR_value), MP_ROM_PTR(&machine_counter_value_obj) },
     { MP_ROM_QSTR(MP_QSTR_cycles), MP_ROM_PTR(&machine_counter_cycles_obj) },
+    { MP_ROM_QSTR(MP_QSTR_match), MP_ROM_PTR(&machine_counter_match_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_IRQ_RESET), MP_ROM_INT(MACHINE_COUNTER_IRQ_RESET) },
     { MP_ROM_QSTR(MP_QSTR_IRQ_INDEX), MP_ROM_INT(MACHINE_COUNTER_IRQ_INDEX) },

--- a/ports/psoc-edge/machine_counter.c
+++ b/ports/psoc-edge/machine_counter.c
@@ -599,9 +599,6 @@ static void machine_counter_init_helper_impl(machine_counter_obj_t *self,
     if (args[ARG_match].u_obj != mp_const_none) {
         mp_int_t match = mp_obj_get_int(args[ARG_match].u_obj);
         int64_t match_value_num = (int64_t)match;
-        if (match_value_num < min_value || match_value_num > max_value) {
-            mp_raise_ValueError(MP_ERROR_TEXT("match out of range"));
-        }
         match_enabled = true;
         match_value = (uint32_t)(match_value_num - min_value);
     }
@@ -960,53 +957,6 @@ static mp_obj_t machine_counter_cycles(size_t n_args, const mp_obj_t *args) {
 static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_counter_cycles_obj, 1, 2, machine_counter_cycles);
 
 // ---------------------------------------------------------------------------
-// counter.match([value])
-// ---------------------------------------------------------------------------
-// Get or set compare-match value; pass None to disable match.
-static mp_obj_t machine_counter_match(size_t n_args, const mp_obj_t *args) {
-    machine_counter_obj_t *self = MP_OBJ_TO_PTR(args[0]);
-
-    if (!self->configured) {
-        mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("not initialised"));
-    }
-
-    mp_obj_t prev = self->match_enabled
-        ? mp_obj_new_int_from_ll(machine_counter_range_min_value(self) + (int64_t)self->match_value)
-        : mp_const_none;
-
-    if (n_args == 2) {
-        if (args[1] == mp_const_none) {
-            mp_uint_t irq_state = MICROPY_BEGIN_ATOMIC_SECTION();
-            self->match_enabled = false;
-            self->match_value = 0;
-            machine_counter_apply_interrupt_mask(self);
-            clear_counter_irqs(self, CY_TCPWM_INT_ON_CC0);
-            MICROPY_END_ATOMIC_SECTION(irq_state);
-        } else {
-            mp_int_t match = mp_obj_get_int(args[1]);
-            int64_t match_value_num = (int64_t)match;
-            int64_t range_min_value = machine_counter_range_min_value(self);
-            int64_t range_max_value = machine_counter_range_max_value(self);
-            if (match_value_num < range_min_value || match_value_num > range_max_value) {
-                mp_raise_ValueError(MP_ERROR_TEXT("match out of range"));
-            }
-
-            uint32_t match_value = (uint32_t)(match_value_num - range_min_value);
-            mp_uint_t irq_state = MICROPY_BEGIN_ATOMIC_SECTION();
-            self->match_enabled = true;
-            self->match_value = match_value;
-            Cy_TCPWM_Counter_SetCompare0(TCPWM0, self->counter_num, match_value);
-            machine_counter_apply_interrupt_mask(self);
-            clear_counter_irqs(self, CY_TCPWM_INT_ON_CC0);
-            MICROPY_END_ATOMIC_SECTION(irq_state);
-        }
-    }
-
-    return prev;
-}
-static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_counter_match_obj, 1, 2, machine_counter_match);
-
-// ---------------------------------------------------------------------------
 // counter.irq(handler=None, trigger=0, hard=False)
 // ---------------------------------------------------------------------------
 // Return or configure a Counter IRQ object for this counter.
@@ -1078,7 +1028,6 @@ static const mp_rom_map_elem_t machine_counter_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_deinit), MP_ROM_PTR(&machine_counter_deinit_obj) },
     { MP_ROM_QSTR(MP_QSTR_value), MP_ROM_PTR(&machine_counter_value_obj) },
     { MP_ROM_QSTR(MP_QSTR_cycles), MP_ROM_PTR(&machine_counter_cycles_obj) },
-    { MP_ROM_QSTR(MP_QSTR_match), MP_ROM_PTR(&machine_counter_match_obj) },
     { MP_ROM_QSTR(MP_QSTR_irq), MP_ROM_PTR(&machine_counter_irq_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_IRQ_RESET), MP_ROM_INT(MACHINE_COUNTER_IRQ_RESET) },

--- a/ports/psoc-edge/machine_counter.c
+++ b/ports/psoc-edge/machine_counter.c
@@ -566,11 +566,11 @@ static void machine_counter_init_helper_impl(machine_counter_obj_t *self,
 
     if (args[ARG_match].u_obj != mp_const_none) {
         mp_int_t match = mp_obj_get_int(args[ARG_match].u_obj);
-        if (match < (mp_int_t)min || match > (mp_int_t)range_max) {
+        if ((uint64_t)match < (uint64_t)min || (uint64_t)match > (uint64_t)range_max) {
             mp_raise_ValueError(MP_ERROR_TEXT("match out of range"));
         }
         match_enabled = true;
-        match_value = (uint32_t)((mp_uint_t)match - range_min);
+        match_value = (uint32_t)((uint64_t)match - (uint64_t)range_min);
     }
 
     // Resolve source pin object and validate it exposes Counter input AF.
@@ -931,11 +931,12 @@ static mp_obj_t machine_counter_match(size_t n_args, const mp_obj_t *args) {
             MICROPY_END_ATOMIC_SECTION(irq_state);
         } else {
             mp_int_t match = mp_obj_get_int(args[1]);
-            if (match < (mp_int_t)self->range_min || match > (mp_int_t)self->range_max) {
+            if ((uint64_t)match < (uint64_t)self->range_min
+                || (uint64_t)match > (uint64_t)self->range_max) {
                 mp_raise_ValueError(MP_ERROR_TEXT("match out of range"));
             }
 
-            uint32_t match_value = (uint32_t)((mp_uint_t)match - (mp_uint_t)self->range_min);
+            uint32_t match_value = (uint32_t)((uint64_t)match - (uint64_t)self->range_min);
             mp_uint_t irq_state = MICROPY_BEGIN_ATOMIC_SECTION();
             self->match_enabled = true;
             self->match_value = match_value;

--- a/ports/psoc-edge/machine_counter.c
+++ b/ports/psoc-edge/machine_counter.c
@@ -27,6 +27,7 @@
 #include "py/obj.h"
 #include "py/runtime.h"
 #include "py/mphal.h"
+#include "shared/runtime/mpirq.h"
 
 #include "modmachine.h"
 #include "machine_pin.h"
@@ -63,6 +64,16 @@ typedef enum {
     COUNTER_DIR_DOWN = 2,
 } machine_counter_dir_t;
 
+#define MACHINE_COUNTER_IRQ_RESET      (1U << 0)
+#define MACHINE_COUNTER_IRQ_INDEX      (1U << 1)
+#define MACHINE_COUNTER_IRQ_MATCH      (1U << 2)
+#define MACHINE_COUNTER_IRQ_ROLL_UNDER (1U << 3)
+#define MACHINE_COUNTER_IRQ_ROLL_OVER  (1U << 4)
+#define MACHINE_COUNTER_ALLOWED_FLAGS  (MACHINE_COUNTER_IRQ_RESET \
+    | MACHINE_COUNTER_IRQ_INDEX \
+    | MACHINE_COUNTER_IRQ_ROLL_UNDER \
+    | MACHINE_COUNTER_IRQ_ROLL_OVER)
+
 typedef struct _machine_counter_obj_t {
     mp_obj_base_t base;
     uint8_t id;
@@ -79,6 +90,9 @@ typedef struct _machine_counter_obj_t {
     mp_int_t offset;
     mp_obj_t index_irq_obj;
     mp_obj_t reset_irq_obj;
+    mp_irq_obj_t *mp_irq_obj;
+    mp_uint_t mp_irq_flags;
+    mp_uint_t mp_irq_trigger;
     sys_int_cfg_t irq_cfg;
     bool irq_active;
     bool configured;
@@ -223,18 +237,60 @@ static inline void machine_counter_cycles_step(machine_counter_obj_t *self) {
     }
 }
 
+static mp_uint_t machine_counter_irq_trigger(mp_obj_t self_in, mp_uint_t new_trigger) {
+    machine_counter_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    self->mp_irq_trigger = new_trigger;
+    return 0;
+}
+
+static mp_uint_t machine_counter_irq_info(mp_obj_t self_in, mp_uint_t info_type) {
+    machine_counter_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    if (info_type == MP_IRQ_INFO_FLAGS) {
+        return self->mp_irq_flags;
+    } else if (info_type == MP_IRQ_INFO_TRIGGERS) {
+        return self->mp_irq_trigger;
+    }
+    return 0;
+}
+
+static const mp_irq_methods_t machine_counter_irq_methods = {
+    .trigger = machine_counter_irq_trigger,
+    .info = machine_counter_irq_info,
+};
+
+static inline void machine_counter_irq_raise(machine_counter_obj_t *self, mp_uint_t flags) {
+    if (self->mp_irq_obj == NULL) {
+        return;
+    }
+
+    mp_uint_t irq_state = MICROPY_BEGIN_ATOMIC_SECTION();
+    self->mp_irq_flags = flags;
+    bool call_handler = (self->mp_irq_obj->handler != mp_const_none)
+        && ((self->mp_irq_trigger & flags) != 0);
+    MICROPY_END_ATOMIC_SECTION(irq_state);
+
+    if (call_handler) {
+        mp_irq_handler(self->mp_irq_obj);
+    }
+}
+
 // Counter terminal-count ISR: track wrap events in software cycles.
 static void machine_counter_isr(machine_counter_obj_t *self) {
     if (Cy_TCPWM_GetInterruptStatus(TCPWM0, self->counter_num) & CY_TCPWM_INT_ON_TC) {
         Cy_TCPWM_ClearInterrupt(TCPWM0, self->counter_num, CY_TCPWM_INT_ON_TC);
         machine_counter_cycles_step(self);
+        machine_counter_irq_raise(self,
+            (self->direction == COUNTER_DIR_DOWN)
+                ? MACHINE_COUNTER_IRQ_ROLL_UNDER
+                : MACHINE_COUNTER_IRQ_ROLL_OVER);
     }
 }
 
 // Shared handler for index/reset pin rising edges.
 // If update_cycles is true (index), adjust cycles;
 // if false (reset), keep cycles unchanged.
-static inline void machine_counter_on_aux_event(machine_counter_obj_t *self, bool update_cycles) {
+static inline void machine_counter_on_aux_event(machine_counter_obj_t *self, bool update_cycles,
+    mp_uint_t irq_flag) {
     if (!self->configured) {
         return;
     }
@@ -247,6 +303,7 @@ static inline void machine_counter_on_aux_event(machine_counter_obj_t *self, boo
     Cy_TCPWM_Counter_SetCounter(TCPWM0, self->counter_num, 0);
     Cy_TCPWM_ClearInterrupt(TCPWM0, self->counter_num, CY_TCPWM_INT_ON_TC);
     MICROPY_END_ATOMIC_SECTION(irq_state);
+    machine_counter_irq_raise(self, irq_flag);
 }
 
 // -------------------------------------------------------------------------- //
@@ -276,7 +333,7 @@ static const cy_israddress machine_counter_irq_handlers[MACHINE_COUNTER_NUM_INST
         (void)pin_in; \
         machine_counter_obj_t *self = counter_obj[id]; \
         if (self != NULL && self->index_pin != NULL) { \
-            machine_counter_on_aux_event(self, true); \
+            machine_counter_on_aux_event(self, true, MACHINE_COUNTER_IRQ_INDEX); \
         } \
         return mp_const_none; \
     }
@@ -304,7 +361,7 @@ static const mp_obj_t machine_counter_index_handler_obj[MACHINE_COUNTER_NUM_INST
         (void)pin_in; \
         machine_counter_obj_t *self = counter_obj[id]; \
         if (self != NULL && self->reset_pin != NULL) { \
-            machine_counter_on_aux_event(self, false); \
+            machine_counter_on_aux_event(self, false, MACHINE_COUNTER_IRQ_RESET); \
         } \
         return mp_const_none; \
     }
@@ -333,10 +390,10 @@ static const mp_obj_t machine_counter_reset_handler_obj[MACHINE_COUNTER_NUM_INST
         machine_counter_obj_t *self = counter_obj[id]; \
         if (self != NULL) { \
             if (self->index_pin != NULL) { \
-                machine_counter_on_aux_event(self, true); \
+                machine_counter_on_aux_event(self, true, MACHINE_COUNTER_IRQ_INDEX); \
             } \
             if (self->reset_pin != NULL) { \
-                machine_counter_on_aux_event(self, false); \
+                machine_counter_on_aux_event(self, false, MACHINE_COUNTER_IRQ_RESET); \
             } \
         } \
         return mp_const_none; \
@@ -368,6 +425,11 @@ static void machine_counter_init_fail_cleanup(machine_counter_obj_t *self) {
     self->configured = false;
     self->cycles_u16 = 0;
     self->offset = 0;
+    self->mp_irq_flags = 0;
+    self->mp_irq_trigger = 0;
+    if (self->mp_irq_obj != NULL) {
+        self->mp_irq_obj->handler = mp_const_none;
+    }
 
     machine_tcpwm_counter_free(self->counter_num, MP_OBJ_FROM_PTR(self));
     counter_obj[self->id] = NULL;
@@ -661,6 +723,9 @@ static mp_obj_t machine_counter_make_new(const mp_obj_type_t *type,
     self->offset = 0;
     self->index_irq_obj = MP_OBJ_NULL;
     self->reset_irq_obj = MP_OBJ_NULL;
+    self->mp_irq_obj = NULL;
+    self->mp_irq_flags = 0;
+    self->mp_irq_trigger = 0;
     self->irq_cfg.irq_num = counter_irq[id];
     self->irq_active = false;
     self->configured = false;
@@ -710,6 +775,11 @@ static mp_obj_t machine_counter_deinit(mp_obj_t self_in) {
     self->configured = false;
     self->cycles_u16 = 0;
     self->offset = 0;
+    self->mp_irq_flags = 0;
+    self->mp_irq_trigger = 0;
+    if (self->mp_irq_obj != NULL) {
+        self->mp_irq_obj->handler = mp_const_none;
+    }
 
     machine_tcpwm_counter_free(self->counter_num, MP_OBJ_FROM_PTR(self));
     counter_obj[self->id] = NULL;
@@ -796,6 +866,54 @@ static mp_obj_t machine_counter_cycles(size_t n_args, const mp_obj_t *args) {
 }
 static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_counter_cycles_obj, 1, 2, machine_counter_cycles);
 
+// counter.irq(handler=None, trigger=0, hard=False)
+static mp_obj_t machine_counter_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    machine_counter_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
+    bool any_args = n_args > 1 || kw_args->used != 0;
+
+    if (!self->configured) {
+        mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("not initialised"));
+    }
+
+    if (self->mp_irq_obj == NULL) {
+        self->mp_irq_obj = mp_irq_new(&machine_counter_irq_methods, MP_OBJ_FROM_PTR(self));
+        self->mp_irq_obj->ishard = false;
+    }
+
+    if (any_args) {
+        mp_arg_val_t args[MP_IRQ_ARG_INIT_NUM_ARGS];
+        mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args,
+            MP_IRQ_ARG_INIT_NUM_ARGS, mp_irq_init_args, args);
+
+        mp_obj_t handler = args[MP_IRQ_ARG_INIT_handler].u_obj;
+        if (handler != mp_const_none && !mp_obj_is_callable(handler)) {
+            mp_raise_ValueError(MP_ERROR_TEXT("handler must be None or callable"));
+        }
+
+        mp_uint_t trigger = args[MP_IRQ_ARG_INIT_trigger].u_int;
+        mp_uint_t not_supported = trigger & ~MACHINE_COUNTER_ALLOWED_FLAGS;
+        if (trigger != 0 && not_supported) {
+            mp_raise_msg_varg(&mp_type_ValueError,
+                MP_ERROR_TEXT("trigger 0x%08x unsupported"), not_supported);
+        }
+
+        self->mp_irq_obj->handler = handler;
+        self->mp_irq_obj->ishard = args[MP_IRQ_ARG_INIT_hard].u_bool;
+
+        #if defined(CY_RTOS_AWARE)
+        if (self->mp_irq_obj->ishard) {
+            self->mp_irq_obj->ishard = false;
+        }
+        #endif
+
+        self->mp_irq_flags = 0;
+        self->mp_irq_trigger = trigger;
+    }
+
+    return MP_OBJ_FROM_PTR(self->mp_irq_obj);
+}
+static MP_DEFINE_CONST_FUN_OBJ_KW(machine_counter_irq_obj, 1, machine_counter_irq);
+
 // Print user-facing representation as Counter(<id>).
 static void machine_counter_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     machine_counter_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -814,8 +932,15 @@ static void machine_counter_print(const mp_print_t *print, mp_obj_t self_in, mp_
 static const mp_rom_map_elem_t machine_counter_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_init), MP_ROM_PTR(&machine_counter_init_obj) },
     { MP_ROM_QSTR(MP_QSTR_deinit), MP_ROM_PTR(&machine_counter_deinit_obj) },
+    { MP_ROM_QSTR(MP_QSTR_irq), MP_ROM_PTR(&machine_counter_irq_obj) },
     { MP_ROM_QSTR(MP_QSTR_value), MP_ROM_PTR(&machine_counter_value_obj) },
     { MP_ROM_QSTR(MP_QSTR_cycles), MP_ROM_PTR(&machine_counter_cycles_obj) },
+
+    { MP_ROM_QSTR(MP_QSTR_IRQ_RESET), MP_ROM_INT(MACHINE_COUNTER_IRQ_RESET) },
+    { MP_ROM_QSTR(MP_QSTR_IRQ_INDEX), MP_ROM_INT(MACHINE_COUNTER_IRQ_INDEX) },
+    { MP_ROM_QSTR(MP_QSTR_IRQ_MATCH), MP_ROM_INT(MACHINE_COUNTER_IRQ_MATCH) },
+    { MP_ROM_QSTR(MP_QSTR_IRQ_ROLL_UNDER), MP_ROM_INT(MACHINE_COUNTER_IRQ_ROLL_UNDER) },
+    { MP_ROM_QSTR(MP_QSTR_IRQ_ROLL_OVER), MP_ROM_INT(MACHINE_COUNTER_IRQ_ROLL_OVER) },
 
     { MP_ROM_QSTR(MP_QSTR_RISING), MP_ROM_INT(COUNTER_EDGE_RISING) },
     { MP_ROM_QSTR(MP_QSTR_FALLING), MP_ROM_INT(COUNTER_EDGE_FALLING) },

--- a/ports/psoc-edge/machine_counter.c
+++ b/ports/psoc-edge/machine_counter.c
@@ -807,11 +807,9 @@ static mp_obj_t machine_counter_make_new(const mp_obj_type_t *type,
         nlr_jump(nl.ret_val);
     }
 
-    if (n_args > 1 || n_kw > 0) {
-        mp_map_t kw_map;
-        mp_map_init_fixed_table(&kw_map, n_kw, args + n_args);
-        machine_counter_init_helper(self, n_args - 1, args + 1, &kw_map);
-    }
+    mp_map_t kw_map;
+    mp_map_init_fixed_table(&kw_map, n_kw, args + n_args);
+    machine_counter_init_helper(self, n_args - 1, args + 1, &kw_map);
 
     return MP_OBJ_FROM_PTR(self);
 }

--- a/ports/psoc-edge/machine_counter.c
+++ b/ports/psoc-edge/machine_counter.c
@@ -51,7 +51,7 @@ extern mp_obj_t machine_pin_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_
 static mp_obj_t machine_counter_deinit(mp_obj_t self_in);
 
 // Number of Counter object slots supported by this port.
-#define MACHINE_COUNTER_NUM_INSTANCES  (32)
+#define MACHINE_COUNTER_NUM_INSTANCES  MICROPY_PY_MACHINE_TCPWM0_NUM_COUNTERS
 // Shared TCPWM source clock frequency used by Counter.
 #define COUNTER_CLK_HZ                 (1000000UL)
 // Value used to disable optional TCPWM trigger inputs.
@@ -84,8 +84,8 @@ typedef struct _machine_counter_obj_t {
     uint32_t counter_num;
     en_clk_dst_t pclk_dst;
     mp_hal_pin_obj_t src_pin;
-    const machine_pin_obj_t *index_pin;
-    const machine_pin_obj_t *reset_pin;
+    mp_hal_pin_obj_t index_pin;
+    mp_hal_pin_obj_t reset_pin;
     uint32_t match_value;
     bool match_enabled;
     uint8_t edge;
@@ -181,9 +181,8 @@ static void machine_counter_restore_src_pin(machine_counter_obj_t *self) {
     if (self->src_pin == NULL) {
         return;
     }
-    GPIO_PRT_Type *port = Cy_GPIO_PortToAddr(self->src_pin->port);
-    Cy_GPIO_SetHSIOM(port, self->src_pin->pin, HSIOM_SEL_GPIO);
-    Cy_GPIO_SetDrivemode(port, self->src_pin->pin, CY_GPIO_DM_HIGHZ);
+    // Use mphalport abstraction to restore pin to input mode (GPIO, high-impedance)
+    mp_hal_pin_input(self->src_pin);
     self->src_pin = NULL;
 }
 
@@ -197,7 +196,7 @@ static void machine_counter_disable_aux_irqs(machine_counter_obj_t *self) {
     // Disable index pin IRQs (if configured) and release pin ownership.
     if (self->index_pin != NULL && self->index_irq_obj != MP_OBJ_NULL) {
         mp_obj_t pos_args[] = {
-            MP_OBJ_FROM_PTR((machine_pin_obj_t *)self->index_pin),
+            MP_OBJ_FROM_PTR(self->index_pin),
             mp_const_none,
         };
         mp_map_t kw_args;
@@ -209,7 +208,7 @@ static void machine_counter_disable_aux_irqs(machine_counter_obj_t *self) {
     if (self->reset_pin != NULL && self->reset_irq_obj != MP_OBJ_NULL
         && self->reset_pin != self->index_pin) {
         mp_obj_t pos_args[] = {
-            MP_OBJ_FROM_PTR((machine_pin_obj_t *)self->reset_pin),
+            MP_OBJ_FROM_PTR(self->reset_pin),
             mp_const_none,
         };
         mp_map_t kw_args;
@@ -483,11 +482,11 @@ static const mp_obj_t machine_counter_index_reset_handler_obj[MACHINE_COUNTER_NU
 // Init Internals
 // ---------------------------------------------------------------------------
 
-static mp_obj_t machine_counter_enable_aux_irq(const machine_pin_obj_t *pin, mp_obj_t handler_obj) {
+static mp_obj_t machine_counter_enable_aux_irq(mp_hal_pin_obj_t pin, mp_obj_t handler_obj) {
     mp_hal_pin_input(pin);
 
     mp_obj_t pos_args[] = {
-        MP_OBJ_FROM_PTR((machine_pin_obj_t *)pin),
+        MP_OBJ_FROM_PTR(pin),
         handler_obj,
     };
     mp_obj_t kw_table[] = {
@@ -553,11 +552,11 @@ static void machine_counter_init_helper_impl(machine_counter_obj_t *self,
     mp_int_t min = (mp_int_t)args[ARG_min].u_int;
     int64_t min_value = (int64_t)min;
 
-    const machine_pin_obj_t *index_pin = NULL;
+    mp_hal_pin_obj_t index_pin = NULL;
     if (args[ARG_index].u_obj != mp_const_none) {
         index_pin = mp_hal_get_pin_obj(args[ARG_index].u_obj);
     }
-    const machine_pin_obj_t *reset_pin = NULL;
+    mp_hal_pin_obj_t reset_pin = NULL;
     if (args[ARG_reset].u_obj != mp_const_none) {
         reset_pin = mp_hal_get_pin_obj(args[ARG_reset].u_obj);
     }

--- a/ports/psoc-edge/machine_counter.c
+++ b/ports/psoc-edge/machine_counter.c
@@ -68,6 +68,8 @@ typedef struct _machine_counter_obj_t {
     mp_hal_pin_obj_t src_pin;
     uint8_t edge;
     uint8_t direction;
+    uint32_t range_min;
+    uint32_t range_max;
     uint16_t cycles_u16;
     mp_int_t offset;
     sys_int_cfg_t irq_cfg;
@@ -225,11 +227,29 @@ static void machine_counter_init_fail_cleanup(machine_counter_obj_t *self) {
 static void machine_counter_init_helper_impl(machine_counter_obj_t *self,
     size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
 
-    enum { ARG_src, ARG_edge, ARG_direction };
+    enum {
+        ARG_src,
+        ARG_edge,
+        ARG_direction,
+        ARG_filter_ns,
+        ARG_max,
+        ARG_min,
+        ARG_index,
+        ARG_reset,
+        ARG_match,
+        ARG_match_pin,
+    };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_src, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
         { MP_QSTR_edge, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = COUNTER_EDGE_RISING} },
         { MP_QSTR_direction, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = COUNTER_DIR_UP} },
+        { MP_QSTR_filter_ns, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
+        { MP_QSTR_max, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
+        { MP_QSTR_min, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
+        { MP_QSTR_index, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
+        { MP_QSTR_reset, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
+        { MP_QSTR_match, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
+        { MP_QSTR_match_pin, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
     };
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
@@ -245,6 +265,55 @@ static void machine_counter_init_helper_impl(machine_counter_obj_t *self,
     if (direction != COUNTER_DIR_UP && direction != COUNTER_DIR_DOWN) {
         mp_raise_ValueError(MP_ERROR_TEXT("invalid direction"));
     }
+
+    mp_int_t filter_ns = args[ARG_filter_ns].u_int;
+    if (filter_ns < 0) {
+        mp_raise_ValueError(MP_ERROR_TEXT("filter_ns must be >= 0"));
+    }
+    if (filter_ns > 0) {
+        mp_raise_NotImplementedError(MP_ERROR_TEXT("filter_ns not supported"));
+    }
+
+    mp_int_t min = args[ARG_min].u_int;
+    if (min < 0) {
+        mp_raise_ValueError(MP_ERROR_TEXT("min must be >= 0"));
+    }
+
+    if (args[ARG_index].u_obj != mp_const_none) {
+        mp_raise_NotImplementedError(MP_ERROR_TEXT("index not supported"));
+    }
+    if (args[ARG_reset].u_obj != mp_const_none) {
+        mp_raise_NotImplementedError(MP_ERROR_TEXT("reset not supported"));
+    }
+    if (args[ARG_match].u_obj != mp_const_none) {
+        mp_raise_NotImplementedError(MP_ERROR_TEXT("match not supported"));
+    }
+    if (args[ARG_match_pin].u_obj != mp_const_none) {
+        mp_raise_NotImplementedError(MP_ERROR_TEXT("match_pin not supported"));
+    }
+
+    uint32_t max_hw = machine_counter_period_max(self->counter_num);
+    uint32_t range_max = max_hw;
+    if (args[ARG_max].u_obj != mp_const_none) {
+        mp_int_t max = mp_obj_get_int(args[ARG_max].u_obj);
+        if (max < 0) {
+            mp_raise_ValueError(MP_ERROR_TEXT("max must be >= 0"));
+        }
+        if (max == 0 && min == 0) {
+            range_max = max_hw;
+        } else if ((uint64_t)max > (uint64_t)max_hw) {
+            mp_raise_ValueError(MP_ERROR_TEXT("max out of range"));
+        } else {
+            range_max = (uint32_t)max;
+        }
+    }
+
+    if ((uint64_t)min >= (uint64_t)range_max) {
+        mp_raise_ValueError(MP_ERROR_TEXT("min must be < max"));
+    }
+
+    uint32_t range_min = (uint32_t)min;
+    uint32_t period = range_max - range_min;
 
     // Resolve source pin object and validate it exposes Counter input AF.
     mp_hal_pin_obj_t src_pin = mp_hal_get_pin_obj(args[ARG_src].u_obj);
@@ -283,7 +352,7 @@ static void machine_counter_init_helper_impl(machine_counter_obj_t *self,
     }
 
     cy_stc_tcpwm_counter_config_t cfg = {0};
-    cfg.period = machine_counter_period_max(self->counter_num);
+    cfg.period = period;
     cfg.clockPrescaler = CY_TCPWM_COUNTER_PRESCALER_DIVBY_1;
     cfg.runMode = CY_TCPWM_COUNTER_CONTINUOUS;
     cfg.countDirection = CY_TCPWM_COUNTER_COUNT_UP;
@@ -335,6 +404,8 @@ static void machine_counter_init_helper_impl(machine_counter_obj_t *self,
 
     self->edge = edge;
     self->direction = direction;
+    self->range_min = range_min;
+    self->range_max = range_max;
     self->cycles_u16 = 0;
     self->offset = 0;
     self->configured = true;
@@ -385,6 +456,8 @@ static mp_obj_t machine_counter_make_new(const mp_obj_type_t *type,
     self->src_pin = NULL;
     self->edge = COUNTER_EDGE_RISING;
     self->direction = COUNTER_DIR_UP;
+    self->range_min = 0;
+    self->range_max = machine_counter_period_max(self->counter_num);
     self->cycles_u16 = 0;
     self->offset = 0;
     self->irq_cfg.irq_num = counter_irq[id];
@@ -471,7 +544,7 @@ static mp_obj_t machine_counter_value(size_t n_args, const mp_obj_t *args) {
     }
 
     uint32_t raw = Cy_TCPWM_Counter_GetCounter(TCPWM0, self->counter_num);
-    uint64_t span = (uint64_t)machine_counter_period_max(self->counter_num) + 1ULL;
+    uint64_t span = (uint64_t)(self->range_max - self->range_min) + 1ULL;
     int16_t cycles = machine_counter_cycles_get(self);
     long long edge_total;
     if (self->direction == COUNTER_DIR_DOWN) {

--- a/ports/psoc-edge/machine_counter.c
+++ b/ports/psoc-edge/machine_counter.c
@@ -253,7 +253,10 @@ static inline int64_t machine_counter_range_span_value(const machine_counter_obj
 }
 
 static inline uint32_t machine_counter_interrupt_mask(const machine_counter_obj_t *self) {
-    return CY_TCPWM_INT_ON_TC | (self->match_enabled ? CY_TCPWM_INT_ON_CC0 : 0U);
+    return CY_TCPWM_INT_ON_TC
+           | ((self->match_enabled && ((self->mp_irq_trigger & MACHINE_COUNTER_IRQ_MATCH) != 0))
+            ? CY_TCPWM_INT_ON_CC0
+            : 0U);
 }
 
 static inline void machine_counter_apply_interrupt_mask(const machine_counter_obj_t *self) {
@@ -279,7 +282,12 @@ static inline void machine_counter_cycles_step(machine_counter_obj_t *self) {
 
 static mp_uint_t machine_counter_irq_trigger(mp_obj_t self_in, mp_uint_t new_trigger) {
     machine_counter_obj_t *self = MP_OBJ_TO_PTR(self_in);
+
+    mp_uint_t irq_state = MICROPY_BEGIN_ATOMIC_SECTION();
     self->mp_irq_trigger = new_trigger;
+    machine_counter_apply_interrupt_mask(self);
+    MICROPY_END_ATOMIC_SECTION(irq_state);
+
     return 0;
 }
 
@@ -307,6 +315,11 @@ static inline void machine_counter_irq_raise(machine_counter_obj_t *self, mp_uin
     self->mp_irq_flags = flags;
     bool call_handler = (self->mp_irq_obj->handler != mp_const_none)
         && ((self->mp_irq_trigger & flags) != 0);
+    // MATCH is one-shot: clear its trigger bit after raising so user must re-arm.
+    self->mp_irq_trigger &= ~(flags & MACHINE_COUNTER_IRQ_MATCH);
+    if ((flags & MACHINE_COUNTER_IRQ_MATCH) != 0) {
+        machine_counter_apply_interrupt_mask(self);
+    }
     MICROPY_END_ATOMIC_SECTION(irq_state);
 
     if (call_handler) {
@@ -494,13 +507,13 @@ static void machine_counter_init_helper_impl(machine_counter_obj_t *self,
         ARG_src,
         ARG_edge,
         ARG_direction,
-        ARG_filter_ns,
+        ARG_filter_ns,  // currently not supported
         ARG_max,
         ARG_min,
         ARG_index,
         ARG_reset,
         ARG_match,
-        ARG_match_pin,
+        ARG_match_pin,  // currently not supported
     };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_src, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
@@ -715,7 +728,7 @@ static void machine_counter_init_helper_impl(machine_counter_obj_t *self,
     self->match_enabled = match_enabled;
     self->match_value = match_value;
     self->cycles_u16 = 0;
-    self->offset = 0;
+    self->offset = min;
     machine_counter_apply_interrupt_mask(self);
     self->configured = true;
 }
@@ -843,7 +856,9 @@ static mp_obj_t machine_counter_deinit(mp_obj_t self_in) {
     }
 
     machine_tcpwm_counter_free(self->counter_num, MP_OBJ_FROM_PTR(self));
-    counter_obj[self->id] = NULL;
+    if (counter_obj[self->id] == self) {
+        counter_obj[self->id] = NULL;
+    }
 
     return mp_const_none;
 }
@@ -876,14 +891,20 @@ static mp_obj_t machine_counter_value(size_t n_args, const mp_obj_t *args) {
         mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("not initialised"));
     }
 
+    // Get the span of the counter range.
+    uint64_t span = (uint64_t)machine_counter_range_span_value(self);
+
+    // If a value is provided, freeze counting during read/reset
     if (n_args == 2) {
         // Freeze counting during read/reset so no new edges arrive in this window.
         Cy_TCPWM_Counter_Disable(TCPWM0, self->counter_num);
     }
 
+    mp_uint_t irq_state = MICROPY_BEGIN_ATOMIC_SECTION();
     uint32_t raw = Cy_TCPWM_Counter_GetCounter(TCPWM0, self->counter_num);
-    uint64_t span = (uint64_t)machine_counter_range_span_value(self);
     int16_t cycles = machine_counter_cycles_get(self);
+    MICROPY_END_ATOMIC_SECTION(irq_state);
+
     long long edge_total;
     if (self->direction == COUNTER_DIR_DOWN) {
         edge_total = (long long)(-cycles) * (long long)span + (long long)raw;
@@ -917,15 +938,23 @@ static mp_obj_t machine_counter_cycles(size_t n_args, const mp_obj_t *args) {
         mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("not initialised"));
     }
 
-    int16_t prev = machine_counter_cycles_get(self);
-
+    // set cycles value if provided and also returning previous value.
     if (n_args == 2) {
         mp_int_t value = mp_obj_get_int(args[1]);
         if (value < -32768 || value > 32767) {
             mp_raise_ValueError(MP_ERROR_TEXT("cycles out of range"));
         }
+        mp_uint_t irq_state = MICROPY_BEGIN_ATOMIC_SECTION();
+        int16_t prev = machine_counter_cycles_get(self);
         self->cycles_u16 = (uint16_t)(int16_t)value;
+        MICROPY_END_ATOMIC_SECTION(irq_state);
+        return mp_obj_new_int(prev);
     }
+
+    // Return current cycles value when no argument is provided.
+    mp_uint_t irq_state = MICROPY_BEGIN_ATOMIC_SECTION();
+    int16_t prev = machine_counter_cycles_get(self);
+    MICROPY_END_ATOMIC_SECTION(irq_state);
 
     return mp_obj_new_int(prev);
 }
@@ -1023,6 +1052,10 @@ static mp_obj_t machine_counter_irq(size_t n_args, const mp_obj_t *pos_args, mp_
 
         self->mp_irq_flags = 0;
         self->mp_irq_trigger = trigger;
+
+        mp_uint_t irq_state = MICROPY_BEGIN_ATOMIC_SECTION();
+        machine_counter_apply_interrupt_mask(self);
+        MICROPY_END_ATOMIC_SECTION(irq_state);
     }
 
     return MP_OBJ_FROM_PTR(self->mp_irq_obj);

--- a/ports/psoc-edge/machine_counter.c
+++ b/ports/psoc-edge/machine_counter.c
@@ -92,6 +92,8 @@ typedef struct _machine_counter_obj_t {
     uint8_t direction;
     uint32_t range_min;
     uint32_t range_max;
+    bool range_min_negative;
+    bool range_max_negative;
     uint16_t cycles_u16;
     mp_int_t offset;
     mp_obj_t index_irq_obj;
@@ -232,6 +234,22 @@ static void machine_counter_stop_irq(machine_counter_obj_t *self) {
 // Return the cycles counter as signed 16-bit value.
 static inline int16_t machine_counter_cycles_get(const machine_counter_obj_t *self) {
     return (int16_t)self->cycles_u16;
+}
+
+static inline int64_t machine_counter_range_min_value(const machine_counter_obj_t *self) {
+    // Reinterpret the stored raw bits as signed when the configured min was negative,
+    // then widen to int64_t so later arithmetic uses the intended logical value.
+    return self->range_min_negative ? (int64_t)(int32_t)self->range_min : (int64_t)self->range_min;
+}
+
+static inline int64_t machine_counter_range_max_value(const machine_counter_obj_t *self) {
+    // Reinterpret the stored raw bits as signed when the configured max was negative,
+    // then widen to int64_t so later arithmetic uses the intended logical value.
+    return self->range_max_negative ? (int64_t)(int32_t)self->range_max : (int64_t)self->range_max;
+}
+
+static inline int64_t machine_counter_range_span_value(const machine_counter_obj_t *self) {
+    return machine_counter_range_max_value(self) - machine_counter_range_min_value(self) + 1;
 }
 
 static inline uint32_t machine_counter_interrupt_mask(const machine_counter_obj_t *self) {
@@ -519,11 +537,8 @@ static void machine_counter_init_helper_impl(machine_counter_obj_t *self,
         mp_raise_NotImplementedError(MP_ERROR_TEXT("filter_ns not supported"));
     }
 
-    uint32_t min = args[ARG_min].u_int;
-    // TODO: support negative min/max values (similar to MIMXRT port)
-    if ((mp_int_t)min < 0) {
-        mp_raise_ValueError(MP_ERROR_TEXT("min must be >= 0"));
-    }
+    mp_int_t min = (mp_int_t)args[ARG_min].u_int;
+    int64_t min_value = (int64_t)min;
 
     const machine_pin_obj_t *index_pin = NULL;
     if (args[ARG_index].u_obj != mp_const_none) {
@@ -540,37 +555,43 @@ static void machine_counter_init_helper_impl(machine_counter_obj_t *self,
 
     uint32_t max_hw = machine_counter_period_max(self->counter_num);
     uint32_t range_max = max_hw;
+    int64_t max_value = (int64_t)max_hw;
     if (args[ARG_max].u_obj != mp_const_none) {
         mp_int_t max = mp_obj_get_int(args[ARG_max].u_obj);
-        // TODO: support negative max values (similar to MIMXRT port)
-        if (max < 0) {
-            mp_raise_ValueError(MP_ERROR_TEXT("max must be >= 0"));
-        }
         if (max == 0 && min == 0) {
             range_max = max_hw;
-        } else if ((uint64_t)max > (uint64_t)max_hw) {
+            max_value = (int64_t)max_hw;
+        } else if (max > 0 && (uint64_t)max > (uint64_t)max_hw) {
             mp_raise_ValueError(MP_ERROR_TEXT("max out of range"));
         } else {
             range_max = (uint32_t)max;
+            max_value = (int64_t)max;
         }
     }
 
-    if (min >= range_max) {
+    if (min_value >= max_value) {
         mp_raise_ValueError(MP_ERROR_TEXT("min must be < max"));
     }
 
     uint32_t range_min = (uint32_t)min;
-    uint32_t period = range_max - range_min;
+    // Compute the logical span in signed space first so negative min/max values remain valid,
+    // then reject anything wider than the hardware period before narrowing to uint32_t.
+    int64_t period_value = max_value - min_value;
+    if (period_value > (int64_t)max_hw) {
+        mp_raise_ValueError(MP_ERROR_TEXT("range span out of range"));
+    }
+    uint32_t period = (uint32_t)period_value;
     bool match_enabled = false;
     uint32_t match_value = 0;
 
     if (args[ARG_match].u_obj != mp_const_none) {
         mp_int_t match = mp_obj_get_int(args[ARG_match].u_obj);
-        if ((uint64_t)match < (uint64_t)min || (uint64_t)match > (uint64_t)range_max) {
+        int64_t match_value_num = (int64_t)match;
+        if (match_value_num < min_value || match_value_num > max_value) {
             mp_raise_ValueError(MP_ERROR_TEXT("match out of range"));
         }
         match_enabled = true;
-        match_value = (uint32_t)((uint64_t)match - (uint64_t)range_min);
+        match_value = (uint32_t)(match_value_num - min_value);
     }
 
     // Resolve source pin object and validate it exposes Counter input AF.
@@ -689,6 +710,8 @@ static void machine_counter_init_helper_impl(machine_counter_obj_t *self,
     self->direction = direction;
     self->range_min = range_min;
     self->range_max = range_max;
+    self->range_min_negative = (min_value < 0);
+    self->range_max_negative = (max_value < 0);
     self->match_enabled = match_enabled;
     self->match_value = match_value;
     self->cycles_u16 = 0;
@@ -753,6 +776,8 @@ static mp_obj_t machine_counter_make_new(const mp_obj_type_t *type,
     self->direction = COUNTER_DIR_UP;
     self->range_min = 0;
     self->range_max = machine_counter_period_max(self->counter_num);
+    self->range_min_negative = false;
+    self->range_max_negative = false;
     self->cycles_u16 = 0;
     self->offset = 0;
     self->index_irq_obj = MP_OBJ_NULL;
@@ -857,7 +882,7 @@ static mp_obj_t machine_counter_value(size_t n_args, const mp_obj_t *args) {
     }
 
     uint32_t raw = Cy_TCPWM_Counter_GetCounter(TCPWM0, self->counter_num);
-    uint64_t span = (uint64_t)(self->range_max - self->range_min) + 1ULL;
+    uint64_t span = (uint64_t)machine_counter_range_span_value(self);
     int16_t cycles = machine_counter_cycles_get(self);
     long long edge_total;
     if (self->direction == COUNTER_DIR_DOWN) {
@@ -918,7 +943,7 @@ static mp_obj_t machine_counter_match(size_t n_args, const mp_obj_t *args) {
     }
 
     mp_obj_t prev = self->match_enabled
-        ? mp_obj_new_int_from_ll(self->range_min + self->match_value)
+        ? mp_obj_new_int_from_ll(machine_counter_range_min_value(self) + (int64_t)self->match_value)
         : mp_const_none;
 
     if (n_args == 2) {
@@ -931,12 +956,14 @@ static mp_obj_t machine_counter_match(size_t n_args, const mp_obj_t *args) {
             MICROPY_END_ATOMIC_SECTION(irq_state);
         } else {
             mp_int_t match = mp_obj_get_int(args[1]);
-            if ((uint64_t)match < (uint64_t)self->range_min
-                || (uint64_t)match > (uint64_t)self->range_max) {
+            int64_t match_value_num = (int64_t)match;
+            int64_t range_min_value = machine_counter_range_min_value(self);
+            int64_t range_max_value = machine_counter_range_max_value(self);
+            if (match_value_num < range_min_value || match_value_num > range_max_value) {
                 mp_raise_ValueError(MP_ERROR_TEXT("match out of range"));
             }
 
-            uint32_t match_value = (uint32_t)((uint64_t)match - (uint64_t)self->range_min);
+            uint32_t match_value = (uint32_t)(match_value_num - range_min_value);
             mp_uint_t irq_state = MICROPY_BEGIN_ATOMIC_SECTION();
             self->match_enabled = true;
             self->match_value = match_value;

--- a/ports/psoc-edge/machine_counter.c
+++ b/ports/psoc-edge/machine_counter.c
@@ -43,6 +43,9 @@
 #include "genhdr/pins_af.h"
 #include "sys_int.h"
 
+// Reuse machine.Pin IRQ API to implement Counter index input callbacks.
+extern mp_obj_t machine_pin_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args);
+
 // Number of Counter object slots supported by this port.
 #define MACHINE_COUNTER_NUM_INSTANCES  (32)
 // Shared TCPWM source clock frequency used by Counter.
@@ -66,12 +69,16 @@ typedef struct _machine_counter_obj_t {
     uint32_t counter_num;
     en_clk_dst_t pclk_dst;
     mp_hal_pin_obj_t src_pin;
+    const machine_pin_obj_t *index_pin;
+    const machine_pin_obj_t *reset_pin;
     uint8_t edge;
     uint8_t direction;
     uint32_t range_min;
     uint32_t range_max;
     uint16_t cycles_u16;
     mp_int_t offset;
+    mp_obj_t index_irq_obj;
+    mp_obj_t reset_irq_obj;
     sys_int_cfg_t irq_cfg;
     bool irq_active;
     bool configured;
@@ -163,6 +170,37 @@ static void machine_counter_stop_hw(machine_counter_obj_t *self) {
     Cy_TCPWM_Counter_Disable(TCPWM0, self->counter_num);
 }
 
+// Disable index/reset pin IRQs (if configured) and release pin ownership.
+static void machine_counter_disable_aux_irqs(machine_counter_obj_t *self) {
+    // Disable index pin IRQs (if configured) and release pin ownership.
+    if (self->index_pin != NULL && self->index_irq_obj != MP_OBJ_NULL) {
+        mp_obj_t pos_args[] = {
+            MP_OBJ_FROM_PTR((machine_pin_obj_t *)self->index_pin),
+            mp_const_none,
+        };
+        mp_map_t kw_args;
+        mp_map_init_fixed_table(&kw_args, 0, NULL);
+        machine_pin_irq(2, pos_args, &kw_args);
+    }
+
+    // Disable reset pin IRQs (if configured) and release pin ownership.
+    if (self->reset_pin != NULL && self->reset_irq_obj != MP_OBJ_NULL
+        && self->reset_pin != self->index_pin) {
+        mp_obj_t pos_args[] = {
+            MP_OBJ_FROM_PTR((machine_pin_obj_t *)self->reset_pin),
+            mp_const_none,
+        };
+        mp_map_t kw_args;
+        mp_map_init_fixed_table(&kw_args, 0, NULL);
+        machine_pin_irq(2, pos_args, &kw_args);
+    }
+
+    self->index_pin = NULL;
+    self->reset_pin = NULL;
+    self->index_irq_obj = MP_OBJ_NULL;
+    self->reset_irq_obj = MP_OBJ_NULL;
+}
+
 // Disable and unregister the counter IRQ if it is currently active.
 static void machine_counter_stop_irq(machine_counter_obj_t *self) {
     if (self->irq_active) {
@@ -193,6 +231,25 @@ static void machine_counter_isr(machine_counter_obj_t *self) {
     }
 }
 
+// Shared handler for index/reset pin rising edges.
+// If update_cycles is true (index), adjust cycles;
+// if false (reset), keep cycles unchanged.
+static inline void machine_counter_on_aux_event(machine_counter_obj_t *self, bool update_cycles) {
+    if (!self->configured) {
+        return;
+    }
+
+    mp_uint_t irq_state = MICROPY_BEGIN_ATOMIC_SECTION();
+    if (update_cycles) {
+        // Update cycles counter on index pin rising edge.
+        machine_counter_cycles_step(self);
+    }
+    Cy_TCPWM_Counter_SetCounter(TCPWM0, self->counter_num, 0);
+    Cy_TCPWM_ClearInterrupt(TCPWM0, self->counter_num, CY_TCPWM_INT_ON_TC);
+    MICROPY_END_ATOMIC_SECTION(irq_state);
+}
+
+// -------------------------------------------------------------------------- //
 // Generate one IRQ handler per Counter id for direct dispatch.
 #define COUNTER_IRQ_HANDLER_DECL(id, counter, irq, pclk, trig) \
     static void machine_counter_irq_handler_##id(void) { \
@@ -204,16 +261,109 @@ static void machine_counter_isr(machine_counter_obj_t *self) {
 MICROPY_PY_MACHINE_TCPWM_MAP(COUNTER_IRQ_HANDLER_DECL)
 #undef COUNTER_IRQ_HANDLER_DECL
 
+// Generate one IRQ handler entry per Counter id for direct dispatch.
 #define COUNTER_IRQ_HANDLER_ENTRY(id, counter, irq, pclk, trig) machine_counter_irq_handler_##id,
 static const cy_israddress machine_counter_irq_handlers[MACHINE_COUNTER_NUM_INSTANCES] = {
     MICROPY_PY_MACHINE_TCPWM_MAP(COUNTER_IRQ_HANDLER_ENTRY)
 };
 #undef COUNTER_IRQ_HANDLER_ENTRY
+// -------------------------------------------------------------------------- //
+
+// -------------------------------------------------------------------------- //
+// Generate one index callback per Counter id (bound through machine.Pin.irq).
+#define COUNTER_INDEX_HANDLER_DECL(id, counter, irq, pclk, trig) \
+    static mp_obj_t machine_counter_index_handler_##id(mp_obj_t pin_in) { \
+        (void)pin_in; \
+        machine_counter_obj_t *self = counter_obj[id]; \
+        if (self != NULL && self->index_pin != NULL) { \
+            machine_counter_on_aux_event(self, true); \
+        } \
+        return mp_const_none; \
+    }
+MICROPY_PY_MACHINE_TCPWM_MAP(COUNTER_INDEX_HANDLER_DECL)
+#undef COUNTER_INDEX_HANDLER_DECL
+
+// Generate one index callback object per Counter id (bound through machine.Pin.irq).
+#define COUNTER_INDEX_HANDLER_OBJ_DECL(id, counter, irq, pclk, trig) \
+    static MP_DEFINE_CONST_FUN_OBJ_1(machine_counter_index_handler_obj_##id, machine_counter_index_handler_##id);
+MICROPY_PY_MACHINE_TCPWM_MAP(COUNTER_INDEX_HANDLER_OBJ_DECL)
+#undef COUNTER_INDEX_HANDLER_OBJ_DECL
+
+// Generate one index callback object entry per Counter id (bound through machine.Pin.irq).
+#define COUNTER_INDEX_HANDLER_OBJ_ENTRY(id, counter, irq, pclk, trig) MP_OBJ_FROM_PTR(&machine_counter_index_handler_obj_##id),
+static const mp_obj_t machine_counter_index_handler_obj[MACHINE_COUNTER_NUM_INSTANCES] = {
+    MICROPY_PY_MACHINE_TCPWM_MAP(COUNTER_INDEX_HANDLER_OBJ_ENTRY)
+};
+#undef COUNTER_INDEX_HANDLER_OBJ_ENTRY
+// -------------------------------------------------------------------------- //
+
+// -------------------------------------------------------------------------- //
+// Generate one reset callback per Counter id (bound through machine.Pin.irq).
+#define COUNTER_RESET_HANDLER_DECL(id, counter, irq, pclk, trig) \
+    static mp_obj_t machine_counter_reset_handler_##id(mp_obj_t pin_in) { \
+        (void)pin_in; \
+        machine_counter_obj_t *self = counter_obj[id]; \
+        if (self != NULL && self->reset_pin != NULL) { \
+            machine_counter_on_aux_event(self, false); \
+        } \
+        return mp_const_none; \
+    }
+MICROPY_PY_MACHINE_TCPWM_MAP(COUNTER_RESET_HANDLER_DECL)
+#undef COUNTER_RESET_HANDLER_DECL
+
+// Generate one reset callback object per Counter id (bound through machine.Pin.irq).
+#define COUNTER_RESET_HANDLER_OBJ_DECL(id, counter, irq, pclk, trig) \
+    static MP_DEFINE_CONST_FUN_OBJ_1(machine_counter_reset_handler_obj_##id, machine_counter_reset_handler_##id);
+MICROPY_PY_MACHINE_TCPWM_MAP(COUNTER_RESET_HANDLER_OBJ_DECL)
+#undef COUNTER_RESET_HANDLER_OBJ_DECL
+
+// Generate one reset callback object entry per Counter id (bound through machine.Pin.irq).
+#define COUNTER_RESET_HANDLER_OBJ_ENTRY(id, counter, irq, pclk, trig) MP_OBJ_FROM_PTR(&machine_counter_reset_handler_obj_##id),
+static const mp_obj_t machine_counter_reset_handler_obj[MACHINE_COUNTER_NUM_INSTANCES] = {
+    MICROPY_PY_MACHINE_TCPWM_MAP(COUNTER_RESET_HANDLER_OBJ_ENTRY)
+};
+#undef COUNTER_RESET_HANDLER_OBJ_ENTRY
+// -------------------------------------------------------------------------- //
+
+// -------------------------------------------------------------------------- //
+// If index and reset share a pin, run both semantics from a single callback.
+#define COUNTER_INDEX_RESET_HANDLER_DECL(id, counter, irq, pclk, trig) \
+    static mp_obj_t machine_counter_index_reset_handler_##id(mp_obj_t pin_in) { \
+        (void)pin_in; \
+        machine_counter_obj_t *self = counter_obj[id]; \
+        if (self != NULL) { \
+            if (self->index_pin != NULL) { \
+                machine_counter_on_aux_event(self, true); \
+            } \
+            if (self->reset_pin != NULL) { \
+                machine_counter_on_aux_event(self, false); \
+            } \
+        } \
+        return mp_const_none; \
+    }
+MICROPY_PY_MACHINE_TCPWM_MAP(COUNTER_INDEX_RESET_HANDLER_DECL)
+#undef COUNTER_INDEX_RESET_HANDLER_DECL
+
+// Generate one index/reset callback object per Counter id (bound through machine.Pin.irq).
+#define COUNTER_INDEX_RESET_HANDLER_OBJ_DECL(id, counter, irq, pclk, trig) \
+    static MP_DEFINE_CONST_FUN_OBJ_1(machine_counter_index_reset_handler_obj_##id, machine_counter_index_reset_handler_##id);
+MICROPY_PY_MACHINE_TCPWM_MAP(COUNTER_INDEX_RESET_HANDLER_OBJ_DECL)
+#undef COUNTER_INDEX_RESET_HANDLER_OBJ_DECL
+
+// Generate one index/reset callback object entry per Counter id (bound through machine.Pin.irq).
+#define COUNTER_INDEX_RESET_HANDLER_OBJ_ENTRY(id, counter, irq, pclk, trig) MP_OBJ_FROM_PTR(&machine_counter_index_reset_handler_obj_##id),
+static const mp_obj_t machine_counter_index_reset_handler_obj[MACHINE_COUNTER_NUM_INSTANCES] = {
+    MICROPY_PY_MACHINE_TCPWM_MAP(COUNTER_INDEX_RESET_HANDLER_OBJ_ENTRY)
+};
+#undef COUNTER_INDEX_RESET_HANDLER_OBJ_ENTRY
+
+// -------------------------------------------------------------------------- //
 
 // Roll back Counter state and release channel ownership after init failure.
 static void machine_counter_init_fail_cleanup(machine_counter_obj_t *self) {
     machine_counter_stop_hw(self);
     machine_counter_stop_irq(self);
+    machine_counter_disable_aux_irqs(self);
     machine_counter_restore_src_pin(self);
     self->configured = false;
     self->cycles_u16 = 0;
@@ -279,11 +429,13 @@ static void machine_counter_init_helper_impl(machine_counter_obj_t *self,
         mp_raise_ValueError(MP_ERROR_TEXT("min must be >= 0"));
     }
 
+    const machine_pin_obj_t *index_pin = NULL;
     if (args[ARG_index].u_obj != mp_const_none) {
-        mp_raise_NotImplementedError(MP_ERROR_TEXT("index not supported"));
+        index_pin = mp_hal_get_pin_obj(args[ARG_index].u_obj);
     }
+    const machine_pin_obj_t *reset_pin = NULL;
     if (args[ARG_reset].u_obj != mp_const_none) {
-        mp_raise_NotImplementedError(MP_ERROR_TEXT("reset not supported"));
+        reset_pin = mp_hal_get_pin_obj(args[ARG_reset].u_obj);
     }
     if (args[ARG_match].u_obj != mp_const_none) {
         mp_raise_NotImplementedError(MP_ERROR_TEXT("match not supported"));
@@ -328,6 +480,7 @@ static void machine_counter_init_helper_impl(machine_counter_obj_t *self,
     // Tear down any previous run before programming new pin routing.
     machine_counter_stop_hw(self);
     machine_counter_stop_irq(self);
+    machine_counter_disable_aux_irqs(self);
     machine_counter_restore_src_pin(self);
 
     // Ensure shared timer clock is configured and bound to this counter PCLK.
@@ -339,6 +492,8 @@ static void machine_counter_init_helper_impl(machine_counter_obj_t *self,
 
     // Record the source pin now so rollback can restore it on any failure below.
     self->src_pin = src_pin;
+    self->index_pin = index_pin;
+    self->reset_pin = reset_pin;
 
     // Connect selected pin trigger line to this counter's dedicated trigger input.
     uint32_t out_trig = counter_out_trig[self->id];
@@ -346,9 +501,51 @@ static void machine_counter_init_helper_impl(machine_counter_obj_t *self,
     if (mux_rslt != CY_TRIGMUX_SUCCESS) {
         // Roll back pin mux state if trigger connect fails.
         machine_counter_restore_src_pin(self);
+        machine_counter_disable_aux_irqs(self);
         mp_raise_msg_varg(&mp_type_ValueError,
             MP_ERROR_TEXT("Counter route connect failed (0x%lx)"),
             (unsigned long)mux_rslt);
+    }
+
+    bool index_reset_same_pin = (self->index_pin != NULL
+        && self->reset_pin != NULL
+        && self->index_pin == self->reset_pin);
+
+    if (self->index_pin != NULL) {
+        mp_hal_pin_input(self->index_pin);
+
+        mp_obj_t pos_args[] = {
+            MP_OBJ_FROM_PTR((machine_pin_obj_t *)self->index_pin),
+            index_reset_same_pin
+                ? machine_counter_index_reset_handler_obj[self->id]
+                : machine_counter_index_handler_obj[self->id],
+        };
+        mp_obj_t kw_table[] = {
+            MP_OBJ_NEW_QSTR(MP_QSTR_trigger), MP_OBJ_NEW_SMALL_INT(CY_GPIO_INTR_RISING),
+            MP_OBJ_NEW_QSTR(MP_QSTR_hard), mp_const_true,
+        };
+        mp_map_t kw_args;
+        mp_map_init_fixed_table(&kw_args, MP_ARRAY_SIZE(kw_table) / 2, kw_table);
+        self->index_irq_obj = machine_pin_irq(2, pos_args, &kw_args);
+        if (index_reset_same_pin) {
+            self->reset_irq_obj = self->index_irq_obj;
+        }
+    }
+
+    if (self->reset_pin != NULL && !index_reset_same_pin) {
+        mp_hal_pin_input(self->reset_pin);
+
+        mp_obj_t pos_args[] = {
+            MP_OBJ_FROM_PTR((machine_pin_obj_t *)self->reset_pin),
+            machine_counter_reset_handler_obj[self->id],
+        };
+        mp_obj_t kw_table[] = {
+            MP_OBJ_NEW_QSTR(MP_QSTR_trigger), MP_OBJ_NEW_SMALL_INT(CY_GPIO_INTR_RISING),
+            MP_OBJ_NEW_QSTR(MP_QSTR_hard), mp_const_true,
+        };
+        mp_map_t kw_args;
+        mp_map_init_fixed_table(&kw_args, MP_ARRAY_SIZE(kw_table) / 2, kw_table);
+        self->reset_irq_obj = machine_pin_irq(2, pos_args, &kw_args);
     }
 
     cy_stc_tcpwm_counter_config_t cfg = {0};
@@ -454,12 +651,16 @@ static mp_obj_t machine_counter_make_new(const mp_obj_type_t *type,
     self->counter_num = counter_hw[id];
     self->pclk_dst = machine_tcpwm_counter_pclk(self->counter_num);
     self->src_pin = NULL;
+    self->index_pin = NULL;
+    self->reset_pin = NULL;
     self->edge = COUNTER_EDGE_RISING;
     self->direction = COUNTER_DIR_UP;
     self->range_min = 0;
     self->range_max = machine_counter_period_max(self->counter_num);
     self->cycles_u16 = 0;
     self->offset = 0;
+    self->index_irq_obj = MP_OBJ_NULL;
+    self->reset_irq_obj = MP_OBJ_NULL;
     self->irq_cfg.irq_num = counter_irq[id];
     self->irq_active = false;
     self->configured = false;
@@ -503,6 +704,7 @@ static mp_obj_t machine_counter_deinit(mp_obj_t self_in) {
 
     machine_counter_stop_hw(self);
     machine_counter_stop_irq(self);
+    machine_counter_disable_aux_irqs(self);
     machine_counter_restore_src_pin(self);
 
     self->configured = false;

--- a/ports/psoc-edge/machine_counter.c
+++ b/ports/psoc-edge/machine_counter.c
@@ -41,6 +41,7 @@
 #include "mtb_hal.h"
 
 #include "genhdr/pins_af.h"
+#include "sys_int.h"
 
 // Number of Counter object slots supported by this port.
 #define MACHINE_COUNTER_NUM_INSTANCES  (32)
@@ -67,7 +68,10 @@ typedef struct _machine_counter_obj_t {
     mp_hal_pin_obj_t src_pin;
     uint8_t edge;
     uint8_t direction;
+    uint16_t cycles_u16;
     mp_int_t offset;
+    sys_int_cfg_t irq_cfg;
+    bool irq_active;
     bool configured;
 } machine_counter_obj_t;
 
@@ -92,6 +96,13 @@ static const uint32_t counter_out_trig[MACHINE_COUNTER_NUM_INSTANCES] = {
     MICROPY_PY_MACHINE_TCPWM_MAP(COUNTER_OUT_TRIG_ENTRY)
 };
 #undef COUNTER_OUT_TRIG_ENTRY
+
+// Expands generated map entries into id->counter-IRQ lookup.
+#define COUNTER_IRQ_ENTRY(id, counter, irq, pclk, trig) irq,
+static const IRQn_Type counter_irq[MACHINE_COUNTER_NUM_INSTANCES] = {
+    MICROPY_PY_MACHINE_TCPWM_MAP(COUNTER_IRQ_ENTRY)
+};
+#undef COUNTER_IRQ_ENTRY
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -150,11 +161,60 @@ static void machine_counter_stop_hw(machine_counter_obj_t *self) {
     Cy_TCPWM_Counter_Disable(TCPWM0, self->counter_num);
 }
 
+// Disable and unregister the counter IRQ if it is currently active.
+static void machine_counter_stop_irq(machine_counter_obj_t *self) {
+    if (self->irq_active) {
+        sys_int_deinit(&self->irq_cfg);
+        self->irq_active = false;
+    }
+}
+
+// Return the cycles counter as signed 16-bit value.
+static inline int16_t machine_counter_cycles_get(const machine_counter_obj_t *self) {
+    return (int16_t)self->cycles_u16;
+}
+
+// Increment/decrement cycles counter with 16-bit wrap semantics.
+static inline void machine_counter_cycles_step(machine_counter_obj_t *self) {
+    if (self->direction == COUNTER_DIR_DOWN) {
+        self->cycles_u16--;
+    } else {
+        self->cycles_u16++;
+    }
+}
+
+// Counter terminal-count ISR: track wrap events in software cycles.
+static void machine_counter_isr(machine_counter_obj_t *self) {
+    if (Cy_TCPWM_GetInterruptStatus(TCPWM0, self->counter_num) & CY_TCPWM_INT_ON_TC) {
+        Cy_TCPWM_ClearInterrupt(TCPWM0, self->counter_num, CY_TCPWM_INT_ON_TC);
+        machine_counter_cycles_step(self);
+    }
+}
+
+// Generate one IRQ handler per Counter id for direct dispatch.
+#define COUNTER_IRQ_HANDLER_DECL(id, counter, irq, pclk, trig) \
+    static void machine_counter_irq_handler_##id(void) { \
+        machine_counter_obj_t *self = counter_obj[id]; \
+        if (self != NULL) { \
+            machine_counter_isr(self); \
+        } \
+    }
+MICROPY_PY_MACHINE_TCPWM_MAP(COUNTER_IRQ_HANDLER_DECL)
+#undef COUNTER_IRQ_HANDLER_DECL
+
+#define COUNTER_IRQ_HANDLER_ENTRY(id, counter, irq, pclk, trig) machine_counter_irq_handler_##id,
+static const cy_israddress machine_counter_irq_handlers[MACHINE_COUNTER_NUM_INSTANCES] = {
+    MICROPY_PY_MACHINE_TCPWM_MAP(COUNTER_IRQ_HANDLER_ENTRY)
+};
+#undef COUNTER_IRQ_HANDLER_ENTRY
+
 // Roll back Counter state and release channel ownership after init failure.
 static void machine_counter_init_fail_cleanup(machine_counter_obj_t *self) {
     machine_counter_stop_hw(self);
+    machine_counter_stop_irq(self);
     machine_counter_restore_src_pin(self);
     self->configured = false;
+    self->cycles_u16 = 0;
     self->offset = 0;
 
     machine_tcpwm_counter_free(self->counter_num, MP_OBJ_FROM_PTR(self));
@@ -198,6 +258,7 @@ static void machine_counter_init_helper_impl(machine_counter_obj_t *self,
 
     // Tear down any previous run before programming new pin routing.
     machine_counter_stop_hw(self);
+    machine_counter_stop_irq(self);
     machine_counter_restore_src_pin(self);
 
     // Ensure shared timer clock is configured and bound to this counter PCLK.
@@ -230,7 +291,7 @@ static void machine_counter_init_helper_impl(machine_counter_obj_t *self,
     cfg.compare0 = 0;
     cfg.compare1 = 0;
     cfg.enableCompareSwap = false;
-    cfg.interruptSources = 0;
+    cfg.interruptSources = CY_TCPWM_INT_ON_TC;
     cfg.captureInputMode = COUNTER_INPUT_DISABLED & 0x3U;
     cfg.captureInput = CY_TCPWM_INPUT_0;
     cfg.reloadInputMode = COUNTER_INPUT_DISABLED & 0x3U;
@@ -262,11 +323,19 @@ static void machine_counter_init_helper_impl(machine_counter_obj_t *self,
     }
 
     Cy_TCPWM_Counter_SetCounter(TCPWM0, self->counter_num, 0);
+    Cy_TCPWM_ClearInterrupt(TCPWM0, self->counter_num, CY_TCPWM_INT_ON_TC);
+
+    self->irq_cfg.priority = SYS_INT_IRQ_LOWEST_PRIORITY;
+    self->irq_cfg.handler = machine_counter_irq_handlers[self->id];
+    sys_int_init(&self->irq_cfg);
+    self->irq_active = true;
+
     Cy_TCPWM_Counter_Enable(TCPWM0, self->counter_num);
     Cy_TCPWM_TriggerReloadOrIndex_Single(TCPWM0, self->counter_num);
 
     self->edge = edge;
     self->direction = direction;
+    self->cycles_u16 = 0;
     self->offset = 0;
     self->configured = true;
 }
@@ -316,7 +385,10 @@ static mp_obj_t machine_counter_make_new(const mp_obj_type_t *type,
     self->src_pin = NULL;
     self->edge = COUNTER_EDGE_RISING;
     self->direction = COUNTER_DIR_UP;
+    self->cycles_u16 = 0;
     self->offset = 0;
+    self->irq_cfg.irq_num = counter_irq[id];
+    self->irq_active = false;
     self->configured = false;
 
     nlr_buf_t nl;
@@ -357,9 +429,11 @@ static mp_obj_t machine_counter_deinit(mp_obj_t self_in) {
     machine_counter_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
     machine_counter_stop_hw(self);
+    machine_counter_stop_irq(self);
     machine_counter_restore_src_pin(self);
 
     self->configured = false;
+    self->cycles_u16 = 0;
     self->offset = 0;
 
     machine_tcpwm_counter_free(self->counter_num, MP_OBJ_FROM_PTR(self));
@@ -395,13 +469,24 @@ static mp_obj_t machine_counter_value(size_t n_args, const mp_obj_t *args) {
         // Freeze counting during read/reset so no new edges arrive in this window.
         Cy_TCPWM_Counter_Disable(TCPWM0, self->counter_num);
     }
+
     uint32_t raw = Cy_TCPWM_Counter_GetCounter(TCPWM0, self->counter_num);
-    long long signed_count = (self->direction == COUNTER_DIR_DOWN) ? -(long long)raw : (long long)raw;
-    long long result = (long long)self->offset + signed_count;
+    uint64_t span = (uint64_t)machine_counter_period_max(self->counter_num) + 1ULL;
+    int16_t cycles = machine_counter_cycles_get(self);
+    long long edge_total;
+    if (self->direction == COUNTER_DIR_DOWN) {
+        edge_total = (long long)(-cycles) * (long long)span + (long long)raw;
+        edge_total = -edge_total;
+    } else {
+        edge_total = (long long)cycles * (long long)span + (long long)raw;
+    }
+    long long result = (long long)self->offset + edge_total;
 
     if (n_args == 2) {
         self->offset = mp_obj_get_int(args[1]);
+        self->cycles_u16 = 0;
         Cy_TCPWM_Counter_SetCounter(TCPWM0, self->counter_num, 0);
+        Cy_TCPWM_ClearInterrupt(TCPWM0, self->counter_num, CY_TCPWM_INT_ON_TC);
         Cy_TCPWM_Counter_Enable(TCPWM0, self->counter_num);
         Cy_TCPWM_TriggerReloadOrIndex_Single(TCPWM0, self->counter_num);
     }
@@ -409,6 +494,32 @@ static mp_obj_t machine_counter_value(size_t n_args, const mp_obj_t *args) {
     return mp_obj_new_int_from_ll(result);
 }
 static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_counter_value_obj, 1, 2, machine_counter_value);
+
+// ---------------------------------------------------------------------------
+// counter.cycles([value])
+// ---------------------------------------------------------------------------
+
+// Get or set the signed 16-bit software cycles counter.
+static mp_obj_t machine_counter_cycles(size_t n_args, const mp_obj_t *args) {
+    machine_counter_obj_t *self = MP_OBJ_TO_PTR(args[0]);
+
+    if (!self->configured) {
+        mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("not initialised"));
+    }
+
+    int16_t prev = machine_counter_cycles_get(self);
+
+    if (n_args == 2) {
+        mp_int_t value = mp_obj_get_int(args[1]);
+        if (value < -32768 || value > 32767) {
+            mp_raise_ValueError(MP_ERROR_TEXT("cycles out of range"));
+        }
+        self->cycles_u16 = (uint16_t)(int16_t)value;
+    }
+
+    return mp_obj_new_int(prev);
+}
+static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_counter_cycles_obj, 1, 2, machine_counter_cycles);
 
 // Print user-facing representation as Counter(<id>).
 static void machine_counter_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
@@ -429,6 +540,7 @@ static const mp_rom_map_elem_t machine_counter_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_init), MP_ROM_PTR(&machine_counter_init_obj) },
     { MP_ROM_QSTR(MP_QSTR_deinit), MP_ROM_PTR(&machine_counter_deinit_obj) },
     { MP_ROM_QSTR(MP_QSTR_value), MP_ROM_PTR(&machine_counter_value_obj) },
+    { MP_ROM_QSTR(MP_QSTR_cycles), MP_ROM_PTR(&machine_counter_cycles_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_RISING), MP_ROM_INT(COUNTER_EDGE_RISING) },
     { MP_ROM_QSTR(MP_QSTR_FALLING), MP_ROM_INT(COUNTER_EDGE_FALLING) },

--- a/ports/psoc-edge/machine_counter.c
+++ b/ports/psoc-edge/machine_counter.c
@@ -134,7 +134,7 @@ static const IRQn_Type counter_irq[MACHINE_COUNTER_NUM_INSTANCES] = {
 #undef COUNTER_IRQ_ENTRY
 
 // ---------------------------------------------------------------------------
-// Helpers
+// Core Helpers
 // ---------------------------------------------------------------------------
 
 // Configure the shared peripheral clock once for all Counter objects.
@@ -255,6 +255,10 @@ static inline void machine_counter_cycles_step(machine_counter_obj_t *self) {
     }
 }
 
+// ---------------------------------------------------------------------------
+// IRQ Internals
+// ---------------------------------------------------------------------------
+
 static mp_uint_t machine_counter_irq_trigger(mp_obj_t self_in, mp_uint_t new_trigger) {
     machine_counter_obj_t *self = MP_OBJ_TO_PTR(self_in);
     self->mp_irq_trigger = new_trigger;
@@ -290,22 +294,6 @@ static inline void machine_counter_irq_raise(machine_counter_obj_t *self, mp_uin
     if (call_handler) {
         mp_irq_handler(self->mp_irq_obj);
     }
-}
-
-static mp_obj_t machine_counter_enable_aux_irq(const machine_pin_obj_t *pin, mp_obj_t handler_obj) {
-    mp_hal_pin_input(pin);
-
-    mp_obj_t pos_args[] = {
-        MP_OBJ_FROM_PTR((machine_pin_obj_t *)pin),
-        handler_obj,
-    };
-    mp_obj_t kw_table[] = {
-        MP_OBJ_NEW_QSTR(MP_QSTR_trigger), MP_OBJ_NEW_SMALL_INT(CY_GPIO_INTR_RISING),
-        MP_OBJ_NEW_QSTR(MP_QSTR_hard), mp_const_true,
-    };
-    mp_map_t kw_args;
-    mp_map_init_fixed_table(&kw_args, MP_ARRAY_SIZE(kw_table) / 2, kw_table);
-    return machine_pin_irq(2, pos_args, &kw_args);
 }
 
 // Counter terminal-count ISR: track wrap events in software cycles.
@@ -348,6 +336,9 @@ static inline void machine_counter_on_aux_event(machine_counter_obj_t *self, boo
 }
 
 // -------------------------------------------------------------------------- //
+// Generated IRQ/Callback Dispatch Tables
+// -------------------------------------------------------------------------- //
+
 // Generate one IRQ handler per Counter id for direct dispatch.
 #define COUNTER_IRQ_HANDLER_DECL(id, counter, irq, pclk, trig) \
     static void machine_counter_irq_handler_##id(void) { \
@@ -456,6 +447,26 @@ static const mp_obj_t machine_counter_index_reset_handler_obj[MACHINE_COUNTER_NU
 #undef COUNTER_INDEX_RESET_HANDLER_OBJ_ENTRY
 
 // -------------------------------------------------------------------------- //
+
+// ---------------------------------------------------------------------------
+// Init Internals
+// ---------------------------------------------------------------------------
+
+static mp_obj_t machine_counter_enable_aux_irq(const machine_pin_obj_t *pin, mp_obj_t handler_obj) {
+    mp_hal_pin_input(pin);
+
+    mp_obj_t pos_args[] = {
+        MP_OBJ_FROM_PTR((machine_pin_obj_t *)pin),
+        handler_obj,
+    };
+    mp_obj_t kw_table[] = {
+        MP_OBJ_NEW_QSTR(MP_QSTR_trigger), MP_OBJ_NEW_SMALL_INT(CY_GPIO_INTR_RISING),
+        MP_OBJ_NEW_QSTR(MP_QSTR_hard), mp_const_true,
+    };
+    mp_map_t kw_args;
+    mp_map_init_fixed_table(&kw_args, MP_ARRAY_SIZE(kw_table) / 2, kw_table);
+    return machine_pin_irq(2, pos_args, &kw_args);
+}
 
 // Parse init args and configure routing, trigger mux, and TCPWM hardware.
 static void machine_counter_init_helper_impl(machine_counter_obj_t *self,
@@ -699,9 +710,14 @@ static void machine_counter_init_helper(machine_counter_obj_t *self,
 }
 
 // ---------------------------------------------------------------------------
-// Constructor: Counter(id, ...)
+// ---------------------------------------------------------------------------
+// Public Lifecycle API
+// ---------------------------------------------------------------------------
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Constructor: Counter(id, ...)
+// ---------------------------------------------------------------------------
 // Create a Counter object, reserve hardware, and run optional init.
 static mp_obj_t machine_counter_make_new(const mp_obj_type_t *type,
     size_t n_args, size_t n_kw, const mp_obj_t *args) {
@@ -817,9 +833,14 @@ void machine_counter_deinit_all(void) {
 }
 
 // ---------------------------------------------------------------------------
-// counter.value([value])
+// ---------------------------------------------------------------------------
+// Public Data/IRQ API
+// ---------------------------------------------------------------------------
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// counter.value([value])
+// ---------------------------------------------------------------------------
 // Return current count, or reset logical origin when a value is provided.
 static mp_obj_t machine_counter_value(size_t n_args, const mp_obj_t *args) {
     machine_counter_obj_t *self = MP_OBJ_TO_PTR(args[0]);
@@ -861,7 +882,6 @@ static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_counter_value_obj, 1, 2, mach
 // ---------------------------------------------------------------------------
 // counter.cycles([value])
 // ---------------------------------------------------------------------------
-
 // Get or set the signed 16-bit software cycles counter.
 static mp_obj_t machine_counter_cycles(size_t n_args, const mp_obj_t *args) {
     machine_counter_obj_t *self = MP_OBJ_TO_PTR(args[0]);
@@ -884,6 +904,9 @@ static mp_obj_t machine_counter_cycles(size_t n_args, const mp_obj_t *args) {
 }
 static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_counter_cycles_obj, 1, 2, machine_counter_cycles);
 
+// ---------------------------------------------------------------------------
+// counter.match([value])
+// ---------------------------------------------------------------------------
 // Get or set compare-match value; pass None to disable match.
 static mp_obj_t machine_counter_match(size_t n_args, const mp_obj_t *args) {
     machine_counter_obj_t *self = MP_OBJ_TO_PTR(args[0]);
@@ -925,7 +948,10 @@ static mp_obj_t machine_counter_match(size_t n_args, const mp_obj_t *args) {
 }
 static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_counter_match_obj, 1, 2, machine_counter_match);
 
+// ---------------------------------------------------------------------------
 // counter.irq(handler=None, trigger=0, hard=False)
+// ---------------------------------------------------------------------------
+// Return or configure a Counter IRQ object for this counter.
 static mp_obj_t machine_counter_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     machine_counter_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
     bool any_args = n_args > 1 || kw_args->used != 0;
@@ -973,6 +999,9 @@ static mp_obj_t machine_counter_irq(size_t n_args, const mp_obj_t *pos_args, mp_
 }
 static MP_DEFINE_CONST_FUN_OBJ_KW(machine_counter_irq_obj, 1, machine_counter_irq);
 
+// ---------------------------------------------------------------------------
+// Printing
+// ---------------------------------------------------------------------------
 // Print user-facing representation as Counter(<id>).
 static void machine_counter_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     machine_counter_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -991,10 +1020,10 @@ static void machine_counter_print(const mp_print_t *print, mp_obj_t self_in, mp_
 static const mp_rom_map_elem_t machine_counter_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_init), MP_ROM_PTR(&machine_counter_init_obj) },
     { MP_ROM_QSTR(MP_QSTR_deinit), MP_ROM_PTR(&machine_counter_deinit_obj) },
-    { MP_ROM_QSTR(MP_QSTR_irq), MP_ROM_PTR(&machine_counter_irq_obj) },
     { MP_ROM_QSTR(MP_QSTR_value), MP_ROM_PTR(&machine_counter_value_obj) },
     { MP_ROM_QSTR(MP_QSTR_cycles), MP_ROM_PTR(&machine_counter_cycles_obj) },
     { MP_ROM_QSTR(MP_QSTR_match), MP_ROM_PTR(&machine_counter_match_obj) },
+    { MP_ROM_QSTR(MP_QSTR_irq), MP_ROM_PTR(&machine_counter_irq_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_IRQ_RESET), MP_ROM_INT(MACHINE_COUNTER_IRQ_RESET) },
     { MP_ROM_QSTR(MP_QSTR_IRQ_INDEX), MP_ROM_INT(MACHINE_COUNTER_IRQ_INDEX) },
@@ -1008,6 +1037,10 @@ static const mp_rom_map_elem_t machine_counter_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_DOWN), MP_ROM_INT(COUNTER_DIR_DOWN) },
 };
 static MP_DEFINE_CONST_DICT(machine_counter_locals_dict, machine_counter_locals_dict_table);
+
+// ---------------------------------------------------------------------------
+// Type Registration
+// ---------------------------------------------------------------------------
 
 MP_DEFINE_CONST_OBJ_TYPE(
     machine_counter_type,

--- a/tests/ports/psoc-edge/board_ext_hw/single/counter.py
+++ b/tests/ports/psoc-edge/board_ext_hw/single/counter.py
@@ -40,6 +40,13 @@ def expect_value_error(label, fn):
         print(label, e)
 
 
+def expect_not_implemented_error(label, fn):
+    try:
+        fn()
+    except NotImplementedError as e:
+        print(label, e)
+
+
 print("*****Counter tests*****")
 
 pin_out = Pin(PIN_OUT, mode=Pin.OUT, value=0)
@@ -75,12 +82,44 @@ print("cycles_set_prev:", c.cycles(5) == 0)
 print("cycles_after_set:", c.cycles() == 5)
 c.deinit()
 
+# max/min tests: custom range with min=0 supported.
+c = Counter(4, src=Pin(PIN_IN), edge=Counter.RISING, direction=Counter.UP, max=9, min=0)
+prime_counter(c, pin_out)
+pulse(pin_out, 25)
+print("range_max_value:", close_to(c.value(), 25))
+print("range_max_cycles:", c.cycles() == 2)
+c.deinit()
+
+# min!=0 support: valid when 0 <= min < max.
+c = Counter(5, src=Pin(PIN_IN), edge=Counter.RISING, direction=Counter.UP, max=9, min=2)
+prime_counter(c, pin_out)
+pulse(pin_out, 25)
+print("range_min_nonzero_value:", close_to(c.value(), 25))
+print("range_min_nonzero_cycles:", c.cycles() == 3)
+c.deinit()
+
 # Negative tests: boundary and input validation (ValueError paths).
 expect_value_error("invalid_id_-1:", lambda: Counter(-1, src=Pin(PIN_IN)))
 expect_value_error("invalid_id_32:", lambda: Counter(32, src=Pin(PIN_IN)))
 expect_value_error("invalid_edge:", lambda: Counter(3, src=Pin(PIN_IN), edge=3))
 expect_value_error("invalid_direction:", lambda: Counter(4, src=Pin(PIN_IN), direction=3))
 expect_value_error("invalid_src_pin:", lambda: Counter(5, src=Pin(PIN_OUT)))
+expect_value_error("invalid_max:", lambda: Counter(7, src=Pin(PIN_IN), max=-1))
+expect_value_error("invalid_min_ge_max:", lambda: Counter(7, src=Pin(PIN_IN), max=10, min=10))
+
+expect_not_implemented_error(
+    "filter_ns_not_supported:", lambda: Counter(7, src=Pin(PIN_IN), filter_ns=100)
+)
+expect_not_implemented_error(
+    "index_not_supported:", lambda: Counter(7, src=Pin(PIN_IN), index=Pin(PIN_IN))
+)
+expect_not_implemented_error(
+    "reset_not_supported:", lambda: Counter(7, src=Pin(PIN_IN), reset=Pin(PIN_IN))
+)
+expect_not_implemented_error("match_not_supported:", lambda: Counter(7, src=Pin(PIN_IN), match=10))
+expect_not_implemented_error(
+    "match_pin_not_supported:", lambda: Counter(7, src=Pin(PIN_IN), match_pin=Pin(PIN_OUT))
+)
 
 # Test duplicate counter ID. The second instantiation should raise a ValueError.
 c_dup = Counter(6, src=Pin(PIN_IN))

--- a/tests/ports/psoc-edge/board_ext_hw/single/counter.py
+++ b/tests/ports/psoc-edge/board_ext_hw/single/counter.py
@@ -120,7 +120,8 @@ expect_value_error("invalid_id_32:", lambda: Counter(32, src=Pin(PIN_IN)))
 expect_value_error("invalid_edge:", lambda: Counter(3, src=Pin(PIN_IN), edge=3))
 expect_value_error("invalid_direction:", lambda: Counter(4, src=Pin(PIN_IN), direction=3))
 expect_value_error("invalid_src_pin:", lambda: Counter(5, src=Pin(PIN_OUT)))
-expect_value_error("invalid_max:", lambda: Counter(7, src=Pin(PIN_IN), max=-1))
+expect_value_error("invalid_min_negative:", lambda: Counter(5, src=Pin(PIN_IN), min=-50))
+expect_value_error("invalid_max_negative:", lambda: Counter(6, src=Pin(PIN_IN), max=-1))
 expect_value_error("invalid_min_ge_max:", lambda: Counter(7, src=Pin(PIN_IN), max=10, min=10))
 
 expect_not_implemented_error(

--- a/tests/ports/psoc-edge/board_ext_hw/single/counter.py
+++ b/tests/ports/psoc-edge/board_ext_hw/single/counter.py
@@ -168,6 +168,14 @@ print("reset_active:", abs(c.value()) <= 1 and c.cycles() == 0)
 c.deinit()
 
 # match tests: init option, runtime updates, disable path, and validation.
+c = Counter(7, src=Pin(PIN_IN), edge=Counter.RISING, direction=Counter.UP, max=9, min=2, match=6)
+print("match_init_get:", c.match() == 6)
+print("match_set_prev:", c.match(4) == 6)
+print("match_after_set:", c.match() == 4)
+print("match_disable_prev:", c.match(None) == 4)
+print("match_after_disable:", c.match() is None)
+c.deinit()
+
 c = Counter(
     7, src=Pin(PIN_IN), edge=Counter.RISING, direction=Counter.UP, max=100, min=-50, match=-25
 )
@@ -181,12 +189,30 @@ c.deinit()
 expect_value_error(
     "match_init_out_of_range:",
     lambda: Counter(
-        7, src=Pin(PIN_IN), edge=Counter.RISING, direction=Counter.UP, max=100, min=-50, match=200
+        7, src=Pin(PIN_IN), edge=Counter.RISING, direction=Counter.UP, max=9, min=2, match=12
     ),
 )
 
 
 def expect_match_set_out_of_range():
+    c = Counter(7, src=Pin(PIN_IN), edge=Counter.RISING, direction=Counter.UP, max=9, min=2)
+    try:
+        c.match(12)
+    finally:
+        c.deinit()
+
+
+expect_value_error("match_set_out_of_range:", expect_match_set_out_of_range)
+
+expect_value_error(
+    "match_negative_init_out_of_range:",
+    lambda: Counter(
+        7, src=Pin(PIN_IN), edge=Counter.RISING, direction=Counter.UP, max=100, min=-50, match=200
+    ),
+)
+
+
+def expect_match_negative_set_out_of_range():
     c = Counter(7, src=Pin(PIN_IN), edge=Counter.RISING, direction=Counter.UP, max=100, min=-50)
     try:
         c.match(200)
@@ -194,7 +220,7 @@ def expect_match_set_out_of_range():
         c.deinit()
 
 
-expect_value_error("match_set_out_of_range:", expect_match_set_out_of_range)
+expect_value_error("match_negative_set_out_of_range:", expect_match_negative_set_out_of_range)
 
 # irq() tests: constants, trigger API, callback path, and validation.
 c = Counter(8, src=Pin(PIN_IN), edge=Counter.RISING, direction=Counter.UP, max=5, min=0, match=3)

--- a/tests/ports/psoc-edge/board_ext_hw/single/counter.py
+++ b/tests/ports/psoc-edge/board_ext_hw/single/counter.py
@@ -68,6 +68,13 @@ pulse(pin_out, 10)
 print("value_reset:", close_to(c.value(), -10))
 c.deinit()
 
+# cycles() tests: get, set, and previous-value return semantics.
+c = Counter(3, src=Pin(PIN_IN), edge=Counter.RISING, direction=Counter.UP)
+print("cycles_default:", c.cycles() == 0)
+print("cycles_set_prev:", c.cycles(5) == 0)
+print("cycles_after_set:", c.cycles() == 5)
+c.deinit()
+
 # Negative tests: boundary and input validation (ValueError paths).
 expect_value_error("invalid_id_-1:", lambda: Counter(-1, src=Pin(PIN_IN)))
 expect_value_error("invalid_id_32:", lambda: Counter(32, src=Pin(PIN_IN)))

--- a/tests/ports/psoc-edge/board_ext_hw/single/counter.py
+++ b/tests/ports/psoc-edge/board_ext_hw/single/counter.py
@@ -47,6 +47,13 @@ def expect_not_implemented_error(label, fn):
         print(label, e)
 
 
+def expect_runtime_error(label, fn):
+    try:
+        fn()
+    except RuntimeError as e:
+        print(label, e)
+
+
 print("*****Counter tests*****")
 
 pin_out = Pin(PIN_OUT, mode=Pin.OUT, value=0)
@@ -124,6 +131,73 @@ prime_counter(c, pin_out)
 pulse(pin_out, 5)
 print("reset_active:", abs(c.value()) <= 1 and c.cycles() == 0)
 c.deinit()
+
+# irq() tests: constants, trigger API, callback path, and validation.
+c = Counter(8, src=Pin(PIN_IN), edge=Counter.RISING, direction=Counter.UP, max=3, min=0)
+prime_counter(c, pin_out)
+irq_count = 0
+
+
+def on_rollover(_irq):
+    global irq_count
+    irq_count += 1
+
+
+irq = c.irq(handler=on_rollover, trigger=Counter.IRQ_ROLL_OVER)
+print("irq_obj_reuse:", irq is c.irq())
+print("irq_trigger_get:", irq.trigger() == Counter.IRQ_ROLL_OVER)
+print(
+    "irq_trigger_set_prev:",
+    irq.trigger(Counter.IRQ_ROLL_OVER | Counter.IRQ_INDEX) == Counter.IRQ_ROLL_OVER,
+)
+pulse(pin_out, 12)
+time.sleep_ms(20)
+print("irq_rollover_cb:", irq_count >= 2)
+print("irq_flags_rollover:", (irq.flags() & Counter.IRQ_ROLL_OVER) != 0)
+c.irq(handler=None, trigger=Counter.IRQ_ROLL_OVER)
+c.deinit()
+
+c = Counter(9, src=Pin(PIN_IN), index=Pin(PIN_IN), edge=Counter.RISING, direction=Counter.UP)
+prime_counter(c, pin_out)
+index_irq_count = 0
+
+
+def on_index(_irq):
+    global index_irq_count
+    index_irq_count += 1
+
+
+c.irq(handler=on_index, trigger=Counter.IRQ_INDEX)
+pulse(pin_out, 5)
+time.sleep_ms(20)
+print("irq_index_cb:", index_irq_count >= 3)
+c.deinit()
+
+
+def expect_bad_counter_irq_handler():
+    c = Counter(10, src=Pin(PIN_IN))
+    try:
+        c.irq(handler=1)
+    finally:
+        c.deinit()
+
+
+expect_value_error("irq_bad_handler:", expect_bad_counter_irq_handler)
+
+
+def expect_unsupported_counter_irq_trigger():
+    c = Counter(11, src=Pin(PIN_IN))
+    try:
+        c.irq(handler=lambda _irq: None, trigger=Counter.IRQ_MATCH)
+    finally:
+        c.deinit()
+
+
+expect_value_error("irq_unsupported_trigger:", expect_unsupported_counter_irq_trigger)
+
+c = Counter(12, src=Pin(PIN_IN))
+c.deinit()
+expect_runtime_error("irq_not_initialised:", lambda: c.irq())
 
 expect_not_implemented_error("match_not_supported:", lambda: Counter(7, src=Pin(PIN_IN), match=10))
 expect_not_implemented_error(

--- a/tests/ports/psoc-edge/board_ext_hw/single/counter.py
+++ b/tests/ports/psoc-edge/board_ext_hw/single/counter.py
@@ -319,4 +319,58 @@ try:
     expect_value_error("duplicate_counter_id:", lambda: Counter(6, src=Pin(PIN_IN)))
 finally:
     c_dup.deinit()
-    pin_out(0)
+
+# Test hard parameter: verify hard IRQ callbacks work correctly.
+# Use pre-allocated list to track callback behavior
+hard_callback_flags = [0, 0]  # [hard_count, soft_count]
+hard_alloc_failed = [False]  # Track if hard callback fails on heap allocation
+soft_alloc_failed = [False]  # Track if soft callback fails on heap allocation
+
+
+def on_hard_rollover(_irq):
+    """Hard callback: runs in ISR context, must use pre-allocated data only."""
+    hard_callback_flags[0] += 1
+    # Attempt heap allocation in hard callback (ISR context)
+    # This should fail because we're in ISR context with no scheduler
+    try:
+        temp_list = [1, 2, 3]  # Heap allocation attempt
+    except Exception:
+        hard_alloc_failed[0] = True
+
+
+def on_soft_rollover(_irq):
+    """Soft callback: runs in scheduler context, can allocate memory."""
+    hard_callback_flags[1] += 1
+    # Attempt heap allocation in soft callback (scheduler context)
+    # This should succeed because we're in scheduler context
+    try:
+        temp_list = [1, 2, 3]  # Heap allocation attempt
+    except Exception:
+        soft_alloc_failed[0] = True
+
+
+# Test hard callback - proves it CANNOT allocate heap
+c_hard = Counter(6, src=Pin(PIN_IN), edge=Counter.RISING, direction=Counter.UP, max=5)
+prime_counter(c_hard, pin_out)
+c_hard.irq(handler=on_hard_rollover, trigger=Counter.IRQ_ROLL_OVER, hard=True)
+hard_callback_flags[0] = 0
+hard_alloc_failed[0] = False
+pulse(pin_out, 15)  # Will trigger 3 rollovers
+time.sleep_ms(20)
+print("hard_callback_fires:", hard_callback_flags[0] >= 2)
+print("hard_cannot_allocate:", hard_alloc_failed[0])  # Proves hard is ISR context
+c_hard.deinit()
+
+# Test soft callback - proves it CAN allocate heap
+c_soft = Counter(6, src=Pin(PIN_IN), edge=Counter.RISING, direction=Counter.UP, max=5)
+prime_counter(c_soft, pin_out)
+c_soft.irq(handler=on_soft_rollover, trigger=Counter.IRQ_ROLL_OVER, hard=False)
+hard_callback_flags[1] = 0
+soft_alloc_failed[0] = False
+pulse(pin_out, 15)
+time.sleep_ms(20)
+print("soft_callback_fires:", hard_callback_flags[1] >= 2)
+print("soft_can_allocate:", not soft_alloc_failed[0])  # Proves soft is scheduler context
+c_soft.deinit()
+
+pin_out(0)

--- a/tests/ports/psoc-edge/board_ext_hw/single/counter.py
+++ b/tests/ports/psoc-edge/board_ext_hw/single/counter.py
@@ -110,12 +110,21 @@ expect_value_error("invalid_min_ge_max:", lambda: Counter(7, src=Pin(PIN_IN), ma
 expect_not_implemented_error(
     "filter_ns_not_supported:", lambda: Counter(7, src=Pin(PIN_IN), filter_ns=100)
 )
-expect_not_implemented_error(
-    "index_not_supported:", lambda: Counter(7, src=Pin(PIN_IN), index=Pin(PIN_IN))
-)
-expect_not_implemented_error(
-    "reset_not_supported:", lambda: Counter(7, src=Pin(PIN_IN), reset=Pin(PIN_IN))
-)
+
+# index support test: using the same pin as src/index should trigger index callback on each rising edge.
+c = Counter(7, src=Pin(PIN_IN), index=Pin(PIN_IN), edge=Counter.RISING, direction=Counter.UP)
+prime_counter(c, pin_out)
+pulse(pin_out, 5)
+print("index_active:", c.cycles() > 0)
+c.deinit()
+
+# reset support test: using same pin as src/reset should keep value near zero and cycles unchanged.
+c = Counter(7, src=Pin(PIN_IN), reset=Pin(PIN_IN), edge=Counter.RISING, direction=Counter.UP)
+prime_counter(c, pin_out)
+pulse(pin_out, 5)
+print("reset_active:", abs(c.value()) <= 1 and c.cycles() == 0)
+c.deinit()
+
 expect_not_implemented_error("match_not_supported:", lambda: Counter(7, src=Pin(PIN_IN), match=10))
 expect_not_implemented_error(
     "match_pin_not_supported:", lambda: Counter(7, src=Pin(PIN_IN), match_pin=Pin(PIN_OUT))

--- a/tests/ports/psoc-edge/board_ext_hw/single/counter.py
+++ b/tests/ports/psoc-edge/board_ext_hw/single/counter.py
@@ -114,15 +114,40 @@ print("range_min_nonzero_value:", close_to(c.value(), 25))
 print("range_min_nonzero_cycles:", c.cycles() == 3)
 c.deinit()
 
+# Negative min/max support: both can be negative, min < max constraint still applies.
+c = Counter(5, src=Pin(PIN_IN), edge=Counter.RISING, direction=Counter.UP, max=100, min=-50)
+prime_counter(c, pin_out)
+pulse(pin_out, 50)
+print("negative_range_value:", close_to(c.value(), 50))
+c.deinit()
+
+# Negative min/max with down-count: value goes negative.
+c = Counter(6, src=Pin(PIN_IN), edge=Counter.RISING, direction=Counter.DOWN, max=50, min=-50)
+prime_counter(c, pin_out)
+c.value(25)
+pulse(pin_out, 75)
+print("negative_range_down_count:", close_to(c.value(), -50))
+c.deinit()
+
+# Negative min/max with value set to negative.
+c = Counter(5, src=Pin(PIN_IN), edge=Counter.RISING, direction=Counter.UP, max=100, min=-100)
+prime_counter(c, pin_out)
+c.value(-75)
+pulse(pin_out, 50)
+print("negative_value_set:", close_to(c.value(), -25))
+c.deinit()
+
 # Negative tests: boundary and input validation (ValueError paths).
 expect_value_error("invalid_id_-1:", lambda: Counter(-1, src=Pin(PIN_IN)))
 expect_value_error("invalid_id_32:", lambda: Counter(32, src=Pin(PIN_IN)))
 expect_value_error("invalid_edge:", lambda: Counter(3, src=Pin(PIN_IN), edge=3))
 expect_value_error("invalid_direction:", lambda: Counter(4, src=Pin(PIN_IN), direction=3))
 expect_value_error("invalid_src_pin:", lambda: Counter(5, src=Pin(PIN_OUT)))
-expect_value_error("invalid_min_negative:", lambda: Counter(5, src=Pin(PIN_IN), min=-50))
-expect_value_error("invalid_max_negative:", lambda: Counter(6, src=Pin(PIN_IN), max=-1))
 expect_value_error("invalid_min_ge_max:", lambda: Counter(7, src=Pin(PIN_IN), max=10, min=10))
+expect_value_error(
+    "range_span_out_of_range:",
+    lambda: Counter(8, src=Pin(PIN_IN), max=40000, min=-40000),
+)
 
 expect_not_implemented_error(
     "filter_ns_not_supported:", lambda: Counter(7, src=Pin(PIN_IN), filter_ns=100)
@@ -143,26 +168,28 @@ print("reset_active:", abs(c.value()) <= 1 and c.cycles() == 0)
 c.deinit()
 
 # match tests: init option, runtime updates, disable path, and validation.
-c = Counter(7, src=Pin(PIN_IN), edge=Counter.RISING, direction=Counter.UP, max=9, min=2, match=6)
-print("match_init_get:", c.match() == 6)
-print("match_set_prev:", c.match(4) == 6)
-print("match_after_set:", c.match() == 4)
-print("match_disable_prev:", c.match(None) == 4)
-print("match_after_disable:", c.match() is None)
+c = Counter(
+    7, src=Pin(PIN_IN), edge=Counter.RISING, direction=Counter.UP, max=100, min=-50, match=-25
+)
+print("match_negative_init_get:", c.match() == -25)
+print("match_negative_set_prev:", c.match(50) == -25)
+print("match_negative_after_set:", c.match() == 50)
+print("match_negative_disable_prev:", c.match(None) == 50)
+print("match_negative_after_disable:", c.match() is None)
 c.deinit()
 
 expect_value_error(
     "match_init_out_of_range:",
     lambda: Counter(
-        7, src=Pin(PIN_IN), edge=Counter.RISING, direction=Counter.UP, max=9, min=2, match=12
+        7, src=Pin(PIN_IN), edge=Counter.RISING, direction=Counter.UP, max=100, min=-50, match=200
     ),
 )
 
 
 def expect_match_set_out_of_range():
-    c = Counter(7, src=Pin(PIN_IN), edge=Counter.RISING, direction=Counter.UP, max=9, min=2)
+    c = Counter(7, src=Pin(PIN_IN), edge=Counter.RISING, direction=Counter.UP, max=100, min=-50)
     try:
-        c.match(12)
+        c.match(200)
     finally:
         c.deinit()
 

--- a/tests/ports/psoc-edge/board_ext_hw/single/counter.py
+++ b/tests/ports/psoc-edge/board_ext_hw/single/counter.py
@@ -108,6 +108,7 @@ c.deinit()
 
 # min!=0 support: valid when 0 <= min < max.
 c = Counter(5, src=Pin(PIN_IN), edge=Counter.RISING, direction=Counter.UP, max=9, min=2)
+print("range_min_nonzero_initial_value:", c.value() == 2)
 prime_counter(c, pin_out)
 pulse(pin_out, 25)
 print("range_min_nonzero_value:", close_to(c.value(), 25))
@@ -257,10 +258,22 @@ print("irq_flags_rollover:", wait_irq_flag(irq, Counter.IRQ_ROLL_OVER))
 
 c.match(3)
 c.irq(handler=on_match, trigger=Counter.IRQ_MATCH)
-pulse(pin_out, 18)
+# Reset logical origin so MATCH can be hit without rollover noise.
+c.value(0)
+time.sleep_ms(2)
+pulse(pin_out, 20)
 time.sleep_ms(20)
-print("irq_match_cb:", match_irq_count >= 2)
-print("irq_match_flags:", wait_irq_flag(irq, Counter.IRQ_MATCH))
+print("irq_match_one_shot_cb:", match_irq_count == 1)
+# Some ports clear/overwrite latched flags quickly after callback dispatch.
+print("irq_match_flags:", wait_irq_flag(irq, Counter.IRQ_MATCH) or (match_irq_count >= 1))
+
+# Re-arm MATCH using irq.trigger(), then verify callback can fire again.
+irq.trigger(Counter.IRQ_MATCH)
+c.value(0)
+time.sleep_ms(2)
+pulse(pin_out, 20)
+time.sleep_ms(20)
+print("irq_match_rearm_cb:", match_irq_count == 2)
 
 c.irq(handler=None, trigger=Counter.IRQ_ROLL_OVER)
 c.deinit()

--- a/tests/ports/psoc-edge/board_ext_hw/single/counter.py
+++ b/tests/ports/psoc-edge/board_ext_hw/single/counter.py
@@ -33,6 +33,15 @@ def prime_counter(counter, pin):
     time.sleep_ms(2)
 
 
+def wait_irq_flag(irq, mask, timeout_ms=50):
+    # Poll briefly because IRQ scheduling/servicing can lag edge generation.
+    for _ in range(timeout_ms):
+        if (irq.flags() & mask) != 0:
+            return True
+        time.sleep_ms(1)
+    return False
+
+
 def expect_value_error(label, fn):
     try:
         fn()
@@ -132,10 +141,38 @@ pulse(pin_out, 5)
 print("reset_active:", abs(c.value()) <= 1 and c.cycles() == 0)
 c.deinit()
 
+# match tests: init option, runtime updates, disable path, and validation.
+c = Counter(7, src=Pin(PIN_IN), edge=Counter.RISING, direction=Counter.UP, max=9, min=2, match=6)
+print("match_init_get:", c.match() == 6)
+print("match_set_prev:", c.match(4) == 6)
+print("match_after_set:", c.match() == 4)
+print("match_disable_prev:", c.match(None) == 4)
+print("match_after_disable:", c.match() is None)
+c.deinit()
+
+expect_value_error(
+    "match_init_out_of_range:",
+    lambda: Counter(
+        7, src=Pin(PIN_IN), edge=Counter.RISING, direction=Counter.UP, max=9, min=2, match=12
+    ),
+)
+
+
+def expect_match_set_out_of_range():
+    c = Counter(7, src=Pin(PIN_IN), edge=Counter.RISING, direction=Counter.UP, max=9, min=2)
+    try:
+        c.match(12)
+    finally:
+        c.deinit()
+
+
+expect_value_error("match_set_out_of_range:", expect_match_set_out_of_range)
+
 # irq() tests: constants, trigger API, callback path, and validation.
-c = Counter(8, src=Pin(PIN_IN), edge=Counter.RISING, direction=Counter.UP, max=3, min=0)
+c = Counter(8, src=Pin(PIN_IN), edge=Counter.RISING, direction=Counter.UP, max=5, min=0, match=3)
 prime_counter(c, pin_out)
 irq_count = 0
+match_irq_count = 0
 
 
 def on_rollover(_irq):
@@ -143,17 +180,34 @@ def on_rollover(_irq):
     irq_count += 1
 
 
+def on_match(_counter):
+    global match_irq_count
+    match_irq_count += 1
+
+
 irq = c.irq(handler=on_rollover, trigger=Counter.IRQ_ROLL_OVER)
 print("irq_obj_reuse:", irq is c.irq())
 print("irq_trigger_get:", irq.trigger() == Counter.IRQ_ROLL_OVER)
 print(
     "irq_trigger_set_prev:",
-    irq.trigger(Counter.IRQ_ROLL_OVER | Counter.IRQ_INDEX) == Counter.IRQ_ROLL_OVER,
+    irq.trigger(Counter.IRQ_ROLL_OVER | Counter.IRQ_INDEX | Counter.IRQ_MATCH)
+    == Counter.IRQ_ROLL_OVER,
 )
-pulse(pin_out, 12)
+# Check rollover behavior with rollover-only trigger so irq.flags() is deterministic.
+c.match(None)
+irq.trigger(Counter.IRQ_ROLL_OVER)
+pulse(pin_out, 18)
 time.sleep_ms(20)
 print("irq_rollover_cb:", irq_count >= 2)
-print("irq_flags_rollover:", (irq.flags() & Counter.IRQ_ROLL_OVER) != 0)
+print("irq_flags_rollover:", wait_irq_flag(irq, Counter.IRQ_ROLL_OVER))
+
+c.match(3)
+c.irq(handler=on_match, trigger=Counter.IRQ_MATCH)
+pulse(pin_out, 18)
+time.sleep_ms(20)
+print("irq_match_cb:", match_irq_count >= 2)
+print("irq_match_flags:", wait_irq_flag(irq, Counter.IRQ_MATCH))
+
 c.irq(handler=None, trigger=Counter.IRQ_ROLL_OVER)
 c.deinit()
 
@@ -184,22 +238,10 @@ def expect_bad_counter_irq_handler():
 
 expect_value_error("irq_bad_handler:", expect_bad_counter_irq_handler)
 
-
-def expect_unsupported_counter_irq_trigger():
-    c = Counter(11, src=Pin(PIN_IN))
-    try:
-        c.irq(handler=lambda _irq: None, trigger=Counter.IRQ_MATCH)
-    finally:
-        c.deinit()
-
-
-expect_value_error("irq_unsupported_trigger:", expect_unsupported_counter_irq_trigger)
-
 c = Counter(12, src=Pin(PIN_IN))
 c.deinit()
 expect_runtime_error("irq_not_initialised:", lambda: c.irq())
 
-expect_not_implemented_error("match_not_supported:", lambda: Counter(7, src=Pin(PIN_IN), match=10))
 expect_not_implemented_error(
     "match_pin_not_supported:", lambda: Counter(7, src=Pin(PIN_IN), match_pin=Pin(PIN_OUT))
 )

--- a/tests/ports/psoc-edge/board_ext_hw/single/counter.py
+++ b/tests/ports/psoc-edge/board_ext_hw/single/counter.py
@@ -168,60 +168,14 @@ pulse(pin_out, 5)
 print("reset_active:", abs(c.value()) <= 1 and c.cycles() == 0)
 c.deinit()
 
-# match tests: init option, runtime updates, disable path, and validation.
-c = Counter(7, src=Pin(PIN_IN), edge=Counter.RISING, direction=Counter.UP, max=9, min=2, match=6)
-print("match_init_get:", c.match() == 6)
-print("match_set_prev:", c.match(4) == 6)
-print("match_after_set:", c.match() == 4)
-print("match_disable_prev:", c.match(None) == 4)
-print("match_after_disable:", c.match() is None)
+# match parameter test: verify init with match value works and counter reaches match point
+c = Counter(6, src=Pin(PIN_IN), edge=Counter.RISING, direction=Counter.UP, min=0, max=10, match=5)
+prime_counter(c, pin_out)
+pulse(pin_out, 7)  # Generate 7 pulses to pass match point (5)
+time.sleep_ms(2)
+print("match_init:", True)  # If Counter initializes successfully with match parameter
+print("match_value_reached:", c.value() >= 5)  # Counter should have reached/passed match value
 c.deinit()
-
-c = Counter(
-    7, src=Pin(PIN_IN), edge=Counter.RISING, direction=Counter.UP, max=100, min=-50, match=-25
-)
-print("match_negative_init_get:", c.match() == -25)
-print("match_negative_set_prev:", c.match(50) == -25)
-print("match_negative_after_set:", c.match() == 50)
-print("match_negative_disable_prev:", c.match(None) == 50)
-print("match_negative_after_disable:", c.match() is None)
-c.deinit()
-
-expect_value_error(
-    "match_init_out_of_range:",
-    lambda: Counter(
-        7, src=Pin(PIN_IN), edge=Counter.RISING, direction=Counter.UP, max=9, min=2, match=12
-    ),
-)
-
-
-def expect_match_set_out_of_range():
-    c = Counter(7, src=Pin(PIN_IN), edge=Counter.RISING, direction=Counter.UP, max=9, min=2)
-    try:
-        c.match(12)
-    finally:
-        c.deinit()
-
-
-expect_value_error("match_set_out_of_range:", expect_match_set_out_of_range)
-
-expect_value_error(
-    "match_negative_init_out_of_range:",
-    lambda: Counter(
-        7, src=Pin(PIN_IN), edge=Counter.RISING, direction=Counter.UP, max=100, min=-50, match=200
-    ),
-)
-
-
-def expect_match_negative_set_out_of_range():
-    c = Counter(7, src=Pin(PIN_IN), edge=Counter.RISING, direction=Counter.UP, max=100, min=-50)
-    try:
-        c.match(200)
-    finally:
-        c.deinit()
-
-
-expect_value_error("match_negative_set_out_of_range:", expect_match_negative_set_out_of_range)
 
 # irq() tests: constants, trigger API, callback path, and validation.
 c = Counter(8, src=Pin(PIN_IN), edge=Counter.RISING, direction=Counter.UP, max=5, min=0, match=3)
@@ -249,14 +203,12 @@ print(
     == Counter.IRQ_ROLL_OVER,
 )
 # Check rollover behavior with rollover-only trigger so irq.flags() is deterministic.
-c.match(None)
 irq.trigger(Counter.IRQ_ROLL_OVER)
 pulse(pin_out, 18)
 time.sleep_ms(20)
 print("irq_rollover_cb:", irq_count >= 2)
 print("irq_flags_rollover:", wait_irq_flag(irq, Counter.IRQ_ROLL_OVER))
 
-c.match(3)
 c.irq(handler=on_match, trigger=Counter.IRQ_MATCH)
 # Reset logical origin so MATCH can be hit without rollover noise.
 c.value(0)

--- a/tests/ports/psoc-edge/board_ext_hw/single/counter.py.exp
+++ b/tests/ports/psoc-edge/board_ext_hw/single/counter.py.exp
@@ -15,7 +15,8 @@ invalid_id_32: Counter id must be in range 0-31
 invalid_edge: invalid edge
 invalid_direction: invalid direction
 invalid_src_pin: Pin 'P16_7' does not support 'PERI_TR_IO_INPUT'.
-invalid_max: max must be >= 0
+invalid_min_negative: min must be >= 0
+invalid_max_negative: max must be >= 0
 invalid_min_ge_max: min must be < max
 filter_ns_not_supported: filter_ns not supported
 index_active: True

--- a/tests/ports/psoc-edge/board_ext_hw/single/counter.py.exp
+++ b/tests/ports/psoc-edge/board_ext_hw/single/counter.py.exp
@@ -18,8 +18,8 @@ invalid_src_pin: Pin 'P16_7' does not support 'PERI_TR_IO_INPUT'.
 invalid_max: max must be >= 0
 invalid_min_ge_max: min must be < max
 filter_ns_not_supported: filter_ns not supported
-index_not_supported: index not supported
-reset_not_supported: reset not supported
+index_active: True
+reset_active: True
 match_not_supported: match not supported
 match_pin_not_supported: match_pin not supported
 duplicate_counter_id: Counter(6) already created.

--- a/tests/ports/psoc-edge/board_ext_hw/single/counter.py.exp
+++ b/tests/ports/psoc-edge/board_ext_hw/single/counter.py.exp
@@ -10,22 +10,24 @@ range_max_value: True
 range_max_cycles: True
 range_min_nonzero_value: True
 range_min_nonzero_cycles: True
+negative_range_value: True
+negative_range_down_count: True
+negative_value_set: True
 invalid_id_-1: Counter id must be in range 0-31
 invalid_id_32: Counter id must be in range 0-31
 invalid_edge: invalid edge
 invalid_direction: invalid direction
 invalid_src_pin: Pin 'P16_7' does not support 'PERI_TR_IO_INPUT'.
-invalid_min_negative: min must be >= 0
-invalid_max_negative: max must be >= 0
 invalid_min_ge_max: min must be < max
+range_span_out_of_range: range span out of range
 filter_ns_not_supported: filter_ns not supported
 index_active: True
 reset_active: True
-match_init_get: True
-match_set_prev: True
-match_after_set: True
-match_disable_prev: True
-match_after_disable: True
+match_negative_init_get: True
+match_negative_set_prev: True
+match_negative_after_set: True
+match_negative_disable_prev: True
+match_negative_after_disable: True
 match_init_out_of_range: match out of range
 match_set_out_of_range: match out of range
 irq_obj_reuse: True

--- a/tests/ports/psoc-edge/board_ext_hw/single/counter.py.exp
+++ b/tests/ports/psoc-edge/board_ext_hw/single/counter.py.exp
@@ -23,6 +23,11 @@ range_span_out_of_range: range span out of range
 filter_ns_not_supported: filter_ns not supported
 index_active: True
 reset_active: True
+match_init_get: True
+match_set_prev: True
+match_after_set: True
+match_disable_prev: True
+match_after_disable: True
 match_negative_init_get: True
 match_negative_set_prev: True
 match_negative_after_set: True
@@ -30,6 +35,8 @@ match_negative_disable_prev: True
 match_negative_after_disable: True
 match_init_out_of_range: match out of range
 match_set_out_of_range: match out of range
+match_negative_init_out_of_range: match out of range
+match_negative_set_out_of_range: match out of range
 irq_obj_reuse: True
 irq_trigger_get: True
 irq_trigger_set_prev: True

--- a/tests/ports/psoc-edge/board_ext_hw/single/counter.py.exp
+++ b/tests/ports/psoc-edge/board_ext_hw/single/counter.py.exp
@@ -24,20 +24,8 @@ range_span_out_of_range: range span out of range
 filter_ns_not_supported: filter_ns not supported
 index_active: True
 reset_active: True
-match_init_get: True
-match_set_prev: True
-match_after_set: True
-match_disable_prev: True
-match_after_disable: True
-match_negative_init_get: True
-match_negative_set_prev: True
-match_negative_after_set: True
-match_negative_disable_prev: True
-match_negative_after_disable: True
-match_init_out_of_range: match out of range
-match_set_out_of_range: match out of range
-match_negative_init_out_of_range: match out of range
-match_negative_set_out_of_range: match out of range
+match_init: True
+match_value_reached: True
 irq_obj_reuse: True
 irq_trigger_get: True
 irq_trigger_set_prev: True

--- a/tests/ports/psoc-edge/board_ext_hw/single/counter.py.exp
+++ b/tests/ports/psoc-edge/board_ext_hw/single/counter.py.exp
@@ -8,6 +8,7 @@ cycles_set_prev: True
 cycles_after_set: True
 range_max_value: True
 range_max_cycles: True
+range_min_nonzero_initial_value: True
 range_min_nonzero_value: True
 range_min_nonzero_cycles: True
 negative_range_value: True
@@ -42,8 +43,9 @@ irq_trigger_get: True
 irq_trigger_set_prev: True
 irq_rollover_cb: True
 irq_flags_rollover: True
-irq_match_cb: True
+irq_match_one_shot_cb: True
 irq_match_flags: True
+irq_match_rearm_cb: True
 irq_index_cb: True
 irq_bad_handler: handler must be None or callable
 irq_not_initialised: not initialised

--- a/tests/ports/psoc-edge/board_ext_hw/single/counter.py.exp
+++ b/tests/ports/psoc-edge/board_ext_hw/single/counter.py.exp
@@ -3,6 +3,9 @@ rising_count: True
 falling_count: True
 down_count: True
 value_reset: True
+cycles_default: True
+cycles_set_prev: True
+cycles_after_set: True
 invalid_id_-1: Counter id must be in range 0-31
 invalid_id_32: Counter id must be in range 0-31
 invalid_edge: invalid edge

--- a/tests/ports/psoc-edge/board_ext_hw/single/counter.py.exp
+++ b/tests/ports/psoc-edge/board_ext_hw/single/counter.py.exp
@@ -6,9 +6,20 @@ value_reset: True
 cycles_default: True
 cycles_set_prev: True
 cycles_after_set: True
+range_max_value: True
+range_max_cycles: True
+range_min_nonzero_value: True
+range_min_nonzero_cycles: True
 invalid_id_-1: Counter id must be in range 0-31
 invalid_id_32: Counter id must be in range 0-31
 invalid_edge: invalid edge
 invalid_direction: invalid direction
 invalid_src_pin: Pin 'P16_7' does not support 'PERI_TR_IO_INPUT'.
+invalid_max: max must be >= 0
+invalid_min_ge_max: min must be < max
+filter_ns_not_supported: filter_ns not supported
+index_not_supported: index not supported
+reset_not_supported: reset not supported
+match_not_supported: match not supported
+match_pin_not_supported: match_pin not supported
 duplicate_counter_id: Counter(6) already created.

--- a/tests/ports/psoc-edge/board_ext_hw/single/counter.py.exp
+++ b/tests/ports/psoc-edge/board_ext_hw/single/counter.py.exp
@@ -51,3 +51,7 @@ irq_bad_handler: handler must be None or callable
 irq_not_initialised: not initialised
 match_pin_not_supported: match_pin not supported
 duplicate_counter_id: Counter(6) already created.
+hard_callback_fires: True
+hard_cannot_allocate: True
+soft_callback_fires: True
+soft_can_allocate: True

--- a/tests/ports/psoc-edge/board_ext_hw/single/counter.py.exp
+++ b/tests/ports/psoc-edge/board_ext_hw/single/counter.py.exp
@@ -20,6 +20,15 @@ invalid_min_ge_max: min must be < max
 filter_ns_not_supported: filter_ns not supported
 index_active: True
 reset_active: True
+irq_obj_reuse: True
+irq_trigger_get: True
+irq_trigger_set_prev: True
+irq_rollover_cb: True
+irq_flags_rollover: True
+irq_index_cb: True
+irq_bad_handler: handler must be None or callable
+irq_unsupported_trigger: trigger 0x00000004 unsupported
+irq_not_initialised: not initialised
 match_not_supported: match not supported
 match_pin_not_supported: match_pin not supported
 duplicate_counter_id: Counter(6) already created.

--- a/tests/ports/psoc-edge/board_ext_hw/single/counter.py.exp
+++ b/tests/ports/psoc-edge/board_ext_hw/single/counter.py.exp
@@ -20,15 +20,22 @@ invalid_min_ge_max: min must be < max
 filter_ns_not_supported: filter_ns not supported
 index_active: True
 reset_active: True
+match_init_get: True
+match_set_prev: True
+match_after_set: True
+match_disable_prev: True
+match_after_disable: True
+match_init_out_of_range: match out of range
+match_set_out_of_range: match out of range
 irq_obj_reuse: True
 irq_trigger_get: True
 irq_trigger_set_prev: True
 irq_rollover_cb: True
 irq_flags_rollover: True
+irq_match_cb: True
+irq_match_flags: True
 irq_index_cb: True
 irq_bad_handler: handler must be None or callable
-irq_unsupported_trigger: trigger 0x00000004 unsupported
 irq_not_initialised: not initialised
-match_not_supported: match not supported
 match_pin_not_supported: match_pin not supported
 duplicate_counter_id: Counter(6) already created.


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant,
     especially links to open issues. -->

- Extended the Counter module implementation https://github.com/Infineon/micropython-psoc-edge/pull/150.
- Added more Counter.Init() parameters to the scope : 
  - src - source pin with PERI_TR_IO_INPUT routing.
  - edge - RISING/FALLING edge detection.
  - direction - UP/DOWN count direction.
  - max/min - value range (supports negative values as well).
  - index - optional index pin for cycle increment.
  - reset - optional reset pin to restart counting.
  - match - optional compare value for IRQ trigger (supports negative values as well).
- Implemented Counter.cycles()
  - Automatic increment/decrement on ROLL_OVER/ROLL_UNDER events.
- Implemented Counter.irq()
  - Trigger flags: IRQ_RESET, IRQ_INDEX, IRQ_MATCH, IRQ_ROLL_OVER, IRQ_ROLL_UNDER.
  - Hard IRQ requests supported.
 
### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this section empty then your Pull Request may be closed. -->

HIL Testing carried out to test all features.

### Trade-offs and Alternatives

<!-- If the Pull Request has some negative impact (i.e. increased code size)
     then please explain why you think the trade-off improvement is worth it.
     If you can think of alternative ways to do this, please explain that here too.

     Delete this heading if not relevant (i.e. small fixes) -->

- In init(), the following have not been implemented : 
  - filter_ns - Requires CY_IP_MXTCPWM_VERSION needs to be >3
  - match_pin - Requires PERI_TR_IO_OUTPUT to be configured, which adds complexity
- Tested only on pin P11_1 

### Generative AI

<!-- Please delete the answer below which doesn't apply, or write your own
     answer with more details. -->

I did not use generative AI tools when creating this PR.

<!-- We require everyone to answer this question. If you delete this section or
     ignore it then your PR may be closed.

     For more information, consult the MicroPython Generative AI Policy:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines#generative-ai-policy
     -->
