### PR TITLE
Clk machine i2c

### DIFF
--- a/ports/psoc-edge/machine_i2c.c
+++ b/ports/psoc-edge/machine_i2c.c
@@ -42,6 +42,7 @@
 
 
 // port-specific includes
+#include "clk.h"
 #include "genhdr/pins_af.h"
 #include "modmachine.h"
 #include "machine_scb.h"
@@ -62,6 +63,7 @@ typedef struct _machine_hw_i2c_obj_t {
     uint32_t freq;
     uint32_t timeout;
     machine_scb_obj_t *scb_obj;
+    pclk_div_obj_t *pclk_div;
     cy_stc_scb_i2c_config_t cfg;   // PDL I2C configuration
     cy_stc_scb_i2c_context_t ctx;  // PDL I2C runtime context
 } machine_hw_i2c_obj_t;
@@ -133,12 +135,18 @@ static void machine_hw_i2c_init(machine_hw_i2c_obj_t *self, uint32_t freq_hz) {
     //   - clk_peri = 100 MHz, divider = 11 → clk_scb = 9.09 MHz ✓ (within range)
     // Note: Cy_SysClk_PeriphSetDivider takes (divider - 1), so divider=11 → value=10
     /* Connect assigned divider to be a clock source for I2C */
-    Cy_SysClk_PeriphAssignDivider(self->scb_obj->clk, CY_SYSCLK_DIV_8_BIT, 2U);
     uint32_t divider = (freq_hz <= 100000) ? 41U : 10U;
-    Cy_SysClk_PeriphSetDivider(CY_SYSCLK_DIV_8_BIT, 2U, divider);
-    Cy_SysClk_PeriphEnableDivider(CY_SYSCLK_DIV_8_BIT, 2U);
+    pclk_div_slave_init(self->scb_obj->clk, self->scb_obj->mmio_slave_nr);
+    self->pclk_div = pclk_div_init(self->scb_obj->clk, divider, 0);
+    if (self->pclk_div == NULL) {
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("failed to initialize clock divider for I2C(%u)"), self->scb_obj->id);
+    }
 
-    uint32_t clk_scb_freq = Cy_SysClk_PeriphGetFrequency(CY_SYSCLK_DIV_8_BIT, 2U);
+    uint32_t input_freq = pclk_div_get_input_freq(self->scb_obj->clk);
+    if (input_freq == 0U) {
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("failed to get clock frequency for I2C(%u)"), self->scb_obj->id);
+    }
+    uint32_t clk_scb_freq = input_freq / (divider + 1U);
     DEBUG_printf("DEBUG: clk_scb_freq=%u Hz\n", clk_scb_freq);
 
     uint32_t actual_rate = Cy_SCB_I2C_SetDataRate(self->scb_obj->scb, freq_hz, clk_scb_freq);
@@ -166,7 +174,8 @@ static void machine_hw_i2c_deinit(mp_obj_base_t *self_in) {
 
     Cy_SCB_I2C_Disable(self->scb_obj->scb, &self->ctx);
     sys_int_deinit(&self->scb_obj->irq);
-    Cy_SysClk_PeriphDisableDivider(CY_SYSCLK_DIV_8_BIT, 0U);
+    pclk_div_deinit(self->pclk_div);
+    pclk_div_slave_deinit(self->scb_obj->clk, self->scb_obj->mmio_slave_nr);
 
     machine_scb_obj_free(self->scb_obj);
     machine_hw_i2c_obj_free(self);

--- a/ports/psoc-edge/machine_i2c_target.c
+++ b/ports/psoc-edge/machine_i2c_target.c
@@ -35,7 +35,8 @@
 #include "py/mphal.h"
 #include "extmod/modmachine.h"
 
-// port-specific includes
+// port-specific
+#include "clk.h"
 #include "genhdr/pins_af.h"
 #include "modmachine.h"
 #include "machine_scb.h"
@@ -53,6 +54,7 @@ typedef struct _machine_i2c_target_obj_t {
     uint32_t slave_addr;
     uint8_t addrsize;
     machine_scb_obj_t *scb_obj;
+    pclk_div_obj_t *pclk_div;
     cy_stc_scb_i2c_config_t cfg;
     cy_stc_scb_i2c_context_t ctx;
     size_t tx_index;
@@ -204,9 +206,14 @@ static void i2c_target_init(machine_i2c_target_obj_t *self, machine_i2c_target_d
     // For 400 khz slave, clk_scb must be 7.82 – 15.38 MHz
     // For 100 khz slave, clk_scb must be 1.55 – 12.8 MHz
     // clk_peri = 100 MHz, divider = 7, clk_scb = 100/8 = 12.5 MHz
-    Cy_SysClk_PeriphAssignDivider(self->scb_obj->clk, CY_SYSCLK_DIV_8_BIT, 2U);
-    Cy_SysClk_PeriphSetDivider(CY_SYSCLK_DIV_8_BIT, 2U, 7U); // divider = n+1, so 7 means divide by 8
-    Cy_SysClk_PeriphEnableDivider(CY_SYSCLK_DIV_8_BIT, 2U);
+    #define I2C_TARGET_SCB_CLK_FREQ_HZ (12500000UL)
+    pclk_div_slave_init(self->scb_obj->clk, self->scb_obj->mmio_slave_nr);
+    uint32_t input_freq = pclk_div_get_input_freq(self->scb_obj->clk);
+    uint32_t divider = input_freq / I2C_TARGET_SCB_CLK_FREQ_HZ - 1;
+    self->pclk_div = pclk_div_init(self->scb_obj->clk, divider, 0);
+    if (self->pclk_div == NULL) {
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("failed to initialize clock divider for I2CTarget(%u)"), self->id);
+    }
 
     sys_int_init(&(self->scb_obj->irq));
 
@@ -350,6 +357,8 @@ static void mp_machine_i2c_target_print(const mp_print_t *print, mp_obj_t self_i
 static void mp_machine_i2c_target_deinit(machine_i2c_target_obj_t *self) {
     Cy_SCB_I2C_Disable(self->scb_obj->scb, &self->ctx);
     sys_int_deinit(&(self->scb_obj->irq));
+    pclk_div_deinit(self->pclk_div);
+    pclk_div_slave_deinit(self->scb_obj->clk, self->scb_obj->mmio_slave_nr);
     self->base.type = NULL;
 
     machine_scb_obj_free(self->scb_obj);

--- a/ports/psoc-edge/main.c
+++ b/ports/psoc-edge/main.c
@@ -110,6 +110,12 @@ extern void machine_deinit(void);
  */
 extern void pclk_div_repl_uart_init(void);
 
+/**
+ * TODO: This will later directly handled by
+ * the static machine_uart REPL UART instance.
+ */
+extern void pclk_div_repl_uart_init(void);
+
 void micropython_task(void *arg);
 #if MICROPY_PY_FREERTOS
 static TaskHandle_t mpy_task_handle;

--- a/ports/psoc-edge/main.c
+++ b/ports/psoc-edge/main.c
@@ -110,12 +110,6 @@ extern void machine_deinit(void);
  */
 extern void pclk_div_repl_uart_init(void);
 
-/**
- * TODO: This will later directly handled by
- * the static machine_uart REPL UART instance.
- */
-extern void pclk_div_repl_uart_init(void);
-
 void micropython_task(void *arg);
 #if MICROPY_PY_FREERTOS
 static TaskHandle_t mpy_task_handle;


### PR DESCRIPTION
* `machine.I2C` and `machine.I2CTarget` uses now the `pclk_div_xxx` API. 