### PR TITLE
Global Interrupt

### DIFF
--- a/docs/psoc-edge/quickref.rst
+++ b/docs/psoc-edge/quickref.rst
@@ -178,22 +178,6 @@ Use :func:`machine.bitstream` directly for timing-sensitive one-wire protocols::
     - Each timing value must be at least 300 ns; smaller values raise ``ValueError``.
     - If the runtime core clock is invalid (0 Hz), transmission raises ``ValueError``.
 
-Interrupt control
------------------
-
-Use :func:`machine.disable_irq` and :func:`machine.enable_irq` to guard short
-critical sections, then restore the saved IRQ state as soon as possible.
-
-::
-
-    import machine
-
-    state = machine.disable_irq()
-
-    # Do brief time-critical work here.
-
-    machine.enable_irq(state)
-
 Real time clock (RTC)
 ---------------------
 

--- a/docs/psoc-edge/quickref.rst
+++ b/docs/psoc-edge/quickref.rst
@@ -178,6 +178,25 @@ Use :func:`machine.bitstream` directly for timing-sensitive one-wire protocols::
     - Each timing value must be at least 300 ns; smaller values raise ``ValueError``.
     - If the runtime core clock is invalid (0 Hz), transmission raises ``ValueError``.
 
+Interrupt control
+-----------------
+
+Use ``machine.disable_irq()`` and ``machine.enable_irq(state)`` for short
+critical sections where interrupts must be masked briefly.
+
+See :ref:`machine.disable_irq <machine.disable_irq>` and
+:ref:`machine.enable_irq <machine.enable_irq>` for full API details.
+
+::
+
+    import machine
+
+    state = machine.disable_irq()
+
+    # Do brief time-critical work here.
+
+    machine.enable_irq(state)
+
 Real time clock (RTC)
 ---------------------
 

--- a/docs/psoc-edge/quickref.rst
+++ b/docs/psoc-edge/quickref.rst
@@ -181,11 +181,8 @@ Use :func:`machine.bitstream` directly for timing-sensitive one-wire protocols::
 Interrupt control
 -----------------
 
-Use ``machine.disable_irq()`` and ``machine.enable_irq(state)`` for short
-critical sections where interrupts must be masked briefly.
-
-See :ref:`machine.disable_irq <machine.disable_irq>` and
-:ref:`machine.enable_irq <machine.enable_irq>` for full API details.
+Use :func:`machine.disable_irq` and :func:`machine.enable_irq` to guard short
+critical sections, then restore the saved IRQ state as soon as possible.
 
 ::
 

--- a/ports/psoc-edge/mpconfigport.h
+++ b/ports/psoc-edge/mpconfigport.h
@@ -69,6 +69,7 @@
 #define MICROPY_PY_MACHINE_INCLUDEFILE          "ports/psoc-edge/modmachine.c"
 #define MICROPY_PY_MACHINE_RESET                (1)
 #define MICROPY_PY_MACHINE_BARE_METAL_FUNCS     (1)
+#define MICROPY_PY_MACHINE_DISABLE_IRQ_ENABLE_IRQ (1)
 
 #define MICROPY_PY_MACHINE_PIN_MAKE_NEW         mp_pin_make_new
 

--- a/tests/ports/psoc-edge/board_only_hw/single/global_interrupts.py
+++ b/tests/ports/psoc-edge/board_only_hw/single/global_interrupts.py
@@ -13,19 +13,17 @@ def _cb(_):
 irq_state = machine.disable_irq()
 tim = Timer(0, period=20, mode=Timer.ONE_SHOT, callback=_cb)
 
-# Wait past the one-shot period; bounded loop avoids hangs if ticks stop.
-start = time.ticks_ms()
+# Busy-wait with IRQs disabled (time.ticks_* is paused on this port).
 for _ in range(500000):
-    if time.ticks_diff(time.ticks_ms(), start) >= 30:
-        break
+    pass
 
-# Callback should still be blocked while IRQs are disabled.
+# Callback should still be blocked.
 print("while_disabled:", fired)
 
 machine.enable_irq(irq_state)
 time.sleep_ms(200)
 
-# Pending callback should run after restoring IRQs.
+# Callback should run after IRQ restore.
 print("after_enable:", fired)
 
 tim.deinit()

--- a/tests/ports/psoc-edge/board_only_hw/single/global_interrupts.py
+++ b/tests/ports/psoc-edge/board_only_hw/single/global_interrupts.py
@@ -13,9 +13,10 @@ def _cb(_):
 irq_state = machine.disable_irq()
 tim = Timer(0, period=20, mode=Timer.ONE_SHOT, callback=_cb)
 
-# Keep IRQs masked long enough for the one-shot period to elapse.
-for _ in range(500000):
-    pass
+# Wait past one-shot period.
+start = time.ticks_ms()
+while time.ticks_diff(time.ticks_ms(), start) < 30:
+    time.sleep_ms(1)
 
 # Callback should still be blocked while IRQs are disabled.
 print("while_disabled:", fired)

--- a/tests/ports/psoc-edge/board_only_hw/single/global_interrupts.py
+++ b/tests/ports/psoc-edge/board_only_hw/single/global_interrupts.py
@@ -13,10 +13,11 @@ def _cb(_):
 irq_state = machine.disable_irq()
 tim = Timer(0, period=20, mode=Timer.ONE_SHOT, callback=_cb)
 
-# Wait past one-shot period.
+# Wait past the one-shot period; bounded loop avoids hangs if ticks stop.
 start = time.ticks_ms()
-while time.ticks_diff(time.ticks_ms(), start) < 30:
-    time.sleep_ms(1)
+for _ in range(500000):
+    if time.ticks_diff(time.ticks_ms(), start) >= 30:
+        break
 
 # Callback should still be blocked while IRQs are disabled.
 print("while_disabled:", fired)

--- a/tests/ports/psoc-edge/board_only_hw/single/global_interrupts.py
+++ b/tests/ports/psoc-edge/board_only_hw/single/global_interrupts.py
@@ -1,0 +1,29 @@
+from machine import Timer
+import machine
+import time
+
+fired = False
+
+
+def _cb(_):
+    global fired
+    fired = True
+
+
+irq_state = machine.disable_irq()
+tim = Timer(0, period=20, mode=Timer.ONE_SHOT, callback=_cb)
+
+# Keep IRQs masked long enough for the one-shot period to elapse.
+for _ in range(500000):
+    pass
+
+# Callback should still be blocked while IRQs are disabled.
+print("while_disabled:", fired)
+
+machine.enable_irq(irq_state)
+time.sleep_ms(200)
+
+# Pending callback should run after restoring IRQs.
+print("after_enable:", fired)
+
+tim.deinit()

--- a/tests/ports/psoc-edge/board_only_hw/single/global_interrupts.py.exp
+++ b/tests/ports/psoc-edge/board_only_hw/single/global_interrupts.py.exp
@@ -1,0 +1,2 @@
+while_disabled: False
+after_enable: True


### PR DESCRIPTION
### Summary

Enable global IRQ API support in config and add a single test for global interrupt behavior.

### Testing

Manually verified expected behavior:

- while_disabled: False
- after_enable: True

### Trade-offs and Alternatives

N/A

### Generative AI

I did not use generative AI tools when creating this PR.
