### PR TITLE
psoc-edge/machine-pwm: Use clk shared lib for clock divider.

### DIFF
--- a/ports/psoc-edge/machine_pwm.c
+++ b/ports/psoc-edge/machine_pwm.c
@@ -28,12 +28,10 @@
 #include "py/mphal.h"
 #include "modmachine.h"
 #include "cy_gpio.h"
-#include "cy_sysclk.h"
 #include "cy_tcpwm_pwm.h"
-#include "cycfg_peripherals.h"
-#include "cycfg_peripheral_clocks.h"
 #include "mphalport.h"
 #include "machine_pin.h"
+#include "clk.h"
 #include "tcpwm.h"
 #include "genhdr/pins_af.h"
 
@@ -51,6 +49,7 @@ typedef struct _machine_pwm_obj_t {
     const machine_pin_af_obj_t *pin_af;      /**< TCPWM alternate function selected for the output pin */
     uint32_t counter_num;                   /**< TCPWM0 counter index assigned to this PWM instance */
     en_clk_dst_t pclk_dst;                  /**< PCLK clock destination for this counter's clock assignment */
+    pclk_div_obj_t *pclk_div;
     uint32_t frequency;                     /**< PWM output frequency in Hz */
     duty_type_t duty_type;                  /**< Indicates whether duty is set as DUTY_U16 or DUTY_NS */
     mp_int_t duty;                          /**< Duty cycle value: 0-65535 if DUTY_U16, nanoseconds if DUTY_NS */
@@ -59,13 +58,7 @@ typedef struct _machine_pwm_obj_t {
 
 // Sentinel value meaning "no trigger"; masked with 0x3U when assigned to 2-bit inputMode fields.
 #define CYBSP_PWM_LED_CTRL_INPUT_DISABLED 0x7U
-
-// TCPWM base clock: PCLK 100 MHz divided to 1 MHz for usable duty resolution at practical
-// frequencies. Divider register value 99 = divisor 100: 100 MHz / 100 = 1 MHz.
-// At 1 MHz a 32-bit counter gives period0 = 1,000,000 at 1 Hz and 1,000 at 1 kHz.
-// Maximum PWM output frequency = PWM_TCPWM_CLK_HZ / 2 = 500 kHz (period0 = 2).
 #define PWM_TCPWM_CLK_HZ        1000000UL
-#define PWM_TCPWM_CLK_DIV_VAL   99U
 #define PWM_GROUP1_PERIOD_MAX   (0xFFFFU)
 
 #define pwm_assert_raise_val(msg, ret)   if (ret != CY_RSLT_SUCCESS) { \
@@ -83,7 +76,6 @@ typedef struct _machine_pwm_obj_t {
  #define pwm_duty_cycle_u16_to_compare(duty_u16, period) ((int)(((float)(duty_u16 + 1) / (float)65536) * (float)period))
 
 static machine_pwm_obj_t *pwm_obj[MICROPY_PY_MACHINE_PWM_MAX_OBJS] = { NULL };
-static bool pwm_clk_configured = false; // true after the shared divider is programmed to PWM_TCPWM_CLK_HZ
 
 static const machine_pin_af_obj_t *pwm_pin_af_find_and_alloc(machine_pwm_obj_t *self) {
     bool has_pwm_af = false;
@@ -196,6 +188,35 @@ static void pwm_config(machine_pwm_obj_t *self) {
     self->pwm_obj.invertPWMOut = self->invert;
 }
 
+
+static void clk_config(machine_pwm_obj_t *self) {
+    // TCPWM base clock: PCLK 100 MHz divided to 1 MHz for usable duty resolution at practical
+    // frequencies. Divider register value 99 = divisor 100: 100 MHz / 100 = 1 MHz.
+    // At 1 MHz a 32-bit counter gives period0 = 1,000,000 at 1 Hz and 1,000 at 1 kHz.
+    // Maximum PWM output frequency = PWM_TCPWM_CLK_HZ / 2 = 500 kHz (period0 = 2).
+
+    /**
+     * TODO: The divider does not need to be fixed, it can be adjusted based on the
+     * required frequency. This will allow for a wider range of frequencies to be
+     * used.
+     */
+
+    pclk_div_slave_init(self->pclk_dst, CY_MMIO_TCPWM0_SLAVE_NR);
+
+    uint32_t clock_freq = pclk_div_get_input_freq(self->pclk_dst);
+    if (clock_freq == 0) {
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("failed to get clock frequency for PWM(%u)"), self->counter_num);
+    }
+
+    uint32_t divider = (uint32_t)(clock_freq / PWM_TCPWM_CLK_HZ) - 1;
+
+    self->pclk_div = pclk_div_init(self->pclk_dst, divider, 0);
+    if (self->pclk_div == NULL) {
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("failed to init pclk divider for PWM(%u)"), self->counter_num);
+    }
+
+}
+
 // Parse freq/duty_u16/duty_ns/invert args, configure the hardware, and start the PWM counter.
 static void mp_machine_pwm_init_helper(machine_pwm_obj_t *self, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_freq, ARG_duty_u16, ARG_duty_ns, ARG_invert};
@@ -245,19 +266,7 @@ static void mp_machine_pwm_init_helper(machine_pwm_obj_t *self, size_t n_args, c
     /* Route the TCPWM output to the configured GPIO pin */
     pwm_pin_config(self);
 
-    /* Program the shared 16-bit divider to PWM_TCPWM_CLK_HZ on the first PWM init, then
-     * connect it to this counter's PCLK input. All channels share divider CYBSP_PWM_LED_CTRL_CLK_DIV_NUM
-     * so the reprogramming only needs to happen once. */
-    if (!pwm_clk_configured) {
-        Cy_SysClk_PeriPclkDisableDivider((en_clk_dst_t)CYBSP_PWM_LED_CTRL_CLK_DIV_GRP_NUM,
-            CY_SYSCLK_DIV_16_BIT, CYBSP_PWM_LED_CTRL_CLK_DIV_NUM);
-        Cy_SysClk_PeriPclkSetDivider((en_clk_dst_t)CYBSP_PWM_LED_CTRL_CLK_DIV_GRP_NUM,
-            CY_SYSCLK_DIV_16_BIT, CYBSP_PWM_LED_CTRL_CLK_DIV_NUM, PWM_TCPWM_CLK_DIV_VAL);
-        Cy_SysClk_PeriPclkEnableDivider((en_clk_dst_t)CYBSP_PWM_LED_CTRL_CLK_DIV_GRP_NUM,
-            CY_SYSCLK_DIV_16_BIT, CYBSP_PWM_LED_CTRL_CLK_DIV_NUM);
-        pwm_clk_configured = true;
-    }
-    Cy_SysClk_PeriPclkAssignDivider(self->pclk_dst, CY_SYSCLK_DIV_16_BIT, CYBSP_PWM_LED_CTRL_CLK_DIV_NUM);
+    clk_config(self);
 
     cy_en_tcpwm_status_t result = Cy_TCPWM_PWM_Init(TCPWM0,
         self->counter_num, &self->pwm_obj);
@@ -382,6 +391,8 @@ static void mp_machine_pwm_deinit(machine_pwm_obj_t *self) {
     Cy_TCPWM_PWM_Disable(TCPWM0, self->counter_num);
     pwm_pin_restore(self->pin);
     machine_tcpwm_counter_free(self->counter_num, MP_OBJ_FROM_PTR(self));
+    pclk_div_deinit(self->pclk_div);
+    pclk_div_slave_deinit(self->pclk_dst, CY_MMIO_TCPWM0_SLAVE_NR);
     pwm_obj_free(self);
 }
 

--- a/ports/psoc-edge/machine_pwm.c
+++ b/ports/psoc-edge/machine_pwm.c
@@ -189,7 +189,7 @@ static void pwm_config(machine_pwm_obj_t *self) {
 }
 
 
-static void clk_config(machine_pwm_obj_t *self) {
+static void machine_pwm_configure_clock(machine_pwm_obj_t *self) {
     // TCPWM base clock: PCLK 100 MHz divided to 1 MHz for usable duty resolution at practical
     // frequencies. Divider register value 99 = divisor 100: 100 MHz / 100 = 1 MHz.
     // At 1 MHz a 32-bit counter gives period0 = 1,000,000 at 1 Hz and 1,000 at 1 kHz.
@@ -266,7 +266,7 @@ static void mp_machine_pwm_init_helper(machine_pwm_obj_t *self, size_t n_args, c
     /* Route the TCPWM output to the configured GPIO pin */
     pwm_pin_config(self);
 
-    clk_config(self);
+    machine_pwm_configure_clock(self);
 
     cy_en_tcpwm_status_t result = Cy_TCPWM_PWM_Init(TCPWM0,
         self->counter_num, &self->pwm_obj);
@@ -311,6 +311,8 @@ static mp_obj_t mp_machine_pwm_make_new(const mp_obj_type_t *type, size_t n_args
 
     self->pin = pin;
     self->counter_num = UINT32_MAX;
+    self->pclk_div = NULL;
+
     nlr_buf_t nl_af;
     if (nlr_push(&nl_af) == 0) {
         self->pin_af = pwm_pin_af_find_and_alloc(self);
@@ -377,6 +379,7 @@ static mp_obj_t mp_machine_pwm_make_new(const mp_obj_type_t *type, size_t n_args
         mp_machine_pwm_init_helper(self, n_args - 1, args + 1, &kw_args);
         nlr_pop();
     } else {
+        pclk_div_deinit(self->pclk_div);
         machine_tcpwm_counter_free(self->counter_num, MP_OBJ_FROM_PTR(self));
         pwm_pin_restore(self->pin);
         pwm_obj_free(self);

--- a/ports/psoc-edge/machine_pwm.c
+++ b/ports/psoc-edge/machine_pwm.c
@@ -392,7 +392,14 @@ static void mp_machine_pwm_deinit(machine_pwm_obj_t *self) {
     pwm_pin_restore(self->pin);
     machine_tcpwm_counter_free(self->counter_num, MP_OBJ_FROM_PTR(self));
     pclk_div_deinit(self->pclk_div);
-    pclk_div_slave_deinit(self->pclk_dst, CY_MMIO_TCPWM0_SLAVE_NR);
+    /**
+     * TODO: The TCPWM0 MMIO slave is shared across Timer and PWM instances.
+     * Tearing it down here can break an active Timer that is using a different
+     * counter, which causes the TCPWM ownership test to hang after a fallback PWM.
+     * Review with a shared usage of the TCPWM0 MMIO slave and implement a reference counting mechanism to avoid
+     * tearing down the TCPWM0 MMIO slave when other instances are still using it.
+     */
+    // pclk_div_slave_deinit(self->pclk_dst, CY_MMIO_TCPWM0_SLAVE_NR);
     pwm_obj_free(self);
 }
 

--- a/ports/psoc-edge/machine_pwm.c
+++ b/ports/psoc-edge/machine_pwm.c
@@ -200,6 +200,10 @@ static void machine_pwm_configure_clock(machine_pwm_obj_t *self) {
      * required frequency. This will allow for a wider range of frequencies to be
      * used.
      */
+    if (self->pclk_div != NULL) {
+        pclk_div_deinit(self->pclk_div);
+        self->pclk_div = NULL;
+    }
 
     pclk_div_slave_init(self->pclk_dst, CY_MMIO_TCPWM0_SLAVE_NR);
 

--- a/ports/psoc-edge/machine_timer.c
+++ b/ports/psoc-edge/machine_timer.c
@@ -34,6 +34,7 @@
 #include "shared/runtime/mpirq.h"
 #include "sys_int.h"
 
+#include "clk.h"
 #include "cy_tcpwm_counter.h"
 #include "cy_tcpwm.h"
 #include "cy_sysclk.h"
@@ -68,6 +69,7 @@ typedef struct _machine_timer_obj_t {
     uint8_t id;                  // 0..31
     uint32_t counter_num;        // TCPWM0 counter index mapped from timer_hw[]
     en_clk_dst_t pclk_dst;
+    pclk_div_obj_t *pclk_div;
     uint16_t mode;               // TIMER_MODE_ONE_SHOT or TIMER_MODE_PERIODIC
     mp_obj_t callback;
     bool ishard;
@@ -112,23 +114,34 @@ static IRQn_Type machine_timer_counter_irq(uint32_t counter_num) {
 
 static machine_timer_obj_t *timer_obj[MACHINE_TIMER_NUM_INSTANCES] = { NULL };
 
-static bool machine_timer_clock_configured = false;
 
-static void machine_timer_configure_clock(void) {
-    if (machine_timer_clock_configured) {
+static void machine_timer_configure_clock(machine_timer_obj_t *self) {
+    if (self->pclk_div != NULL) {
         return;
     }
 
-    // Keep timer periods stable even when other modules stop configuring this divider.
-    cy_rslt_t rslt = mtb_hal_clock_set_peri_clock_freq(&CYBSP_GENERAL_PURPOSE_TIMER_clock_ref,
-        TIMER_CLK_HZ, 1000);
-    if (rslt != CY_RSLT_SUCCESS) {
-        mp_raise_msg_varg(&mp_type_ValueError,
-            MP_ERROR_TEXT("Timer clock setup failed (0x%lx)"),
-            (unsigned long)rslt);
+    pclk_div_slave_init(self->pclk_dst, CY_MMIO_TCPWM0_SLAVE_NR);
+
+    uint32_t clk_freq = pclk_div_get_input_freq(self->pclk_dst);
+
+    if (clk_freq == 0U) {
+        mp_raise_ValueError(MP_ERROR_TEXT("failed to get timer input clock"));
     }
 
-    machine_timer_clock_configured = true;
+    // HAL-like divider selection for f_out = f_in / ((divider + 1) + frac/32).
+    // Pick the smallest divisor that keeps output at or below TIMER_CLK_HZ.
+    uint64_t scaled_div = ((uint64_t)clk_freq * 32ULL + TIMER_CLK_HZ - 1ULL) / TIMER_CLK_HZ;
+    if (scaled_div < 32ULL) {
+        scaled_div = 32ULL;
+    }
+
+    uint32_t divider = (uint32_t)(scaled_div / 32ULL) - 1U;
+    uint8_t divider_frac = (uint8_t)(scaled_div % 32ULL);
+
+    self->pclk_div = pclk_div_init(self->pclk_dst, divider, divider_frac);
+    if (self->pclk_div == NULL) {
+        mp_raise_ValueError(MP_ERROR_TEXT("Timer clock dividers exhausted"));
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -174,7 +187,7 @@ static const cy_israddress machine_timer_irq_handlers[MACHINE_TIMER_NUM_INSTANCE
 // ---------------------------------------------------------------------------
 
 static void machine_timer_start(machine_timer_obj_t *self, uint32_t period_ticks) {
-    machine_timer_configure_clock();
+    machine_timer_configure_clock(self);
 
     // Stop counter and unregister any existing IRQ before reconfiguring.
     Cy_TCPWM_Counter_Disable(TCPWM0, self->counter_num);
@@ -182,10 +195,6 @@ static void machine_timer_start(machine_timer_obj_t *self, uint32_t period_ticks
         sys_int_deinit(&self->irq_cfg);
         self->active = false;
     }
-
-    // Connect the shared 1 MHz PCLK divider to this counter's clock input.
-    Cy_SysClk_PeriPclkAssignDivider(self->pclk_dst,
-        CY_SYSCLK_DIV_16_BIT, CYBSP_GENERAL_PURPOSE_TIMER_CLK_DIV_NUM);
 
     // The counter counts 0 → period_reg (inclusive) then fires TC.
     // So period_reg = period_ticks - 1.
@@ -353,6 +362,7 @@ static mp_obj_t machine_timer_make_new(const mp_obj_type_t *type,
     self->callback = mp_const_none;
     self->ishard = false;
     self->active = false;
+    self->pclk_div = NULL;
     self->irq_cfg.irq_num = machine_timer_counter_irq(self->counter_num);
 
     nlr_buf_t nl;
@@ -365,6 +375,8 @@ static mp_obj_t machine_timer_make_new(const mp_obj_type_t *type,
         }
         nlr_pop();
     } else {
+        pclk_div_deinit(self->pclk_div);
+        self->pclk_div = NULL;
         machine_tcpwm_counter_free(self->counter_num, MP_OBJ_FROM_PTR(self));
         timer_obj[id] = NULL;
         nlr_jump(nl.ret_val);
@@ -397,6 +409,10 @@ static mp_obj_t machine_timer_deinit(mp_obj_t self_in) {
     self->callback = mp_const_none;
     self->ishard = false;
     self->active = false;
+    pclk_div_deinit(self->pclk_div);
+    /* TODO: Review obj initialization in general... */
+    // pclk_div_slave_deinit(self->pclk_dst, CY_MMIO_TCPWM0_SLAVE_NR);
+    self->pclk_div = NULL;
     machine_tcpwm_counter_free(self->counter_num, MP_OBJ_FROM_PTR(self));
     timer_obj[self->id] = NULL;
     return mp_const_none;

--- a/tests/ports/psoc-edge/board_only_hw/single/timer.py.exp
+++ b/tests/ports/psoc-edge/board_only_hw/single/timer.py.exp
@@ -10,6 +10,7 @@ Periodic timer triggered
 Periodic timer triggered
 Periodic timer triggered
 Periodic timer triggered
+Periodic timer triggered
 *****Multiple Timers Execution*****
 Oneshot timer triggered
 Periodic timer triggered


### PR DESCRIPTION
Use of clk shared library