### PR TITLE
Machine SCB classes CLK based + PR feedback improvements

### DIFF
--- a/ports/psoc-edge/Makefile
+++ b/ports/psoc-edge/Makefile
@@ -551,6 +551,10 @@ LDFLAGS += -Wl,--defsym=__GcHeapStart=__HeapBase+$(MICROPY_C_HEAP_SIZE)
 LDFLAGS += -Wl,--defsym=__GcHeapEnd=__HeapLimit
 endif
 
+# Increase the default stack size from (4 KB) to (16 KB).
+APP_MSP_STACK_SIZE ?= 0x4000
+LDFLAGS +=-Wl,--defsym=APP_MSP_STACK_SIZE=$(APP_MSP_STACK_SIZE) \
+
 LIBS += -lm
 
 # PSOC Edge uses Cortex-M33 and Cortex-M55 (ARMv8-M architecture)

--- a/ports/psoc-edge/Makefile
+++ b/ports/psoc-edge/Makefile
@@ -593,7 +593,6 @@ MOD_SRC_C += \
 	machine_rtc.c \
 	machine_ipc.c \
 	machine_scb.c \
-	tcpwm.c \
 	machine_timer.c \
 	machine_bitstream.c \
 	modpsocedge.c \
@@ -609,11 +608,14 @@ MOD_SRC_C += \
 endif
 
 SRC_C += \
+	clk.c \
 	help.c \
 	main.c \
 	mphalport.c \
 	systick.c \
 	sys_int.c \
+	tcpwm.c \
+
 
 # List of sources for qstr extraction
 SRC_QSTR += $(SRC_C) $(SHARED_SRC_C) $(MOD_SRC_C) $(GEN_PINS_SRC)

--- a/ports/psoc-edge/boards/KIT_PSE84_AI/bsp-cfg/cycfg.c
+++ b/ports/psoc-edge/boards/KIT_PSE84_AI/bsp-cfg/cycfg.c
@@ -36,6 +36,11 @@ void init_cycfg_all(void) {
 }
 void cycfg_config_init(void) {
     init_cycfg_clocks();
+    /**
+     * TODO: Comment init_cycfg_peripheral_clocks()
+     * & init_cycfg_peripherals() out once all machine peripherals
+     * are implemented based on `clk` lib.
+     */
     init_cycfg_peripheral_clocks();
     init_cycfg_system();
     init_cycfg_peripherals();

--- a/ports/psoc-edge/clk.c
+++ b/ports/psoc-edge/clk.c
@@ -1,0 +1,317 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2026 Infineon Technologies AG
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "pse84_config.h"
+#include "cy_device.h"
+#include "cy_sysclk.h"
+#include "py/misc.h"
+#include "py/runtime.h"
+
+#include "clk.h"
+
+#define DEBUG_printf(...) // printf(__VA_ARGS__)
+#define clk_assert_raise_val(msg, ret)   if (ret != CY_SYSCLK_SUCCESS) { \
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT(msg), ret); \
+}
+
+/**
+  * Value extracted from TRM.
+  */
+ #define PERI_PCLK_DIVIDER_MAX_NUM 26
+
+#define CLK_DEST_PERI(clk_dest) ((clk_dest) & PERI_PCLK_PERI_NUM_Msk)
+#define CLK_DEST_GROUP(clk_dest) (((clk_dest) & PERI_PCLK_GR_NUM_Msk) >> PERI_PCLK_GR_NUM_Pos)
+#define CLK_DEST_INST(clk_dest) (((clk_dest) & PERI_PCLK_INST_NUM_Msk) >> PERI_PCLK_INST_NUM_Pos)
+
+#define PCLK_DIV_NO_FREE_DIVIDER 0xFF
+
+typedef struct _pclk_div_obj_t {
+    uint32_t peri_inst;
+    uint32_t group;
+    cy_en_divider_types_t type;
+    uint32_t number;
+    uint32_t value;
+    uint8_t value_frac;
+    uint8_t owner_count;
+} pclk_div_obj_t;
+
+pclk_div_obj_t *pclk_div_obj[PERI_PCLK_DIVIDER_MAX_NUM] = {NULL};
+
+static pclk_div_obj_t *pclk_div_obj_alloc(void) {
+    pclk_div_obj_t *clk = NULL;
+    for (int i = 0; i < PERI_PCLK_DIVIDER_MAX_NUM; i++) {
+        if (pclk_div_obj[i] == NULL) {
+            clk = m_new_obj(pclk_div_obj_t);
+            pclk_div_obj[i] = clk;
+            break;
+        }
+    }
+    return clk;
+}
+
+static void pclk_div_obj_free(pclk_div_obj_t *clk) {
+    for (int i = 0; i < PERI_PCLK_DIVIDER_MAX_NUM; i++) {
+        if (pclk_div_obj[i] == clk) {
+            m_del_obj(pclk_div_obj_t, clk);
+            pclk_div_obj[i] = NULL;
+            break;
+        }
+    }
+}
+
+static pclk_div_obj_t *pclk_div_find(en_clk_dst_t clk_dst, uint32_t divider_value, uint8_t divider_value_frac) {
+    pclk_div_obj_t *clk = NULL;
+    for (int i = 0; i < PERI_PCLK_DIVIDER_MAX_NUM; i++) {
+        if (pclk_div_obj[i] != NULL) {
+            if (pclk_div_obj[i]->value == divider_value &&
+                pclk_div_obj[i]->value_frac == divider_value_frac &&
+                pclk_div_obj[i]->peri_inst == CLK_DEST_INST(clk_dst) &&
+                pclk_div_obj[i]->group == CLK_DEST_GROUP(clk_dst)) {
+                DEBUG_printf("DEBUG: pclk_div_obj found for peri_inst=%u, group=%u, number=%u, divider=%u, divider_frac=%u\n", CLK_DEST_INST(clk_dst), CLK_DEST_GROUP(clk_dst), pclk_div_obj[i]->number, divider_value, divider_value_frac);
+                return pclk_div_obj[i];
+            }
+        }
+    }
+    return clk;
+}
+
+static void pclk_div_share(en_clk_dst_t clk_dst, pclk_div_obj_t *clk) {
+    cy_en_sysclk_status_t ret = Cy_SysClk_PeriphAssignDivider(clk_dst, clk->type, clk->number);
+    clk_assert_raise_val("failed to share divider (PDL err: %lu)", ret);
+    DEBUG_printf("DEBUG: pclk_div_obj shared for dest = %u\n", clk_dst);
+    clk->owner_count++;
+}
+
+static pclk_div_obj_t *pclk_div_new_assign_set_enable(en_clk_dst_t clk_dst, cy_en_divider_types_t div_type, uint32_t div_num, uint32_t divider, uint8_t divider_frac) {
+    uint32_t peri_inst = CLK_DEST_INST(clk_dst);
+    uint32_t group = CLK_DEST_GROUP(clk_dst);
+
+    pclk_div_obj_t *pclk = pclk_div_obj_alloc();
+    if (pclk == NULL) {
+        return NULL;
+    }
+
+    pclk->peri_inst = peri_inst;
+    pclk->group = group;
+    pclk->type = div_type;
+    pclk->number = div_num;
+    pclk->value = divider;
+    pclk->value_frac = divider_frac;
+    pclk->owner_count = 1;
+
+    DEBUG_printf("DEBUG: pclk_div_obj(peri_inst=%u, group=%u, div_type=%u, div_num=%u, divider=%u, divider_frac=%u)\n",
+        peri_inst, group, div_type, div_num, divider, divider_frac);
+
+    cy_en_sysclk_status_t ret = Cy_SysClk_PeriphAssignDivider(clk_dst, div_type, div_num);
+    clk_assert_raise_val("failed to assign divider (PDL err: %lu)", ret);
+
+    if (div_type == CY_SYSCLK_DIV_16_5_BIT || div_type == CY_SYSCLK_DIV_24_5_BIT) {
+        ret = Cy_SysClk_PeriPclkSetFracDivider(clk_dst, div_type, div_num, divider, divider_frac);
+        clk_assert_raise_val("failed to set fractional divider (PDL err: %lu)", ret);
+    } else {
+        ret = Cy_SysClk_PeriPclkSetDivider(clk_dst, div_type, div_num, divider);
+        clk_assert_raise_val("failed to set divider (PDL err: %lu)", ret);
+    }
+    ret = Cy_SysClk_PeriPclkEnableDivider(clk_dst, div_type, div_num);
+    clk_assert_raise_val("failed to enable divider (PDL err: %lu)", ret);
+
+    DEBUG_printf("DEBUG: pclk_div_obj assigned, set, enabled on dest=%u.\n", clk_dst);
+
+    return pclk;
+}
+
+static cy_en_divider_types_t pclk_div_get_type(uint32_t divider, uint8_t divider_frac) {
+    /* If fractional part is needed, use fractional divider types */
+    if (divider_frac != 0) {
+        if (divider <= 0xFFFFU) {
+            return CY_SYSCLK_DIV_16_5_BIT;
+        } else {
+            return CY_SYSCLK_DIV_24_5_BIT;
+        }
+    }
+
+    /* No fractional part needed, use integer dividers */
+    if (divider <= 0xFFU) {
+        return CY_SYSCLK_DIV_8_BIT;
+    } else if (divider <= 0xFFFFU) {
+        return CY_SYSCLK_DIV_16_BIT;
+    } else {
+        return CY_SYSCLK_DIV_24_5_BIT;
+    }
+}
+
+static uint8_t  pclk_div_get_max_num_for_peri_group(en_clk_dst_t clk_dst, cy_en_divider_types_t div_type) {
+    uint32_t peri_inst = CLK_DEST_INST(clk_dst);
+    uint32_t group_num = CLK_DEST_GROUP(clk_dst);
+    uint8_t max_num = 0;
+
+    if (div_type == CY_SYSCLK_DIV_8_BIT) {
+        max_num = PERI_PCLK_GR_DIV_8_NR(peri_inst, group_num);
+    } else if (div_type == CY_SYSCLK_DIV_16_BIT) {
+        max_num = PERI_PCLK_GR_DIV_16_NR(peri_inst, group_num);
+    } else if (div_type == CY_SYSCLK_DIV_16_5_BIT) {
+        max_num = PERI_PCLK_GR_DIV_16_5_NR(peri_inst, group_num);
+    } else if (div_type == CY_SYSCLK_DIV_24_5_BIT) {
+        max_num = PERI_PCLK_GR_DIV_24_5_NR(peri_inst, group_num);
+    }
+
+    return max_num;
+}
+
+static uint8_t pclk_div_get_free_num(en_clk_dst_t clk_dst, cy_en_divider_types_t div_type) {
+    uint8_t peri_gr_div_max_num = pclk_div_get_max_num_for_peri_group(clk_dst, div_type);
+
+    for (uint8_t i = 0; i < peri_gr_div_max_num; i++) {
+        bool used = false;
+        for (uint8_t j = 0; j < PERI_PCLK_DIVIDER_MAX_NUM; j++) {
+            if (pclk_div_obj[j] != NULL) {
+                if (pclk_div_obj[j]->peri_inst == CLK_DEST_INST(clk_dst) &&
+                    pclk_div_obj[j]->group == CLK_DEST_GROUP(clk_dst) &&
+                    pclk_div_obj[j]->type == div_type &&
+                    pclk_div_obj[j]->number == i) {
+                    used = true;
+                    break;
+                }
+            }
+        }
+        if (!used) {
+            return i;
+        }
+    }
+
+    return PCLK_DIV_NO_FREE_DIVIDER;
+}
+
+/******************************************************************************/
+/** -- Peripheral Clock Divider API -- **/
+
+void pclk_div_slave_init(en_clk_dst_t clk_dst, pclk_mmio_slave_num_t clk_slave_num) {
+    uint32_t peri_inst = CLK_DEST_INST(clk_dst);
+    uint32_t group = CLK_DEST_GROUP(clk_dst);
+    if (!Cy_SysClk_IsPeriGroupSlaveEnabled(peri_inst, group, clk_slave_num)) {
+        Cy_SysClk_PeriGroupSlaveInit(peri_inst, group, clk_slave_num, Cy_Sysclk_PeriPclkGetClkHfNum(clk_dst));
+    }
+}
+
+void pclk_div_slave_deinit(en_clk_dst_t clk_dst, pclk_mmio_slave_num_t clk_slave_num) {
+    uint32_t peri_inst = CLK_DEST_INST(clk_dst);
+    uint32_t group = CLK_DEST_GROUP(clk_dst);
+    if (Cy_SysClk_IsPeriGroupSlaveEnabled(peri_inst, group, clk_slave_num)) {
+        Cy_SysClk_PeriGroupSlaveDeinit(peri_inst, group, clk_slave_num);
+    }
+}
+
+uint32_t pclk_div_get_input_freq(en_clk_dst_t clk_dst) {
+    uint32_t hf_clk_source = Cy_Sysclk_PeriPclkGetClkHfNum(clk_dst);
+
+    if (!Cy_SysClk_ClkHfIsEnabled(hf_clk_source)) {
+        /**
+         * TODO:
+         * Currently all this is initialized in "cycfg_clocks.c".
+         * Therefore, we assume that this is initialized and enabled.
+         * In the future, maybe the clock management is exposed to
+         * the user.
+         */
+        return 0;
+    }
+
+    return Cy_SysClk_ClkHfGetFrequency(hf_clk_source);
+}
+
+pclk_div_obj_t *pclk_div_init(en_clk_dst_t clk_dst, uint32_t divider, uint8_t divider_frac) {
+    pclk_div_obj_t *pclk = NULL;
+
+    /**
+     * Look for an existing peripheral clock divider
+     * which could be reused.
+     * If found, share it with the caller.
+     */
+    pclk = pclk_div_find(clk_dst, divider, divider_frac);
+    if (pclk != NULL) {
+        pclk_div_share(clk_dst, pclk);
+        return pclk;
+    }
+
+    /* Get the required divider type base on its value + fractional value */
+    cy_en_divider_types_t div_type = pclk_div_get_type(divider, divider_frac);
+
+    /* Get the a free peri-group divider number*/
+    uint8_t div_num = pclk_div_get_free_num(clk_dst, div_type);
+    if (div_num == PCLK_DIV_NO_FREE_DIVIDER) {
+        return NULL;
+    }
+
+    return pclk_div_new_assign_set_enable(clk_dst, div_type, div_num, divider, divider_frac);
+}
+
+void pclk_div_deinit(pclk_div_obj_t *clk) {
+    if (clk == NULL) {
+        return;
+    }
+
+    clk->owner_count--;
+
+    /* Still in use by other peripherals */
+    if (clk->owner_count > 0) {
+        return;
+    }
+
+    uint32_t ip_block = (clk->peri_inst << PERI_PCLK_INST_NUM_Pos) | (clk->group << PERI_PCLK_GR_NUM_Pos);
+    cy_en_sysclk_status_t ret = Cy_SysClk_PeriPclkDisableDivider(ip_block, clk->type, clk->number);
+    clk_assert_raise_val("failed to disable divider (PDL err: %lu)", ret);
+    DEBUG_printf("DEBUG: pclk_div_obj disabled for peri_inst=%u, group=%u, div_type=%u, div_num=%u\n", clk->peri_inst, clk->group, clk->type, clk->number);
+
+    pclk_div_obj_free(clk);
+}
+
+
+/******************************************************************************/
+/** -- Static PCLK Divider instance enablement for REPL UART-- **/
+
+/**
+ * TODO: This needs to be reviewed when we reuse machine_uart static object
+ * for REPL.
+ */
+static pclk_div_obj_t pclk_div_obj_repl_uart;
+void pclk_div_repl_uart_init(void) {
+    pclk_div_obj_t *pclk = &pclk_div_obj_repl_uart;
+    pclk->group = CLK_DEST_GROUP(PCLK_SCB2_CLOCK_SCB_EN);
+    pclk->peri_inst = CLK_DEST_INST(PCLK_SCB2_CLOCK_SCB_EN);
+    pclk->type = CY_SYSCLK_DIV_8_BIT;
+    pclk->number = 0;
+    pclk->value = 86U; // From retarget-io: floor(10000000/(115200*10)) - 1 = 86
+    pclk->value_frac = 0;
+    pclk->owner_count = 1;
+
+    pclk_div_obj[0] = pclk;
+
+    Cy_SysClk_PeriGroupSlaveInit(CY_MMIO_SCB2_PERI_NR, CY_MMIO_SCB2_GROUP_NR, CY_MMIO_SCB2_SLAVE_NR, CY_MMIO_SCB2_CLK_HF_NR);
+    Cy_SysClk_PeriPclkAssignDivider(PCLK_SCB2_CLOCK_SCB_EN, CY_SYSCLK_DIV_8_BIT, 0U);
+
+    uint32_t ip_block = (pclk->peri_inst << PERI_PCLK_INST_NUM_Pos) | (pclk->group << PERI_PCLK_GR_NUM_Pos);
+    Cy_SysClk_PeriPclkSetDivider(ip_block, CY_SYSCLK_DIV_8_BIT, 0U, 86U);
+    Cy_SysClk_PeriPclkEnableDivider(ip_block, CY_SYSCLK_DIV_8_BIT, 0U);
+}

--- a/ports/psoc-edge/clk.c
+++ b/ports/psoc-edge/clk.c
@@ -58,7 +58,7 @@ typedef struct _pclk_div_obj_t {
     uint8_t owner_count;
 } pclk_div_obj_t;
 
-pclk_div_obj_t *pclk_div_obj[PERI_PCLK_DIVIDER_MAX_NUM] = {NULL};
+static pclk_div_obj_t *pclk_div_obj[PERI_PCLK_DIVIDER_MAX_NUM] = {NULL};
 
 static pclk_div_obj_t *pclk_div_obj_alloc(void) {
     pclk_div_obj_t *clk = NULL;

--- a/ports/psoc-edge/clk.h
+++ b/ports/psoc-edge/clk.h
@@ -1,0 +1,42 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2026 Infineon Technologies AG
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef MICROPY_INCLUDED_PSOC_EDGE_CLK_H
+#define MICROPY_INCLUDED_PSOC_EDGE_CLK_H
+
+/* Forward declare pclk_div_obj_t */
+typedef struct _pclk_div_obj_t pclk_div_obj_t;
+
+typedef uint32_t pclk_mmio_slave_num_t;
+
+void pclk_div_slave_init(en_clk_dst_t clk_dst, pclk_mmio_slave_num_t clk_slave_num);
+void pclk_div_slave_deinit(en_clk_dst_t clk_dst, pclk_mmio_slave_num_t clk_slave_num);
+
+uint32_t pclk_div_get_input_freq(en_clk_dst_t clk_dst);
+pclk_div_obj_t *pclk_div_init(en_clk_dst_t clk_dst, uint32_t divider, uint8_t divider_frac);
+void pclk_div_deinit(pclk_div_obj_t *clk);
+
+#endif // MICROPY_INCLUDED_PSOC_EDGE_CLK_H

--- a/ports/psoc-edge/machine_i2c.c
+++ b/ports/psoc-edge/machine_i2c.c
@@ -42,6 +42,7 @@
 
 
 // port-specific includes
+#include "clk.h"
 #include "genhdr/pins_af.h"
 #include "modmachine.h"
 #include "machine_scb.h"
@@ -62,6 +63,7 @@ typedef struct _machine_hw_i2c_obj_t {
     uint32_t freq;
     uint32_t timeout;
     machine_scb_obj_t *scb_obj;
+    pclk_div_obj_t *pclk_div;
     cy_stc_scb_i2c_config_t cfg;   // PDL I2C configuration
     cy_stc_scb_i2c_context_t ctx;  // PDL I2C runtime context
 } machine_hw_i2c_obj_t;
@@ -133,12 +135,18 @@ static void machine_hw_i2c_init(machine_hw_i2c_obj_t *self, uint32_t freq_hz) {
     //   - clk_peri = 100 MHz, divider = 11 → clk_scb = 9.09 MHz ✓ (within range)
     // Note: Cy_SysClk_PeriphSetDivider takes (divider - 1), so divider=11 → value=10
     /* Connect assigned divider to be a clock source for I2C */
-    Cy_SysClk_PeriphAssignDivider(self->scb_obj->clk, CY_SYSCLK_DIV_8_BIT, 2U);
     uint32_t divider = (freq_hz <= 100000) ? 41U : 10U;
-    Cy_SysClk_PeriphSetDivider(CY_SYSCLK_DIV_8_BIT, 2U, divider);
-    Cy_SysClk_PeriphEnableDivider(CY_SYSCLK_DIV_8_BIT, 2U);
+    pclk_div_slave_init(self->scb_obj->clk, self->scb_obj->mmio_slave_nr);
+    self->pclk_div = pclk_div_init(self->scb_obj->clk, divider, 0);
+    if (self->pclk_div == NULL) {
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("failed to initialize clock divider for I2C(%u)"), self->scb_obj->id);
+    }
 
-    uint32_t clk_scb_freq = Cy_SysClk_PeriphGetFrequency(CY_SYSCLK_DIV_8_BIT, 2U);
+    uint32_t input_freq = pclk_div_get_input_freq(self->scb_obj->clk);
+    if (input_freq == 0U) {
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("failed to get clock frequency for I2C(%u)"), self->scb_obj->id);
+    }
+    uint32_t clk_scb_freq = input_freq / (divider + 1U);
     DEBUG_printf("DEBUG: clk_scb_freq=%u Hz\n", clk_scb_freq);
 
     uint32_t actual_rate = Cy_SCB_I2C_SetDataRate(self->scb_obj->scb, freq_hz, clk_scb_freq);
@@ -166,7 +174,8 @@ static void machine_hw_i2c_deinit(mp_obj_base_t *self_in) {
 
     Cy_SCB_I2C_Disable(self->scb_obj->scb, &self->ctx);
     sys_int_deinit(&self->scb_obj->irq);
-    Cy_SysClk_PeriphDisableDivider(CY_SYSCLK_DIV_8_BIT, 0U);
+    pclk_div_deinit(self->pclk_div);
+    pclk_div_slave_deinit(self->scb_obj->clk, self->scb_obj->mmio_slave_nr);
 
     machine_scb_obj_free(self->scb_obj);
     machine_hw_i2c_obj_free(self);

--- a/ports/psoc-edge/machine_i2c_target.c
+++ b/ports/psoc-edge/machine_i2c_target.c
@@ -35,7 +35,8 @@
 #include "py/mphal.h"
 #include "extmod/modmachine.h"
 
-// port-specific includes
+// port-specific
+#include "clk.h"
 #include "genhdr/pins_af.h"
 #include "modmachine.h"
 #include "machine_scb.h"
@@ -53,6 +54,7 @@ typedef struct _machine_i2c_target_obj_t {
     uint32_t slave_addr;
     uint8_t addrsize;
     machine_scb_obj_t *scb_obj;
+    pclk_div_obj_t *pclk_div;
     cy_stc_scb_i2c_config_t cfg;
     cy_stc_scb_i2c_context_t ctx;
     size_t tx_index;
@@ -204,9 +206,14 @@ static void i2c_target_init(machine_i2c_target_obj_t *self, machine_i2c_target_d
     // For 400 khz slave, clk_scb must be 7.82 – 15.38 MHz
     // For 100 khz slave, clk_scb must be 1.55 – 12.8 MHz
     // clk_peri = 100 MHz, divider = 7, clk_scb = 100/8 = 12.5 MHz
-    Cy_SysClk_PeriphAssignDivider(self->scb_obj->clk, CY_SYSCLK_DIV_8_BIT, 2U);
-    Cy_SysClk_PeriphSetDivider(CY_SYSCLK_DIV_8_BIT, 2U, 7U); // divider = n+1, so 7 means divide by 8
-    Cy_SysClk_PeriphEnableDivider(CY_SYSCLK_DIV_8_BIT, 2U);
+    #define I2C_TARGET_SCB_CLK_FREQ_HZ (12500000UL)
+    pclk_div_slave_init(self->scb_obj->clk, self->scb_obj->mmio_slave_nr);
+    uint32_t input_freq = pclk_div_get_input_freq(self->scb_obj->clk);
+    uint32_t divider = input_freq / I2C_TARGET_SCB_CLK_FREQ_HZ - 1;
+    self->pclk_div = pclk_div_init(self->scb_obj->clk, divider, 0);
+    if (self->pclk_div == NULL) {
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("failed to initialize clock divider for I2CTarget(%u)"), self->id);
+    }
 
     sys_int_init(&(self->scb_obj->irq));
 
@@ -350,6 +357,8 @@ static void mp_machine_i2c_target_print(const mp_print_t *print, mp_obj_t self_i
 static void mp_machine_i2c_target_deinit(machine_i2c_target_obj_t *self) {
     Cy_SCB_I2C_Disable(self->scb_obj->scb, &self->ctx);
     sys_int_deinit(&(self->scb_obj->irq));
+    pclk_div_deinit(self->pclk_div);
+    pclk_div_slave_deinit(self->scb_obj->clk, self->scb_obj->mmio_slave_nr);
     self->base.type = NULL;
 
     machine_scb_obj_free(self->scb_obj);

--- a/ports/psoc-edge/machine_pin_af.c
+++ b/ports/psoc-edge/machine_pin_af.c
@@ -26,6 +26,15 @@
 
 #include "machine_pin_af.h"
 
+const char *machine_pin_af_fn_str[] = {
+    [MACHINE_PIN_AF_FN_I2C] = "I2C",
+    [MACHINE_PIN_AF_FN_SPI] = "SPI",
+    [MACHINE_PIN_AF_FN_UART] = "UART",
+    [MACHINE_PIN_AF_FN_PDM] = "PDM",
+    [MACHINE_PIN_AF_FN_TCPWM] = "TCPWM",
+    /* TODO: Add additional functionalities */
+};
+
 const char *machine_pin_af_signal_str[] = {
     [MACHINE_PIN_AF_SIGNAL_I2C_SDA] = "I2C_SDA",
     [MACHINE_PIN_AF_SIGNAL_I2C_SCL] = "I2C_SCL",

--- a/ports/psoc-edge/machine_scb.c
+++ b/ports/psoc-edge/machine_scb.c
@@ -71,10 +71,7 @@ MICROPY_PY_MACHINE_FOR_ALL_SCB(DEFINE_SCB_IRQ_HANDLER)
             SCB##scb##_IRQ_Handler \
         }, \
         PCLK_SCB##scb##_CLOCK_SCB_EN, \
-        CY_MMIO_SCB##scb##_PERI_NR, \
-        CY_MMIO_SCB##scb##_GROUP_NR, \
         CY_MMIO_SCB##scb##_SLAVE_NR, \
-        CY_MMIO_SCB##scb##_CLK_HF_NR, \
         NULL, \
         NULL, \
     },
@@ -82,47 +79,6 @@ MICROPY_PY_MACHINE_FOR_ALL_SCB(DEFINE_SCB_IRQ_HANDLER)
 static machine_scb_obj_t machine_scb_obj[MICROPY_PY_MACHINE_SCB_NUM_ENTRIES] = {
     MICROPY_PY_MACHINE_FOR_ALL_SCB(MAP_SCB_IRQ_CONFIG)
 };
-
-typedef struct {
-    uint32_t peri_nr;
-    uint32_t group_nr;
-    uint32_t slave_nr;
-    uint32_t clk_hf_nr;
-} machine_scb_group_info_t;
-
-#define MAP_SCB_GROUP_INFO(scb) \
-    [scb] = { \
-        .peri_nr = CY_MMIO_SCB##scb##_PERI_NR, \
-        .group_nr = CY_MMIO_SCB##scb##_GROUP_NR, \
-        .slave_nr = CY_MMIO_SCB##scb##_SLAVE_NR, \
-        .clk_hf_nr = CY_MMIO_SCB##scb##_CLK_HF_NR, \
-    },
-
-static const machine_scb_group_info_t machine_scb_group_info[MICROPY_PY_MACHINE_SCB_NUM_ENTRIES] = {
-    MICROPY_PY_MACHINE_FOR_ALL_SCB(MAP_SCB_GROUP_INFO)
-};
-
-typedef struct {
-    const void *owner;
-    en_clk_dst_t clk_dst;
-    uint8_t div_num;
-} machine_scb_div8_alloc_t;
-
-static machine_scb_div8_alloc_t machine_scb_div8_alloc[MICROPY_PY_MACHINE_SCB_NUM_ENTRIES] = {0};
-
-static inline uint32_t machine_scb_div8_count_for_clk(en_clk_dst_t clk_dst) {
-    uint32_t grp_num = (((uint32_t)clk_dst) & PERI_PCLK_GR_NUM_Msk) >> PERI_PCLK_GR_NUM_Pos;
-    uint32_t inst_num = (((uint32_t)clk_dst) & PERI_PCLK_INST_NUM_Msk) >> PERI_PCLK_INST_NUM_Pos;
-    return PERI_PCLK_GR_DIV_8_NR(inst_num, grp_num);
-}
-
-static inline bool machine_scb_same_divider_group(en_clk_dst_t clk_a, en_clk_dst_t clk_b) {
-    uint32_t a_grp = (((uint32_t)clk_a) & PERI_PCLK_GR_NUM_Msk) >> PERI_PCLK_GR_NUM_Pos;
-    uint32_t a_inst = (((uint32_t)clk_a) & PERI_PCLK_INST_NUM_Msk) >> PERI_PCLK_INST_NUM_Pos;
-    uint32_t b_grp = (((uint32_t)clk_b) & PERI_PCLK_GR_NUM_Msk) >> PERI_PCLK_GR_NUM_Pos;
-    uint32_t b_inst = (((uint32_t)clk_b) & PERI_PCLK_INST_NUM_Msk) >> PERI_PCLK_INST_NUM_Pos;
-    return (a_grp == b_grp) && (a_inst == b_inst);
-}
 
 static void machine_scb_irq_handler(uint8_t scb) {
     machine_scb_obj_t *scb_obj = &machine_scb_obj[scb];
@@ -136,16 +92,8 @@ machine_scb_obj_t *machine_scb_obj_alloc(uint8_t scb, mp_obj_t parent, machine_s
     if (obj->parent != NULL) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("SCB %u is already in use by another I2C, SPI or UART instance."), scb);
     }
-    /*
-     * Enable the peripheral clock gate for this SCB. The BSP's
-     * cycfg_config_reservations() only does this for the SCBs that are
-     * configured in the board design (e.g. the debug UART). Any SCB
-     * that was not pre-configured will have its clock gate disabled, and
-     * attempting to read or write its registers stalls the AHB bus,
-     * causing a hard lock-up. Calling this for already-enabled SCBs is
-     * idempotent.
-     */
-    Cy_SysClk_PeriGroupSlaveInit(obj->peri_nr, obj->group_nr, obj->slave_nr, obj->clk_hf_nr);
+    ;
+
     obj->parent = parent;
     obj->parent_handler = handler;
     return &machine_scb_obj[scb];
@@ -154,92 +102,11 @@ machine_scb_obj_t *machine_scb_obj_alloc(uint8_t scb, mp_obj_t parent, machine_s
 void machine_scb_obj_free(machine_scb_obj_t *scb) {
     scb->parent = NULL;
     scb->parent_handler = NULL;
-    Cy_SysClk_PeriGroupSlaveDeinit(scb->peri_nr, scb->group_nr, scb->slave_nr);
 }
 
 bool machine_scb_is_free(uint8_t scb) {
     return machine_scb_obj[scb].parent == NULL;
 
-}
-
-void machine_scb_enable_group(uint8_t scb) {
-    const machine_scb_group_info_t *gi = &machine_scb_group_info[scb];
-    Cy_SysClk_PeriGroupSlaveInit(gi->peri_nr, gi->group_nr,
-        gi->slave_nr, gi->clk_hf_nr);
-}
-
-void machine_scb_peri_pclk_config_divider(en_clk_dst_t clk_dst,
-    cy_en_divider_types_t div_type, uint8_t div_num, uint32_t div_val) {
-    Cy_SysClk_PeriPclkDisableDivider(clk_dst, div_type, div_num);
-    Cy_SysClk_PeriPclkAssignDivider(clk_dst, div_type, div_num);
-    Cy_SysClk_PeriPclkSetDivider(clk_dst, div_type, div_num, div_val);
-    Cy_SysClk_PeriPclkEnableDivider(clk_dst, div_type, div_num);
-}
-
-bool machine_scb_div8_try_alloc(en_clk_dst_t clk_dst, uint8_t div_base, uint8_t div_invalid,
-    const void *owner, uint8_t *div_num_out) {
-    uint32_t max_div = machine_scb_div8_count_for_clk(clk_dst);
-    if (div_base >= max_div || div_num_out == NULL || owner == NULL) {
-        return false;
-    }
-
-    for (uint32_t div = div_base; div < max_div; ++div) {
-        if (div > div_invalid) {
-            break;
-        }
-
-        bool used = false;
-        for (uint8_t i = 0; i < MICROPY_PY_MACHINE_SCB_NUM_ENTRIES; i++) {
-            if (machine_scb_div8_alloc[i].owner == NULL) {
-                continue;
-            }
-            if (!machine_scb_same_divider_group(machine_scb_div8_alloc[i].clk_dst, clk_dst)) {
-                continue;
-            }
-            if (machine_scb_div8_alloc[i].div_num == (uint8_t)div) {
-                used = true;
-                break;
-            }
-        }
-
-        if (!used) {
-            for (uint8_t i = 0; i < MICROPY_PY_MACHINE_SCB_NUM_ENTRIES; i++) {
-                if (machine_scb_div8_alloc[i].owner == NULL) {
-                    machine_scb_div8_alloc[i].owner = owner;
-                    machine_scb_div8_alloc[i].clk_dst = clk_dst;
-                    machine_scb_div8_alloc[i].div_num = (uint8_t)div;
-                    *div_num_out = (uint8_t)div;
-                    return true;
-                }
-            }
-            return false;
-        }
-    }
-
-    return false;
-}
-
-void machine_scb_div8_free(en_clk_dst_t clk_dst, uint8_t div_num, const void *owner) {
-    if (owner == NULL) {
-        return;
-    }
-
-    for (uint8_t i = 0; i < MICROPY_PY_MACHINE_SCB_NUM_ENTRIES; i++) {
-        if (machine_scb_div8_alloc[i].owner != owner) {
-            continue;
-        }
-        if (machine_scb_div8_alloc[i].div_num != div_num) {
-            continue;
-        }
-        if (!machine_scb_same_divider_group(machine_scb_div8_alloc[i].clk_dst, clk_dst)) {
-            continue;
-        }
-
-        machine_scb_div8_alloc[i].owner = NULL;
-        machine_scb_div8_alloc[i].div_num = 0;
-        machine_scb_div8_alloc[i].clk_dst = 0;
-        return;
-    }
 }
 
 #endif // MICROPY_PY_MACHINE_I2C || MICROPY_PY_MACHINE_I2C_TARGET || MICROPY_PY_MACHINE_SPI || MICROPY_PY_MACHINE_SPI_TARGET || MICROPY_PY_MACHINE_UART

--- a/ports/psoc-edge/machine_scb.c
+++ b/ports/psoc-edge/machine_scb.c
@@ -29,7 +29,7 @@
 #if MICROPY_PY_MACHINE_I2C || MICROPY_PY_MACHINE_I2C_TARGET || MICROPY_PY_MACHINE_SPI || MICROPY_PY_MACHINE_SPI_TARGET || MICROPY_PY_MACHINE_UART
 
 #include "py/runtime.h"
-#include "cy_sysclk.h"
+// #include "cy_sysclk.h"
 #include "genhdr/pins_af.h"
 #include "machine_scb.h"
 

--- a/ports/psoc-edge/machine_scb.c
+++ b/ports/psoc-edge/machine_scb.c
@@ -29,7 +29,6 @@
 #if MICROPY_PY_MACHINE_I2C || MICROPY_PY_MACHINE_I2C_TARGET || MICROPY_PY_MACHINE_SPI || MICROPY_PY_MACHINE_SPI_TARGET || MICROPY_PY_MACHINE_UART
 
 #include "py/runtime.h"
-// #include "cy_sysclk.h"
 #include "genhdr/pins_af.h"
 #include "machine_scb.h"
 

--- a/ports/psoc-edge/machine_scb.h
+++ b/ports/psoc-edge/machine_scb.h
@@ -37,10 +37,7 @@ typedef struct _machine_scb_obj_t {
     CySCB_Type *scb;
     sys_int_cfg_t irq;
     en_clk_dst_t clk;
-    uint8_t peri_nr;
-    uint8_t group_nr;
-    uint8_t slave_nr;
-    uint8_t clk_hf_nr;
+    uint8_t mmio_slave_nr;
     mp_obj_t parent;
     machine_scb_parent_irq_handler_t parent_handler;
 } machine_scb_obj_t;
@@ -48,11 +45,5 @@ typedef struct _machine_scb_obj_t {
 machine_scb_obj_t *machine_scb_obj_alloc(uint8_t scb, mp_obj_t parent, machine_scb_parent_irq_handler_t handler);
 void machine_scb_obj_free(machine_scb_obj_t *scb);
 bool machine_scb_is_free(uint8_t scb);
-void machine_scb_enable_group(uint8_t scb);
-void machine_scb_peri_pclk_config_divider(en_clk_dst_t clk_dst,
-    cy_en_divider_types_t div_type, uint8_t div_num, uint32_t div_val);
-bool machine_scb_div8_try_alloc(en_clk_dst_t clk_dst, uint8_t div_base, uint8_t div_invalid,
-    const void *owner, uint8_t *div_num_out);
-void machine_scb_div8_free(en_clk_dst_t clk_dst, uint8_t div_num, const void *owner);
 
 #endif // MICROPY_INCLUDED_PSOC_EDGE_MACHINE_SCB_H

--- a/ports/psoc-edge/machine_spi.c
+++ b/ports/psoc-edge/machine_spi.c
@@ -31,7 +31,7 @@
 #include "py/mperrno.h"
 #include "cybsp.h"
 #include "cy_scb_spi.h"
-#include "cy_sysclk.h"
+#include "clk.h"
 #include "genhdr/pins_af.h"
 #include "machine_scb.h"
 #include "modmachine.h"
@@ -44,9 +44,7 @@
 #define DEFAULT_SPI_TIMEOUT     (50000)
 
 #define SPI_OVERSAMPLE          (4U)
-#define SPI_CLK_DIV_TYPE        CY_SYSCLK_DIV_8_BIT
 #define SPI_CLK_DIV_BASE        (4U)
-#define SPI_CLK_DIV_INVALID      (0xFFU)
 
 typedef struct _machine_spi_obj_t {
     mp_obj_base_t base;
@@ -59,7 +57,7 @@ typedef struct _machine_spi_obj_t {
     uint8_t bits;
     uint8_t firstbit;
     uint32_t timeout;
-    uint8_t div_num;
+    pclk_div_obj_t *pclk_div;
     machine_scb_obj_t *scb_obj;
     cy_stc_scb_spi_config_t cfg;
     cy_stc_scb_spi_context_t ctx;
@@ -71,7 +69,6 @@ static inline machine_spi_obj_t *machine_hw_spi_obj_alloc(void) {
     for (uint8_t i = 0; i < MICROPY_PY_MACHINE_SPI_NUM_ENTRIES; i++) {
         if (machine_hw_spi_obj[i] == NULL) {
             machine_hw_spi_obj[i] = mp_obj_malloc(machine_spi_obj_t, &machine_spi_type);
-            machine_hw_spi_obj[i]->div_num = SPI_CLK_DIV_INVALID;
             return machine_hw_spi_obj[i];
         }
     }
@@ -141,32 +138,19 @@ static void machine_spi_hw_init(machine_spi_obj_t *self) {
     uint8_t scb_unit = machine_spi_pins_config_and_get_scb_unit(
         self->sck, self->mosi, self->miso);
 
-    // Power on the peripheral group that contains this SCB.
-    // Note: "Slave" in PeriGroupSlaveInit refers to the bus architecture
-    // (SCB is a slave on the internal PERI interconnect), not SPI slave mode.
-    machine_scb_enable_group(scb_unit);
-
     // Allocate SCB
     self->scb_obj = machine_scb_obj_alloc(scb_unit, self,
         machine_spi_scb_isr);
 
-    if (!machine_scb_div8_try_alloc(self->scb_obj->clk,
-        SPI_CLK_DIV_BASE,
-        SPI_CLK_DIV_INVALID,
-        self,
-        &self->div_num)) {
+    pclk_div_slave_init(self->scb_obj->clk, self->scb_obj->mmio_slave_nr);
+
+    uint32_t clk_hf_freq = pclk_div_get_input_freq(self->scb_obj->clk);
+    if (clk_hf_freq == 0U) {
+        pclk_div_slave_deinit(self->scb_obj->clk, self->scb_obj->mmio_slave_nr);
         machine_scb_obj_free(self->scb_obj);
         self->scb_obj = NULL;
-        mp_raise_ValueError(MP_ERROR_TEXT("SPI clock dividers exhausted"));
+        mp_raise_ValueError(MP_ERROR_TEXT("failed to get SPI input clock"));
     }
-
-    // Configure SPI clock divider
-    machine_scb_peri_pclk_config_divider(self->scb_obj->clk,
-        SPI_CLK_DIV_TYPE, self->div_num, 0U);
-
-    // Get HF clock frequency and calculate divider value for desired baudrate
-    uint32_t clk_hf_freq = Cy_SysClk_PeriPclkGetFrequency(
-        self->scb_obj->clk, SPI_CLK_DIV_TYPE, self->div_num);
 
     // Compute divider value for requested baudrate
     uint32_t div_val = clk_hf_freq / ((uint64_t)self->baudrate * SPI_OVERSAMPLE);
@@ -174,9 +158,18 @@ static void machine_spi_hw_init(machine_spi_obj_t *self) {
         div_val--;
     }
 
-    // Apply divider
-    machine_scb_peri_pclk_config_divider(self->scb_obj->clk,
-        SPI_CLK_DIV_TYPE, self->div_num, div_val);
+    if (div_val < SPI_CLK_DIV_BASE) {
+        div_val = SPI_CLK_DIV_BASE;
+    }
+
+    self->pclk_div = pclk_div_init(self->scb_obj->clk, div_val, 0);
+    if (self->pclk_div == NULL) {
+        pclk_div_slave_deinit(self->scb_obj->clk, self->scb_obj->mmio_slave_nr);
+        machine_scb_obj_free(self->scb_obj);
+        self->pclk_div = NULL;
+        self->scb_obj = NULL;
+        mp_raise_ValueError(MP_ERROR_TEXT("SPI clock dividers exhausted"));
+    }
 
     // Select SPI clock polarity and phase
     cy_en_scb_spi_sclk_mode_t sclk_mode;
@@ -226,8 +219,9 @@ static void machine_spi_hw_init(machine_spi_obj_t *self) {
         Cy_SCB_SPI_Init(self->scb_obj->scb, &self->cfg, &self->ctx);
 
     if (result != CY_SCB_SPI_SUCCESS) {
-        machine_scb_div8_free(self->scb_obj->clk, self->div_num, self);
-        self->div_num = SPI_CLK_DIV_INVALID;
+        pclk_div_deinit(self->pclk_div);
+        self->pclk_div = NULL;
+        pclk_div_slave_deinit(self->scb_obj->clk, self->scb_obj->mmio_slave_nr);
         machine_scb_obj_free(self->scb_obj);
         self->scb_obj = NULL;
         mp_raise_msg_varg(&mp_type_ValueError,
@@ -242,11 +236,9 @@ static void machine_spi_hw_deinit(machine_spi_obj_t *self) {
     Cy_SCB_SPI_Disable(self->scb_obj->scb, &self->ctx);
     Cy_SCB_SPI_DeInit(self->scb_obj->scb);
     sys_int_deinit(&self->scb_obj->irq);
-    if (self->div_num != SPI_CLK_DIV_INVALID) {
-        machine_scb_div8_free(self->scb_obj->clk, self->div_num, self);
-        Cy_SysClk_PeriPclkDisableDivider(self->scb_obj->clk, SPI_CLK_DIV_TYPE, self->div_num);
-        self->div_num = SPI_CLK_DIV_INVALID;
-    }
+    pclk_div_deinit(self->pclk_div);
+    self->pclk_div = NULL;
+    pclk_div_slave_deinit(self->scb_obj->clk, self->scb_obj->mmio_slave_nr);
     machine_scb_obj_free(self->scb_obj);
     self->scb_obj = NULL;
 }
@@ -429,6 +421,7 @@ mp_obj_t mp_machine_spi_make_new(const mp_obj_type_t *type, size_t n_args, size_
     self->bits = DEFAULT_SPI_BITS;
     self->firstbit = MICROPY_PY_MACHINE_SPI_MSB;
     self->timeout = DEFAULT_SPI_TIMEOUT;
+    self->pclk_div = NULL;
     self->scb_obj = NULL;
     self->sck = NULL;
     self->mosi = NULL;

--- a/ports/psoc-edge/machine_spi.c
+++ b/ports/psoc-edge/machine_spi.c
@@ -244,7 +244,7 @@ static void machine_spi_hw_deinit(machine_spi_obj_t *self) {
 }
 
 // Parse and validate user arguments shared by constructor and init().
-static void machine_spi_init_helper(machine_spi_obj_t *self, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
+static void machine_spi_init(mp_obj_base_t *self_in, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_id, ARG_baudrate, ARG_polarity, ARG_phase, ARG_bits,
            ARG_firstbit, ARG_sck, ARG_mosi, ARG_miso };
 
@@ -261,7 +261,9 @@ static void machine_spi_init_helper(machine_spi_obj_t *self, size_t n_args, size
     };
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    machine_spi_obj_t *self = (machine_spi_obj_t *)self_in;
 
     bool reinit = false;
 
@@ -310,29 +312,6 @@ static void machine_spi_init_helper(machine_spi_obj_t *self, size_t n_args, size
         }
         machine_spi_hw_init(self);
     }
-}
-
-// Thin protocol adapter for mp_machine_spi_p.init signature.
-static void machine_spi_init(mp_obj_base_t *self_in, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
-    machine_spi_obj_t *self = (machine_spi_obj_t *)self_in;
-
-    // Convert runtime pos/kw args into the kw-array form expected by init_helper.
-    size_t n_kw = kw_args->used;
-    size_t all_args_len = n_args + 2 * n_kw;
-    mp_obj_t all_args[all_args_len == 0 ? 1 : all_args_len];
-
-    size_t out = 0;
-    for (size_t i = 0; i < n_args; i++) {
-        all_args[out++] = pos_args[i];
-    }
-    for (size_t i = 0; i < kw_args->alloc; i++) {
-        if (mp_map_slot_is_filled(kw_args, i)) {
-            all_args[out++] = kw_args->table[i].key;
-            all_args[out++] = kw_args->table[i].value;
-        }
-    }
-
-    machine_spi_init_helper(self, n_args, n_kw, all_args);
 }
 
 static void machine_spi_deinit(mp_obj_base_t *self_in) {
@@ -414,6 +393,9 @@ mp_obj_t mp_machine_spi_make_new(const mp_obj_type_t *type, size_t n_args, size_
         mp_raise_ValueError(MP_ERROR_TEXT("machine.SPI: Maximum number of SPI instances reached"));
     }
 
+    mp_map_t kw_args;
+    mp_map_init_fixed_table(&kw_args, n_kw, all_args + n_args);
+
     // Set defaults
     self->baudrate = DEFAULT_SPI_BAUDRATE;
     self->polarity = DEFAULT_SPI_POLARITY;
@@ -430,7 +412,7 @@ mp_obj_t mp_machine_spi_make_new(const mp_obj_type_t *type, size_t n_args, size_
     // Delegate argument parsing and initialization to init_helper
     nlr_buf_t nlr;
     if (nlr_push(&nlr) == 0) {
-        machine_spi_init_helper(self, n_args, n_kw, all_args);
+        machine_spi_init((mp_obj_base_t *)self, n_args, all_args, &kw_args);
         nlr_pop();
     } else {
         machine_hw_spi_obj_free(self);

--- a/ports/psoc-edge/machine_spi.c
+++ b/ports/psoc-edge/machine_spi.c
@@ -387,7 +387,6 @@ static void machine_spi_print(const mp_print_t *print,
 mp_obj_t mp_machine_spi_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     mp_arg_check_num(n_args, n_kw, 0, 9, true);
 
-    // Allocate a SPI object from static pool (each slot has a unique clock divider index)
     machine_spi_obj_t *self = machine_hw_spi_obj_alloc();
     if (self == NULL) {
         mp_raise_ValueError(MP_ERROR_TEXT("machine.SPI: Maximum number of SPI instances reached"));

--- a/ports/psoc-edge/machine_spi_target.c
+++ b/ports/psoc-edge/machine_spi_target.c
@@ -30,7 +30,7 @@
 #include <string.h>
 #include "cybsp.h"
 #include "cy_scb_spi.h"
-#include "cy_sysclk.h"
+#include "clk.h"
 #include "genhdr/pins_af.h"
 #include "machine_scb.h"
 #include "modmachine.h"
@@ -43,9 +43,7 @@
 #define SPI_TARGET_TICKS_WRAP_MS       (15000U) // from mp_hal_ticks_ms source timer period in modtime.c
 #define DEFAULT_SPI_TARGET_TIMEOUT_MS  (5000U)  // must stay below SPI_TARGET_TICKS_WRAP_MS
 
-#define SPI_TARGET_CLK_DIV_TYPE        CY_SYSCLK_DIV_8_BIT
 #define SPI_TARGET_CLK_DIV_BASE        (4U)
-#define SPI_TARGET_CLK_DIV_INVALID      (0xFFU)
 
 // mp_hal_ticks_ms() on this port wraps every SPI_TARGET_TICKS_WRAP_MS.
 // This computes elapsed time across one wrap; caller keeps timeout < wrap period.
@@ -65,7 +63,7 @@ typedef struct _machine_spi_target_obj_t {
     uint8_t bits;
     uint8_t firstbit;
     uint32_t timeout;
-    uint8_t div_num;  // Clock divider number for PCLK
+    pclk_div_obj_t *pclk_div;
     machine_scb_obj_t *scb_obj;
     cy_stc_scb_spi_config_t cfg;
     cy_stc_scb_spi_context_t ctx;
@@ -77,7 +75,6 @@ static inline machine_spi_target_obj_t *machine_spi_target_obj_alloc(void) {
     for (uint8_t i = 0; i < MICROPY_PY_MACHINE_SPI_TARGET_MAX; i++) {
         if (machine_spi_target_obj[i] == NULL) {
             machine_spi_target_obj[i] = mp_obj_malloc(machine_spi_target_obj_t, &machine_spi_target_type);
-            machine_spi_target_obj[i]->div_num = SPI_TARGET_CLK_DIV_INVALID;
             return machine_spi_target_obj[i];
         }
     }
@@ -144,27 +141,19 @@ static void machine_spi_target_hw_init(machine_spi_target_obj_t *self) {
     uint8_t scb_unit = machine_spi_target_pins_config_and_get_scb_unit(
         self->sck, self->mosi, self->miso, self->ssel);
 
-    // Power on the peripheral group that contains this SCB.
-    machine_scb_enable_group(scb_unit);
 
     // Allocate SCB
     self->scb_obj = machine_scb_obj_alloc(scb_unit, self,
         machine_spi_target_scb_isr);
 
-    if (!machine_scb_div8_try_alloc(self->scb_obj->clk,
-        SPI_TARGET_CLK_DIV_BASE,
-        SPI_TARGET_CLK_DIV_INVALID,
-        self,
-        &self->div_num)) {
+    pclk_div_slave_init(self->scb_obj->clk, self->scb_obj->mmio_slave_nr);
+    self->pclk_div = pclk_div_init(self->scb_obj->clk, SPI_TARGET_CLK_DIV_BASE, 0);
+    if (self->pclk_div == NULL) {
+        pclk_div_slave_deinit(self->scb_obj->clk, self->scb_obj->mmio_slave_nr);
         machine_scb_obj_free(self->scb_obj);
         self->scb_obj = NULL;
         mp_raise_ValueError(MP_ERROR_TEXT("SPITarget clock dividers exhausted"));
     }
-
-    // Configure SPI PCLK divider (needed for slave's internal clock even though
-    // the bit clock comes from master's SCK)
-    machine_scb_peri_pclk_config_divider(self->scb_obj->clk,
-        SPI_TARGET_CLK_DIV_TYPE, self->div_num, 0U);
 
     // Select SPI clock polarity and phase
     cy_en_scb_spi_sclk_mode_t sclk_mode;
@@ -214,8 +203,9 @@ static void machine_spi_target_hw_init(machine_spi_target_obj_t *self) {
         Cy_SCB_SPI_Init(self->scb_obj->scb, &self->cfg, &self->ctx);
 
     if (result != CY_SCB_SPI_SUCCESS) {
-        machine_scb_div8_free(self->scb_obj->clk, self->div_num, self);
-        self->div_num = SPI_TARGET_CLK_DIV_INVALID;
+        pclk_div_deinit(self->pclk_div);
+        self->pclk_div = NULL;
+        pclk_div_slave_deinit(self->scb_obj->clk, self->scb_obj->mmio_slave_nr);
         machine_scb_obj_free(self->scb_obj);
         self->scb_obj = NULL;
         mp_raise_msg_varg(&mp_type_ValueError,
@@ -230,11 +220,9 @@ static void machine_spi_target_hw_deinit(machine_spi_target_obj_t *self) {
     Cy_SCB_SPI_Disable(self->scb_obj->scb, &self->ctx);
     Cy_SCB_SPI_DeInit(self->scb_obj->scb);
     sys_int_deinit(&self->scb_obj->irq);
-    if (self->div_num != SPI_TARGET_CLK_DIV_INVALID) {
-        machine_scb_div8_free(self->scb_obj->clk, self->div_num, self);
-        Cy_SysClk_PeriPclkDisableDivider(self->scb_obj->clk, SPI_TARGET_CLK_DIV_TYPE, self->div_num);
-        self->div_num = SPI_TARGET_CLK_DIV_INVALID;
-    }
+    pclk_div_deinit(self->pclk_div);
+    self->pclk_div = NULL;
+    pclk_div_slave_deinit(self->scb_obj->clk, self->scb_obj->mmio_slave_nr);
     machine_scb_obj_free(self->scb_obj);
     self->scb_obj = NULL;
 }
@@ -282,6 +270,7 @@ static mp_obj_t machine_spi_target_make_new(const mp_obj_type_t *type, size_t n_
     self->bits = args[ARG_bits].u_int;
     self->firstbit = args[ARG_firstbit].u_int;
     self->timeout = DEFAULT_SPI_TARGET_TIMEOUT_MS;
+    self->pclk_div = NULL;
     self->scb_obj = NULL;
 
     nlr_buf_t nlr;

--- a/ports/psoc-edge/machine_uart.c
+++ b/ports/psoc-edge/machine_uart.c
@@ -219,7 +219,7 @@ static void machine_uart_obj_make_or_reuse(machine_uart_obj_t **self_ptr, uint8_
             (*self_ptr)->id = id;
             (*self_ptr)->pclk_div = NULL;
             (*self_ptr)->scb_obj = machine_scb_obj_alloc(id, *self_ptr, machine_uart_scb_isr);
-            pclk_div_slave_init((*self_ptr)->scb_obj->clk, (*self_ptr)->scb_obj->slave_nr);
+            pclk_div_slave_init((*self_ptr)->scb_obj->clk, (*self_ptr)->scb_obj->mmio_slave_nr);
         } else {
             mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("SCB %u is already in use by a machine.I2C or machine.SPI instance."), id);
         }
@@ -670,7 +670,7 @@ static mp_obj_t mp_machine_uart_make_new(const mp_obj_type_t *type, size_t n_arg
 static void mp_machine_uart_deinit(machine_uart_obj_t *self) {
     machine_uart_hw_deinit(self);
     m_del(uint8_t, self->rx_ringbuf.buf, self->rx_ringbuf.size);
-    pclk_div_slave_deinit(self->scb_obj->clk, self->scb_obj->slave_nr);
+    pclk_div_slave_deinit(self->scb_obj->clk, self->scb_obj->mmio_slave_nr);
     machine_scb_obj_free(self->scb_obj);
     mp_machine_uart_obj_free(self);
 }

--- a/ports/psoc-edge/machine_uart.c
+++ b/ports/psoc-edge/machine_uart.c
@@ -34,7 +34,6 @@
 #include "cybsp.h"
 #include "cy_scb_uart.h"
 #include "cy_scb_common.h"
-#include "cy_sysclk.h"
 
 // MicroPython includes
 #include "py/ringbuf.h"
@@ -42,6 +41,7 @@
 #include "py/mperrno.h"
 #include "py/nlr.h"
 #include "py/stream.h"
+#include "py/misc.h"
 
 // Port-specific includes
 #include "genhdr/pins_af.h"
@@ -58,14 +58,21 @@
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT(msg), ret); \
 }
 
+/**
+ * Integer ceil conversion from microseconds to milliseconds.
+ * (us + 999) / 1000 == ceil(us / 1000), so sub-ms durations do not become 0 ms.
+ */
+#define us_to_ms_ceil(us) (((us) + 999ULL) / 1000ULL)
+
 // Flow control macros not part of PSOC Edge PDL
 #define UART_FLOW_CONTROL_NONE    (0)
 #define UART_FLOW_CONTROL_RTS     (1)
 #define UART_FLOW_CONTROL_CTS     (2)
+#define UART_IRQ_RXIDLE           (CY_SCB_RX_INTR_NOT_EMPTY)
 
 // Class-level constants exposed to Python
 #define MICROPY_PY_MACHINE_UART_CLASS_CONSTANTS \
-    { MP_ROM_QSTR(MP_QSTR_IRQ_RXIDLE), MP_ROM_INT(CY_SCB_RX_INTR_NOT_EMPTY) }, \
+    { MP_ROM_QSTR(MP_QSTR_IRQ_RXIDLE), MP_ROM_INT(UART_IRQ_RXIDLE) }, \
     { MP_ROM_QSTR(MP_QSTR_IRQ_BREAK), MP_ROM_INT(CY_SCB_RX_INTR_UART_BREAK_DETECT) }, \
     { MP_ROM_QSTR(MP_QSTR_IRQ_TXIDLE), MP_ROM_INT(CY_SCB_TX_INTR_UART_DONE) }, \
     { MP_ROM_QSTR(MP_QSTR_RTS), MP_ROM_INT(UART_FLOW_CONTROL_RTS) }, \
@@ -85,7 +92,7 @@ typedef struct _machine_uart_obj_t {
     uint32_t baudrate;
     uint32_t flow;
     uint8_t bits;
-    uint8_t parity;
+    mp_obj_t parity;
     uint8_t stop;
     uint32_t timeout_ms;
     uint32_t timeout_char_ms;
@@ -95,6 +102,8 @@ typedef struct _machine_uart_obj_t {
     uint32_t mp_irq_trigger;
     uint32_t mp_irq_flags;
     mp_irq_obj_t *mp_irq_obj;
+    bool rx_idle_irq_pending;
+    uint32_t rx_idle_timeout;
     #endif
 } machine_uart_obj_t;
 
@@ -159,9 +168,6 @@ static void machine_uart_fill_rx_ring_buff(machine_uart_obj_t *self) {
 
 static void machine_uart_scb_isr(mp_obj_t hw_uart_obj) {
     machine_uart_obj_t *self = MP_OBJ_TO_PTR(hw_uart_obj);
-    #if MICROPY_PY_MACHINE_UART_IRQ
-    self->mp_irq_flags = 0; // Clear flags at the beginning of the ISR.
-    #endif
 
     if (0UL != (CY_SCB_RX_INTR & Cy_SCB_GetInterruptCause(self->scb_obj->scb))) {
         if (0UL != (CY_SCB_RX_INTR_NOT_EMPTY & Cy_SCB_GetRxInterruptStatusMasked(self->scb_obj->scb))) {
@@ -226,12 +232,24 @@ static void machine_uart_obj_make_or_reuse(machine_uart_obj_t **self_ptr, uint8_
 static inline uint8_t machine_uart_break_width(machine_uart_obj_t *self) {
     return 1 +  // Start bit
            self->bits +
-           (self->parity != CY_SCB_UART_PARITY_NONE ? 1 : 0) +
-           (self->stop == CY_SCB_UART_STOP_BITS_1 ? 1 : 2) +
+           (self->parity != mp_const_none ? 1 : 0) +
+           (self->stop) +
            1; // Extra bit, make the frame longer
 }
 
-static uint32_t machine_uart_baudrate_get_divider(machine_uart_obj_t *self) {
+static inline uint32_t machine_uart_frame_time_us(machine_uart_obj_t *self) {
+    /**
+     * Integer ceil division:
+     * (num + den - 1) / den == ceil(num / den).
+     * Here it computes ceil((bits_per_frame * 1e6) / baudrate), so frame time does
+     * not round down too aggressively when baudrate is high.
+     */
+    uint32_t bits_per_frame = machine_uart_break_width(self) - 1;
+    uint64_t num = (uint64_t)bits_per_frame * 1000000ULL;
+    return (uint32_t)((num + self->baudrate - 1) / self->baudrate);
+}
+
+static inline uint32_t machine_uart_baudrate_get_divider(machine_uart_obj_t *self) {
     uint32_t clock_freq = pclk_div_get_input_freq(self->scb_obj->clk);
     if (clock_freq == 0) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("failed to get clock frequency for UART(%u)"), self->id);
@@ -253,6 +271,51 @@ static uint32_t machine_uart_baudrate_get_divider(machine_uart_obj_t *self) {
     return divider;
 }
 
+static inline cy_en_scb_uart_parity_t machine_uart_get_pdl_parity(mp_obj_t parity) {
+    if (parity == mp_const_none) {
+        return CY_SCB_UART_PARITY_NONE;
+    }
+    switch (mp_obj_get_int(parity)) {
+        case 0:
+            return CY_SCB_UART_PARITY_EVEN;
+        case 1:
+            return CY_SCB_UART_PARITY_ODD;
+    }
+
+    return CY_SCB_UART_PARITY_NONE;
+}
+
+static inline char *machine_uart_get_parity_str(mp_obj_t parity) {
+    static char *parity_str[] = {
+        "0",
+        "1",
+        "None"
+    };
+
+    if (parity == mp_const_none) {
+        return parity_str[2];
+    }
+    switch (mp_obj_get_int(parity)) {
+        case 0:
+            return parity_str[0];
+        case 1:
+            return parity_str[1];
+    }
+
+    return parity_str[2];
+}
+
+static inline cy_en_scb_uart_stop_bits_t machine_uart_get_pdl_stop(uint8_t stop) {
+    switch (stop) {
+        case 1:
+            return CY_SCB_UART_STOP_BITS_1;
+        case 2:
+            return CY_SCB_UART_STOP_BITS_2;
+    }
+
+    return CY_SCB_UART_STOP_BITS_1;
+}
+
 static void machine_uart_hw_init(machine_uart_obj_t *self) {
     cy_stc_scb_uart_config_t config =
     {
@@ -266,8 +329,8 @@ static void machine_uart_hw_init(machine_uart_obj_t *self) {
 
         .enableMsbFirst = false,
         .dataWidth = self->bits,
-        .parity = self->parity,
-        .stopBits = self->stop,
+        .parity = machine_uart_get_pdl_parity(self->parity),
+        .stopBits = machine_uart_get_pdl_stop(self->stop),
         .enableInputFilter = false,
         .breakWidth = machine_uart_break_width(self),
         .dropOnFrameError = false,
@@ -348,14 +411,14 @@ static void mp_machine_uart_print(const mp_print_t *print, mp_obj_t self_in, mp_
         "rx="MP_HAL_PIN_FMT ", "
         "baudrate=%ld, "
         "bits=%u, "
-        "parity=%u, "
+        "parity=%s, "
         "stop=%u, ",
         self->id,
         mp_hal_pin_name(self->tx),
         mp_hal_pin_name(self->rx),
         self->baudrate,
         self->bits,
-        self->parity,
+        machine_uart_get_parity_str(self->parity),
         self->stop
         );
 
@@ -490,29 +553,17 @@ static void machine_uart_init_impl(machine_uart_obj_t **self_ptr, int uart_id, s
     }
 
     /* -- Parity -- */
-    mp_obj_t parity_arg = args[ARG_parity].u_obj;
-    uint8_t parity;
-    if (parity_arg == mp_const_none) {
-        parity = (uint8_t)CY_SCB_UART_PARITY_NONE;
-    } else {
-        int p = mp_obj_get_int(parity_arg);
-        if (p == 0) {
-            parity = (uint8_t)CY_SCB_UART_PARITY_EVEN;
-        } else if (p == 1) {
-            parity = (uint8_t)CY_SCB_UART_PARITY_ODD;
-        } else {
+    mp_obj_t parity = args[ARG_parity].u_obj;
+    if (parity != mp_const_none) {
+        int p = mp_obj_get_int(parity);
+        if (p != 0 && p != 1) {
             mp_raise_ValueError(MP_ERROR_TEXT("parity must be None, 0 (even) or 1 (odd)"));
         }
     }
 
     /* -- Stop bits -- */
-    int stop_arg = args[ARG_stop].u_int;
-    uint8_t stop;
-    if (stop_arg == 1) {
-        stop = (uint8_t)CY_SCB_UART_STOP_BITS_1;
-    } else if (stop_arg == 2) {
-        stop = (uint8_t)CY_SCB_UART_STOP_BITS_2;
-    } else {
+    uint8_t stop = args[ARG_stop].u_int;
+    if (stop != 1 && stop != 2) {
         mp_raise_ValueError(MP_ERROR_TEXT("stop bits must be 1 or 2"));
     }
 
@@ -567,6 +618,8 @@ static void machine_uart_init_impl(machine_uart_obj_t **self_ptr, int uart_id, s
     self->mp_irq_obj = NULL;
     self->mp_irq_trigger = 0;
     self->mp_irq_flags = 0;
+    self->rx_idle_irq_pending = false;
+    self->rx_idle_timeout = 0;
     #endif
 
     /* -- Initialise hardware -- */
@@ -719,17 +772,14 @@ static mp_uint_t mp_machine_uart_ioctl(mp_obj_t self_in, mp_uint_t request, uint
         }
     } else if (request == MP_STREAM_FLUSH) {
         /**
-         * Estimate the time required to shift out all remaining bytes from the TX hardware pipeline.
-         * Cy_SCB_UART_GetNumInTxFifo() returns the exact byte count in the TX FIFO but explicitly
-         * excludes the TX shifter register (1 byte). Adding 1 accounts for that shifter. The sum is
-         * multiplied by 13 bits per symbol (1 start + 8 data + 2 stop, 1 parity), and multiplied by 2
-         * (for safety margin) and divided by the baudrate to get the duration in milliseconds.
-         * uint32_t is sufficient: max FIFO is < 256 bytes, so the worst-case duration is well within
-         * the uint32_t range even at the lowest supported baud rates.
+         * Calculate the timeout based on the number of TX FIFO frame
+         * left (+ some margin) and the frame time.
+         * This is to avoid waiting too long for the flush to complete.
          */
-        uint32_t timeout = mp_hal_ticks_ms() + (1
-            + Cy_SCB_UART_GetNumInTxFifo(self->scb_obj->scb)
-            ) * 13000 * 2 / self->baudrate;
+        #define MACHINE_UART_FLUSH_EXTRA_FRAMES_MARGIN 10
+        uint64_t flush_time_us = (uint64_t)(MACHINE_UART_FLUSH_EXTRA_FRAMES_MARGIN + Cy_SCB_UART_GetNumInTxFifo(self->scb_obj->scb)) * machine_uart_frame_time_us(self);
+        uint32_t flush_time_ms = us_to_ms_ceil(flush_time_us);
+        uint32_t timeout = mp_hal_ticks_ms() + flush_time_ms;
         do {
             if (mp_machine_uart_txdone(self)) {
                 return 0;
@@ -756,23 +806,60 @@ void machine_uart_deinit_all() {
 
 #if MICROPY_PY_MACHINE_UART_IRQ
 
-#define MP_UART_ALLOWED_FLAGS (CY_SCB_RX_INTR_NOT_EMPTY | \
+#define MP_UART_ALLOWED_FLAGS (UART_IRQ_RXIDLE | \
     CY_SCB_RX_INTR_UART_BREAK_DETECT | \
     CY_SCB_TX_INTR_UART_DONE)
 
+static mp_obj_t machine_uart_rx_idle_soft(mp_obj_t self_in);
+static MP_DEFINE_CONST_FUN_OBJ_1(machine_uart_rx_idle_soft_obj, machine_uart_rx_idle_soft);
+
+
+static mp_obj_t machine_uart_rx_idle_soft(mp_obj_t self_in) {
+    /**
+     * The irq handle is only scheduled when no bytes
+     * have been received within the frame time.
+     * This avoid calling the irq handler for every NOT_EMPTY
+     * interrupt when a burst of bytes is received.
+     *  */
+    machine_uart_obj_t *self = MP_OBJ_TO_PTR(self_in);
+
+    if (self->rx_idle_irq_pending) {
+        if (mp_hal_ticks_ms() >= self->rx_idle_timeout) {
+            if (ringbuf_avail(&self->rx_ringbuf) > 0) {
+                mp_irq_handler(self->mp_irq_obj);
+            }
+            self->rx_idle_irq_pending = false;
+        } else {
+            mp_sched_schedule(MP_OBJ_FROM_PTR(&machine_uart_rx_idle_soft_obj), MP_OBJ_FROM_PTR(self));
+        }
+    }
+
+    return mp_const_none;
+}
+
 static void machine_uart_irq_rx_idle(machine_uart_obj_t *self) {
     /**
-     * Use CY_SCB_RX_INTR_NOT_EMPTY as RX_IDLE combined with
-     * checking if the RX FIFO is empty. Therefore this function
-     * will be called after reading all the data in the
-     * RX FIFO.
+     * If an IRQ_IDLE is pending, the timeout is just updated
+     * after a NOT_EMPTY interrupt has triggered a RX FIFO buffer
+     * read.
+     * Otherwise, the soft irq handler is scheduled. The
+     * soft irq handler checks if the timeout is expired, and
+     * if so, calls the user irq handler. If not, it reschedules itself
+     * to check again after the timeout.
      */
     if ((self->mp_irq_obj != NULL) &&
         (self->mp_irq_obj->handler != NULL) &&
-        (self->mp_irq_trigger & CY_SCB_RX_INTR_NOT_EMPTY) &&
-        (Cy_SCB_UART_GetNumInRxFifo(self->scb_obj->scb) == 0)) {
-        self->mp_irq_flags |= CY_SCB_RX_INTR_NOT_EMPTY;
-        mp_irq_handler(self->mp_irq_obj);
+        (self->mp_irq_trigger & UART_IRQ_RXIDLE)) {
+        self->mp_irq_flags |= UART_IRQ_RXIDLE;
+
+        /* Number of frame times to wait before triggering RX idle IRQ */
+        #define RX_IDLE_NUM_OF_FRAMES_MARGIN 5
+        uint32_t frame_time_ms = us_to_ms_ceil(machine_uart_frame_time_us(self));
+        self->rx_idle_timeout = mp_hal_ticks_ms() + frame_time_ms * RX_IDLE_NUM_OF_FRAMES_MARGIN;
+        if (!self->rx_idle_irq_pending) {
+            self->rx_idle_irq_pending = true;
+            mp_sched_schedule(MP_OBJ_FROM_PTR(&machine_uart_rx_idle_soft_obj), MP_OBJ_FROM_PTR(self));
+        }
     }
 }
 
@@ -804,7 +891,7 @@ static void machine_uart_irq_scb_config(machine_uart_obj_t *self, bool enable) {
              * Clear any stale sticky status before unmasking to prevent a
              * spurious ISR from a break that occurred before this irq() call.
              */
-            Cy_SCB_ClearRxInterrupt(self->scb_obj->scb, CY_SCB_RX_INTR_UART_BREAK_DETECT);
+            Cy_SCB_ClearRxInterrupt(self->scb_obj->scb, CY_SCB_RX_INTR_UART_BREAK_DETECT | CY_SCB_RX_INTR_NOT_EMPTY);
             Cy_SCB_SetRxInterruptMask(self->scb_obj->scb, CY_SCB_RX_INTR_UART_BREAK_DETECT | CY_SCB_RX_INTR_NOT_EMPTY);
         }
         if (self->mp_irq_trigger & CY_SCB_TX_INTR_UART_DONE) {
@@ -836,7 +923,9 @@ static mp_uint_t uart_irq_trigger(mp_obj_t self_in, mp_uint_t new_trigger) {
 static mp_uint_t uart_irq_info(mp_obj_t self_in, mp_uint_t info_type) {
     machine_uart_obj_t *self = MP_OBJ_TO_PTR(self_in);
     if (info_type == MP_IRQ_INFO_FLAGS) {
-        return self->mp_irq_flags;
+        mp_uint_t flags = self->mp_irq_flags;
+        self->mp_irq_flags = 0;
+        return flags;
     } else if (info_type == MP_IRQ_INFO_TRIGGERS) {
         return self->mp_irq_trigger;
     }

--- a/ports/psoc-edge/machine_uart.c
+++ b/ports/psoc-edge/machine_uart.c
@@ -49,6 +49,7 @@
 #include "mphalport.h"
 #include "machine_scb.h"
 #include "sys_int.h"
+#include "clk.h"
 
 /******************************************************************************/
 // Defaults and constants
@@ -76,6 +77,7 @@ typedef struct _machine_uart_obj_t {
     mp_obj_base_t base;
     int id;                         // id matches the SCB id.
     machine_scb_obj_t *scb_obj;
+    pclk_div_obj_t *pclk_div;
     mp_hal_pin_obj_t tx;
     mp_hal_pin_obj_t rx;
     mp_hal_pin_obj_t rts;
@@ -209,7 +211,9 @@ static void machine_uart_obj_make_or_reuse(machine_uart_obj_t **self_ptr, uint8_
         if (machine_scb_is_free(id)) {
             (*self_ptr) = mp_machine_uart_obj_alloc();
             (*self_ptr)->id = id;
+            (*self_ptr)->pclk_div = NULL;
             (*self_ptr)->scb_obj = machine_scb_obj_alloc(id, *self_ptr, machine_uart_scb_isr);
+            pclk_div_slave_init((*self_ptr)->scb_obj->clk, (*self_ptr)->scb_obj->slave_nr);
         } else {
             mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("SCB %u is already in use by a machine.I2C or machine.SPI instance."), id);
         }
@@ -217,21 +221,7 @@ static void machine_uart_obj_make_or_reuse(machine_uart_obj_t **self_ptr, uint8_
     }
 }
 
-static void machine_uart_baudrate_set(machine_uart_obj_t *self) {
-    /**
-     * TODO: Review clock configuration and formula to calculate the divider value.
-     *       Clock sources, path and proper divider configuration.
-     * Given the clock peripheral = 100 MHz
-     * Oversampling = 12 (fixed for now)
-     * The formula to calculate the divider value is: divider = clock / (baudrate * oversample)
-     */
-    #define CLOCK_PERIPHERAL_FREQ_HZ (100000000UL)
-
-    Cy_SysClk_PeriphAssignDivider(self->scb_obj->clk, CY_SYSCLK_DIV_16_BIT, 0UL);
-    uint32_t divider = CLOCK_PERIPHERAL_FREQ_HZ / (self->baudrate * 12UL);
-    Cy_SysClk_PeriphSetDivider(CY_SYSCLK_DIV_16_BIT, 0UL, divider);
-    Cy_SysClk_PeriphEnableDivider(CY_SYSCLK_DIV_16_BIT, 0UL);
-}
+#define MACHINER_UART_OVERSAMPLING (12UL)
 
 static inline uint8_t machine_uart_break_width(machine_uart_obj_t *self) {
     return 1 +  // Start bit
@@ -239,6 +229,28 @@ static inline uint8_t machine_uart_break_width(machine_uart_obj_t *self) {
            (self->parity != CY_SCB_UART_PARITY_NONE ? 1 : 0) +
            (self->stop == CY_SCB_UART_STOP_BITS_1 ? 1 : 2) +
            1; // Extra bit, make the frame longer
+}
+
+static uint32_t machine_uart_baudrate_get_divider(machine_uart_obj_t *self) {
+    uint32_t clock_freq = pclk_div_get_input_freq(self->scb_obj->clk);
+    if (clock_freq == 0) {
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("failed to get clock frequency for UART(%u)"), self->id);
+    }
+
+    uint32_t divider = (uint32_t)(clock_freq / (self->baudrate * MACHINER_UART_OVERSAMPLING));
+    /*
+     * No fractional divider should be required:
+     * Experimentally:
+     * - baud rates 2400, 4800, 9600, 19200 bps:
+     *   The error between the actual baud rate
+     *   and the requested is < 1% for 16 bits divider
+     * - baud rates 115200, 230400, 460800 bps:
+     *   The error between the actual baud rate and
+     *   the requested is < 1% for 8 bits divider
+     *
+     */
+
+    return divider;
 }
 
 static void machine_uart_hw_init(machine_uart_obj_t *self) {
@@ -250,7 +262,7 @@ static void machine_uart_hw_init(machine_uart_obj_t *self) {
         .irdaInvertRx = false,
         .irdaEnableLowPowerReceiver = false,
 
-        .oversample = 12UL,
+        .oversample = MACHINER_UART_OVERSAMPLING,
 
         .enableMsbFirst = false,
         .dataWidth = self->bits,
@@ -279,6 +291,12 @@ static void machine_uart_hw_init(machine_uart_obj_t *self) {
         .txFifoIntEnableMask = 0UL,
     };
 
+    uint32_t divider = machine_uart_baudrate_get_divider(self);
+    self->pclk_div = pclk_div_init(self->scb_obj->clk, divider, 0);
+    if (self->pclk_div == NULL) {
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("failed to initialize clock divider for UART(%u)"), self->id);
+    }
+
     cy_en_scb_uart_status_t rslt = Cy_SCB_UART_Init(self->scb_obj->scb, &config, &self->ctx);
     uart_assert_raise_val("failed to initialize UART hardware, error code: %d", rslt);
 
@@ -291,6 +309,8 @@ static void machine_uart_hw_init(machine_uart_obj_t *self) {
 static void machine_uart_hw_deinit(machine_uart_obj_t *self) {
     Cy_SCB_UART_Disable(self->scb_obj->scb, &self->ctx);
     sys_int_deinit(&self->scb_obj->irq);
+    pclk_div_deinit(self->pclk_div);
+    self->pclk_div = NULL;
 }
 
 static bool machine_uart_rx_wait(machine_uart_obj_t *self, uint32_t timeout_ms) {
@@ -552,7 +572,6 @@ static void machine_uart_init_impl(machine_uart_obj_t **self_ptr, int uart_id, s
     if (nlr_push(&nlr) == 0) {
         ringbuf_alloc(&self->rx_ringbuf, args[ARG_rxbuf].u_int);
         mp_hal_periph_pins_af_init(uart_pins_af_config, pin_num);
-        machine_uart_baudrate_set(self);
         machine_uart_hw_init(self);
         nlr_pop();
     } else {
@@ -596,6 +615,7 @@ static mp_obj_t mp_machine_uart_make_new(const mp_obj_type_t *type, size_t n_arg
 static void mp_machine_uart_deinit(machine_uart_obj_t *self) {
     machine_uart_hw_deinit(self);
     m_del(uint8_t, self->rx_ringbuf.buf, self->rx_ringbuf.size);
+    pclk_div_slave_deinit(self->scb_obj->clk, self->scb_obj->slave_nr);
     machine_scb_obj_free(self->scb_obj);
     mp_machine_uart_obj_free(self);
 }

--- a/ports/psoc-edge/machine_uart.c
+++ b/ports/psoc-edge/machine_uart.c
@@ -221,7 +221,7 @@ static void machine_uart_obj_make_or_reuse(machine_uart_obj_t **self_ptr, uint8_
     }
 }
 
-#define MACHINER_UART_OVERSAMPLING (12UL)
+#define MACHINE_UART_OVERSAMPLING (12UL)
 
 static inline uint8_t machine_uart_break_width(machine_uart_obj_t *self) {
     return 1 +  // Start bit
@@ -237,7 +237,7 @@ static uint32_t machine_uart_baudrate_get_divider(machine_uart_obj_t *self) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("failed to get clock frequency for UART(%u)"), self->id);
     }
 
-    uint32_t divider = (uint32_t)(clock_freq / (self->baudrate * MACHINER_UART_OVERSAMPLING));
+    uint32_t divider = (uint32_t)(clock_freq / (self->baudrate * MACHINE_UART_OVERSAMPLING));
     /*
      * No fractional divider should be required:
      * Experimentally:
@@ -262,7 +262,7 @@ static void machine_uart_hw_init(machine_uart_obj_t *self) {
         .irdaInvertRx = false,
         .irdaEnableLowPowerReceiver = false,
 
-        .oversample = MACHINER_UART_OVERSAMPLING,
+        .oversample = MACHINE_UART_OVERSAMPLING,
 
         .enableMsbFirst = false,
         .dataWidth = self->bits,
@@ -343,12 +343,14 @@ static bool machine_uart_tx_wait(machine_uart_obj_t *self, uint32_t timeout_ms) 
 
 static void mp_machine_uart_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     machine_uart_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_printf(print, "UART(tx="MP_HAL_PIN_FMT ", "
+    mp_printf(print, "UART(id=%u, "
+        "tx="MP_HAL_PIN_FMT ", "
         "rx="MP_HAL_PIN_FMT ", "
         "baudrate=%ld, "
         "bits=%u, "
         "parity=%u, "
         "stop=%u, ",
+        self->id,
         mp_hal_pin_name(self->tx),
         mp_hal_pin_name(self->rx),
         self->baudrate,

--- a/ports/psoc-edge/main.c
+++ b/ports/psoc-edge/main.c
@@ -104,6 +104,12 @@ extern void machine_timer_deinit_all(void);
 extern void machine_wdt_deinit(void);
 extern void machine_deinit(void);
 
+/**
+ * TODO: This will later directly handled by
+ * the static machine_uart REPL UART instance.
+ */
+extern void pclk_div_repl_uart_init(void);
+
 void micropython_task(void *arg);
 #if MICROPY_PY_FREERTOS
 static TaskHandle_t mpy_task_handle;
@@ -152,6 +158,10 @@ int main(void) {
     __enable_irq();
 
     /* Initialize retarget-io middleware */
+    /**
+     * TODO: Enable once not relying on bsp initialization
+     * pclk_div_repl_uart_init();
+     */
     init_retarget_io();
 
     #if MICROPY_PY_FREERTOS

--- a/ports/psoc-edge/main.c
+++ b/ports/psoc-edge/main.c
@@ -110,6 +110,12 @@ extern void machine_deinit(void);
  */
 extern void pclk_div_repl_uart_init(void);
 
+/**
+ * TODO: This will later directly handled by
+ * the static machine_uart REPL UART instance.
+ */
+extern void pclk_div_repl_uart_init(void);
+
 void micropython_task(void *arg);
 #if MICROPY_PY_FREERTOS
 static TaskHandle_t mpy_task_handle;

--- a/ports/psoc-edge/main.c
+++ b/ports/psoc-edge/main.c
@@ -110,12 +110,6 @@ extern void machine_deinit(void);
  */
 extern void pclk_div_repl_uart_init(void);
 
-/**
- * TODO: This will later directly handled by
- * the static machine_uart REPL UART instance.
- */
-extern void pclk_div_repl_uart_init(void);
-
 void micropython_task(void *arg);
 #if MICROPY_PY_FREERTOS
 static TaskHandle_t mpy_task_handle;

--- a/ports/psoc-edge/systick.c
+++ b/ports/psoc-edge/systick.c
@@ -128,6 +128,7 @@ mp_uint_t mp_hal_ticks_cpu(void) {
 
 void mp_hal_delay_ms(mp_uint_t ms) {
     mp_uint_t start = mp_hal_ticks_ms();
+    mp_event_handle_nowait();
     while (mp_hal_ticks_ms() - start < ms) {
         mp_event_handle_nowait();
     }
@@ -135,6 +136,7 @@ void mp_hal_delay_ms(mp_uint_t ms) {
 
 void mp_hal_delay_us(mp_uint_t us) {
     mp_uint_t start = mp_hal_ticks_us();
+    mp_event_handle_nowait();
     while (mp_hal_ticks_us() - start < us) {
         mp_event_handle_nowait();
     }

--- a/tests/extmod/machine_uart_irq_txidle.py
+++ b/tests/extmod/machine_uart_irq_txidle.py
@@ -19,6 +19,11 @@ def irq(u):
 
 text = "Hello World" * 20
 
+char_margin = 10  # number of characters to wait before and after the expected IRQ firing
+
+if "psoc-edge" in sys.platform:
+    char_margin = 100
+
 # Test that the IRQ is called after the write has completed.
 for bits_per_s in (2400, 9600, 115200):
     uart = UART(*uart_loopback_args, baudrate=bits_per_s, **uart_loopback_kwargs)
@@ -27,12 +32,12 @@ for bits_per_s in (2400, 9600, 115200):
     # The IRQ_TXIDLE shall trigger after the message has been sent. Thus
     # the test marks a time window close to the expected of the sending
     # and the time at which the IRQ should have been fired.
-    # It is just a rough estimation of 10 characters before and
-    # 20 characters after the data's end.
+    # It is just a rough estimation of 'char_margin' characters before and
+    # '2 x char_margin' characters after the data's end.
 
     bits_per_char = 10  # 1(startbit) + 8(bits) + 1(stopbit) + 0(parity)
-    start_time_us = (len(text) - 10) * bits_per_char * 1_000_000 // bits_per_s
-    window_ms = 20 * bits_per_char * 1_000 // bits_per_s + 1
+    start_time_us = (len(text) - char_margin) * bits_per_char * 1_000_000 // bits_per_s
+    window_ms = (2 * char_margin) * bits_per_char * 1_000 // bits_per_s + 1
 
     print("write", bits_per_s)
     uart.write(text)

--- a/tests/extmod/machine_uart_tx.py
+++ b/tests/extmod/machine_uart_tx.py
@@ -26,6 +26,8 @@ elif "mimxrt" in sys.platform:
     bit_margin = 1
 elif "nrf" in sys.platform:
     timing_margin_us = 130
+elif "psoc-edge" in sys.platform:
+    timing_margin_us = 190
 elif "pyboard" in sys.platform:
     initial_delay_ms = 50  # UART sends idle frame after init, so wait for that
     bit_margin = 1  # first start-bit must wait to sync with the UART clock


### PR DESCRIPTION
This PR contains the following PRs #130, #133, #143 #153, #151, #167. 

Summary:  

* Add the clk shared lib (abstract configuration and manage shared access to resources) 
* Enable all SCB classes (UART, I2C, SPI) based on the clk.
* UART refinement from the upstream PR (including tests enablement).
* Suite test enablement.

The rest of the machines classes CLK usage will come in separate PRs.
Please @Infineon/micropython start using the clk.h class for peripheral clocks config. 