### PR TITLE
Add ADCBlock and deinit.

### DIFF
--- a/ports/psoc-edge/machine_adc.c
+++ b/ports/psoc-edge/machine_adc.c
@@ -34,14 +34,10 @@
 #include "genhdr/pins_af.h"
 
 // PSoC Edge SAR ADC: 1 block, 8 GPIO channels (P15_0 to P15_7)
-#define PSOC_EDGE_ADC_NUM_CHANNELS (8)
-#define PSOC_EDGE_ADC_READ_TIMEOUT_US (1000)
+#define ADC_NUM_CHANNELS (8)
+#define ADC_READ_TIMEOUT_US (1000)
 
-#ifdef CY_CFG_PWR_VDDA_MV
-#define PSOC_EDGE_ADC_VDDA_MV    (CY_CFG_PWR_VDDA_MV)
-#else
-#define PSOC_EDGE_ADC_VDDA_MV    (3300)
-#endif
+#define ADC_VDDA_MV (CY_CFG_PWR_VDDA_MV)
 
 #define MICROPY_PY_MACHINE_ADC_CLASS_CONSTANTS
 
@@ -50,7 +46,7 @@ static bool adc_autanalog_initialized = false;
 // Bitmask of ADC channels enabled by user-created ADC objects.
 static uint8_t adc_enabled_channels_mask = 0;
 // Per-channel user reference count to support shared ADC objects per channel.
-static uint8_t adc_channel_refcount[PSOC_EDGE_ADC_NUM_CHANNELS] = {0};
+static uint8_t adc_channel_refcount[ADC_NUM_CHANNELS] = {0};
 
 // ADC channel object: stores pin mapping
 typedef struct _machine_adc_obj_t {
@@ -58,6 +54,7 @@ typedef struct _machine_adc_obj_t {
     const machine_pin_obj_t *pin;      // GPIO pin used as the ADC input
     uint8_t sar_block;                 // SAR block index (always 0 on PSE84)
     uint8_t gpio_channel;              // GPIO channel index (0-7 for P15_0-P15_7)
+    bool active;                       // Tracks whether this object still owns a channel reference.
 } machine_adc_obj_t;
 
 // ADC.__repr__ -> <ADC pin='P15_0' ch=0>
@@ -68,7 +65,7 @@ static void mp_machine_adc_print(const mp_print_t *print, mp_obj_t self_in, mp_p
 
 // Initialize BSP-generated CYBSP_SAR_ADC_* structures for one requested GPIO channel.
 static void machine_adc_init_gpio_channel(uint8_t channel) {
-    if (channel >= PSOC_EDGE_ADC_NUM_CHANNELS) {
+    if (channel >= ADC_NUM_CHANNELS) {
         return;
     }
 
@@ -98,7 +95,7 @@ static void machine_adc_init_sta_hs_cfg(void) {
     }
 
     // Start with no enabled GPIO channels. Channels are enabled on ADC(pin) creation.
-    for (size_t i = 0; i < PSOC_EDGE_ADC_NUM_CHANNELS; i++) {
+    for (size_t i = 0; i < ADC_NUM_CHANNELS; i++) {
         CYBSP_SAR_ADC_sta_hs_cfg.hsGpioChan[i] = NULL;
     }
 
@@ -199,7 +196,7 @@ static void machine_adc_reload_config(uint8_t sar_block) {
 
 // Increase channel refcount and enable HW on first user.
 static bool machine_adc_enable_channel(uint8_t channel) {
-    if (channel >= PSOC_EDGE_ADC_NUM_CHANNELS) {
+    if (channel >= ADC_NUM_CHANNELS) {
         return false;
     }
 
@@ -225,7 +222,7 @@ static bool machine_adc_enable_channel(uint8_t channel) {
 
 // Decrease channel refcount and disable HW when the last user releases it.
 static bool machine_adc_disable_channel(uint8_t channel) {
-    if (channel >= PSOC_EDGE_ADC_NUM_CHANNELS) {
+    if (channel >= ADC_NUM_CHANNELS) {
         return false;
     }
 
@@ -285,6 +282,22 @@ static void machine_adc_init_autanalog(void) {
     adc_autanalog_initialized = true;
 }
 
+void machine_adc_deinit_all(void) {
+    if (adc_autanalog_initialized) {
+        Cy_AutAnalog_Disable();
+    }
+
+    adc_autanalog_initialized = false;
+    adc_enabled_channels_mask = 0;
+    for (size_t i = 0; i < ADC_NUM_CHANNELS; i++) {
+        adc_channel_refcount[i] = 0;
+    }
+
+    // Rebuild the cached config structures so the next ADC creation starts from
+    // a clean software state after the hardware MMIO/STT contents are dropped.
+    machine_adc_init_configs();
+}
+
 // ADC(pin) -> machine_adc_obj_t *; validates pin
 static mp_obj_t mp_machine_adc_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 1, 1, false);
@@ -300,6 +313,7 @@ static mp_obj_t mp_machine_adc_make_new(const mp_obj_type_t *type, size_t n_args
     o->pin = pin;
     o->sar_block = sar_block;
     o->gpio_channel = channel;
+    o->active = true;
 
     // Initialize autonomous analog once and enable only the requested channel.
     machine_adc_init_autanalog();
@@ -315,8 +329,12 @@ static mp_obj_t mp_machine_adc_make_new(const mp_obj_type_t *type, size_t n_args
 
 // Read one ADC conversion as raw 12-bit value (0-4095).
 static uint16_t machine_adc_read_raw_12b(machine_adc_obj_t *self) {
+    if (!self->active) {
+        mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("ADC is deinitialized"));
+    }
+
     uint8_t channel_mask = (uint8_t)(1u << self->gpio_channel);
-    uint32_t timeout = PSOC_EDGE_ADC_READ_TIMEOUT_US;
+    uint32_t timeout = ADC_READ_TIMEOUT_US;
 
     // Clear result status and wait for new result
     Cy_AutAnalog_SAR_ClearHSchanResultStatus(self->sar_block, channel_mask);
@@ -348,11 +366,16 @@ static mp_int_t mp_machine_adc_read_u16(machine_adc_obj_t *self) {
 static mp_int_t mp_machine_adc_read_uv(machine_adc_obj_t *self) {
     uint16_t raw_12b = machine_adc_read_raw_12b(self);
     // Use raw SAR code for better precision than converting from quantized read_u16().
-    return (mp_int_t)(((uint64_t)raw_12b * ((uint64_t)PSOC_EDGE_ADC_VDDA_MV * 1000u)) / 4095u);
+    return (mp_int_t)(((uint64_t)raw_12b * ((uint64_t)ADC_VDDA_MV * 1000u)) / 4095u);
 }
 
 // ADC.deinit() - release this ADC user's channel reference.
 static void mp_machine_adc_deinit(machine_adc_obj_t *self) {
+    if (!self->active) {
+        return;
+    }
+
+    self->active = false;
     if (machine_adc_disable_channel(self->gpio_channel)) {
         machine_adc_reload_config(self->sar_block);
     }

--- a/ports/psoc-edge/machine_adc.c
+++ b/ports/psoc-edge/machine_adc.c
@@ -24,9 +24,6 @@
  * THE SOFTWARE.
  */
 
-// This file is never compiled standalone, it is included directly from
-// extmod/machine_adc.c via MICROPY_PY_MACHINE_ADC_INCLUDEFILE.
-
 #include "py/mphal.h"
 #include "py/mperrno.h"
 #include "machine_pin.h"
@@ -52,6 +49,8 @@
 static bool adc_autanalog_initialized = false;
 // Bitmask of ADC channels enabled by user-created ADC objects.
 static uint8_t adc_enabled_channels_mask = 0;
+// Per-channel user reference count to support shared ADC objects per channel.
+static uint8_t adc_channel_refcount[PSOC_EDGE_ADC_NUM_CHANNELS] = {0};
 
 // ADC channel object: stores pin mapping
 typedef struct _machine_adc_obj_t {
@@ -189,6 +188,7 @@ static void machine_adc_init_configs(void) {
     machine_adc_init_stt_cfg();
 }
 
+// Reload SAR config after channel mask updates.
 static void machine_adc_reload_config(uint8_t sar_block) {
     uint32_t status = Cy_AutAnalog_SAR_LoadConfig(sar_block, &CYBSP_SAR_ADC_cfg);
     if (status != CY_AUTANALOG_SUCCESS) {
@@ -197,9 +197,14 @@ static void machine_adc_reload_config(uint8_t sar_block) {
     Cy_AutAnalog_StartAutonomousControl();
 }
 
+// Increase channel refcount and enable HW on first user.
 static bool machine_adc_enable_channel(uint8_t channel) {
     if (channel >= PSOC_EDGE_ADC_NUM_CHANNELS) {
         return false;
+    }
+
+    if (adc_channel_refcount[channel] < UINT8_MAX) {
+        adc_channel_refcount[channel]++;
     }
 
     uint8_t channel_mask = (uint8_t)(1u << channel);
@@ -212,6 +217,34 @@ static bool machine_adc_enable_channel(uint8_t channel) {
     machine_adc_init_gpio_channel(channel);
     CYBSP_SAR_ADC_sta_hs_cfg.hsGpioChan[channel] = &CYBSP_SAR_ADC_gpio_ch_cfg[channel];
     adc_enabled_channels_mask |= channel_mask;
+    CYBSP_SAR_ADC_sta_hs_cfg.hsGpioResultMask = adc_enabled_channels_mask;
+    CYBSP_SAR_ADC_seq_hs_cfg[0].chanEn = adc_enabled_channels_mask;
+    CYBSP_SAR_ADC_seq_hs_cfg[1].chanEn = adc_enabled_channels_mask;
+    return true;
+}
+
+// Decrease channel refcount and disable HW when the last user releases it.
+static bool machine_adc_disable_channel(uint8_t channel) {
+    if (channel >= PSOC_EDGE_ADC_NUM_CHANNELS) {
+        return false;
+    }
+
+    if (adc_channel_refcount[channel] == 0u) {
+        return false;
+    }
+
+    adc_channel_refcount[channel]--;
+    if (adc_channel_refcount[channel] != 0u) {
+        return false;
+    }
+
+    uint8_t channel_mask = (uint8_t)(1u << channel);
+    if ((adc_enabled_channels_mask & channel_mask) == 0u) {
+        return false;
+    }
+
+    adc_enabled_channels_mask &= (uint8_t) ~channel_mask;
+    CYBSP_SAR_ADC_sta_hs_cfg.hsGpioChan[channel] = NULL;
     CYBSP_SAR_ADC_sta_hs_cfg.hsGpioResultMask = adc_enabled_channels_mask;
     CYBSP_SAR_ADC_seq_hs_cfg[0].chanEn = adc_enabled_channels_mask;
     CYBSP_SAR_ADC_seq_hs_cfg[1].chanEn = adc_enabled_channels_mask;
@@ -318,13 +351,16 @@ static mp_int_t mp_machine_adc_read_uv(machine_adc_obj_t *self) {
     return (mp_int_t)(((uint64_t)raw_12b * ((uint64_t)PSOC_EDGE_ADC_VDDA_MV * 1000u)) / 4095u);
 }
 
-// ADC.deinit() - no-op on PSE84
+// ADC.deinit() - release this ADC user's channel reference.
 static void mp_machine_adc_deinit(machine_adc_obj_t *self) {
-    (void)self;
+    if (machine_adc_disable_channel(self->gpio_channel)) {
+        machine_adc_reload_config(self->sar_block);
+    }
 }
 
-// ADC.block() -> ADCBlock or None
+// ADC.block() -> ADCBlock(0)
 static mp_obj_t mp_machine_adc_block(machine_adc_obj_t *self) {
     (void)self;
-    return mp_const_none;
+    mp_obj_t block_id = MP_OBJ_NEW_SMALL_INT(0);
+    return MP_OBJ_TYPE_GET_SLOT(&machine_adc_block_type, make_new)(&machine_adc_block_type, 1, 0, &block_id);
 }

--- a/ports/psoc-edge/machine_adc_block.c
+++ b/ports/psoc-edge/machine_adc_block.c
@@ -24,28 +24,29 @@
  * THE SOFTWARE.
  */
 
-// This file is never compiled standalone, it is included directly from
-// extmod/machine_adc_block.c via MICROPY_PY_MACHINE_ADC_BLOCK_INCLUDEFILE.
-
+#include "py/runtime.h"
 #include "py/mphal.h"
+#include "extmod/modmachine.h"
 #include "machine_pin.h"
+#include "genhdr/pins_af.h"
 
-// PSE84 SAR ADC: 1 block, fixed 12-bit resolution
-#define PSE84_ADC_BLOCK_ID    (0)
-#define PSE84_ADC_BLOCK_BITS  (12)
+// PSoC Edge SAR ADC: 1 block, fixed 12-bit resolution
+#define PSOC_EDGE_ADC_BLOCK_ID      (0)
+#define PSOC_EDGE_ADC_BLOCK_BITS    (12)
+#define PSOC_EDGE_ADC_NUM_CHANNELS  (8)
 
 // ADCBlock object: unit and bits fields
 typedef struct _machine_adc_block_obj_t {
     mp_obj_base_t base;
-    uint8_t unit; // SAR block index — always 0 on PSE84
-    uint8_t bits; // current resolution — fixed at 12 for PSE84 SAR
+    uint8_t unit; // SAR block index — always 0 on PSoC Edge
+    uint8_t bits; // current resolution — fixed at 12 for PSoC Edge SAR
 } machine_adc_block_obj_t;
 
 // ADCBlock(0) singleton instance
 static machine_adc_block_obj_t machine_adc_block_obj = {
     .base = {&machine_adc_block_type},
-    .unit = PSE84_ADC_BLOCK_ID,
-    .bits = PSE84_ADC_BLOCK_BITS,
+    .unit = PSOC_EDGE_ADC_BLOCK_ID,
+    .bits = PSOC_EDGE_ADC_BLOCK_BITS,
 };
 
 // ADCBlock.__repr__ -> <ADCBlock 0 bits=12>
@@ -55,7 +56,7 @@ static void mp_machine_adc_block_print(const mp_print_t *print, machine_adc_bloc
 
 // ADCBlock(id) -> machine_adc_block_obj_t or NULL; only id=0 valid
 static machine_adc_block_obj_t *mp_machine_adc_block_get(mp_int_t unit) {
-    if (unit == PSE84_ADC_BLOCK_ID) {
+    if (unit == PSOC_EDGE_ADC_BLOCK_ID) {
         return &machine_adc_block_obj;
     }
     return NULL;
@@ -66,18 +67,104 @@ static void mp_machine_adc_block_bits_set(machine_adc_block_obj_t *self, mp_int_
     if (bits == -1) {
         return;              // No-op
     }
-    if (bits != PSE84_ADC_BLOCK_BITS) {
+    if (bits != PSOC_EDGE_ADC_BLOCK_BITS) {
         mp_raise_ValueError(MP_ERROR_TEXT("invalid bits"));
     }
     (void)self;
 }
 
+// Map pin object to ADC block/channel.
+static bool machine_adc_block_get_block_channel_from_pin(
+    const machine_pin_obj_t *pin, uint8_t *sar_block, uint8_t *gpio_channel) {
+    #define MICROPY_HW_ADC_PIN_MAP_ENTRY(b, c, p, pn) \
+    if (pin->port == p && pin->pin == pn) { \
+        *sar_block = (uint8_t)(b); \
+        *gpio_channel = (uint8_t)(c); \
+        return true; \
+    }
+    MICROPY_HW_ADC_PIN_MAP(MICROPY_HW_ADC_PIN_MAP_ENTRY)
+#undef MICROPY_HW_ADC_PIN_MAP_ENTRY
+    return false;
+}
+
+// Map ADC block/channel to pin object.
+static const machine_pin_obj_t *machine_adc_block_get_pin_from_channel(uint8_t block, uint8_t channel) {
+    uint8_t adc_port;
+    uint8_t adc_pin;
+    bool found = false;
+
+    #define MICROPY_HW_ADC_PIN_MAP_ENTRY(b, c, p, pn) \
+    if ((uint8_t)(b) == block && (uint8_t)(c) == channel) { \
+        adc_port = (uint8_t)(p); \
+        adc_pin = (uint8_t)(pn); \
+        found = true; \
+    }
+    MICROPY_HW_ADC_PIN_MAP(MICROPY_HW_ADC_PIN_MAP_ENTRY)
+#undef MICROPY_HW_ADC_PIN_MAP_ENTRY
+
+    if (!found) {
+        return NULL;
+    }
+
+    const mp_map_t *cpu_map = &machine_pin_cpu_pins_locals_dict.map;
+    for (size_t i = 0; i < cpu_map->alloc; i++) {
+        const mp_map_elem_t *elem = &cpu_map->table[i];
+        if (elem->value == MP_OBJ_NULL) {
+            continue;
+        }
+        const machine_pin_obj_t *pin = MP_OBJ_TO_PTR(elem->value);
+        if (pin->port == adc_port && pin->pin == adc_pin) {
+            return pin;
+        }
+    }
+
+    return NULL;
+}
+
 // ADCBlock.connect(channel, pin) -> machine_adc_obj_t or NULL
 static machine_adc_obj_t *mp_machine_adc_block_connect(machine_adc_block_obj_t *self,
     mp_int_t channel_id, mp_hal_pin_obj_t pin, mp_map_t *kw_args) {
-    (void)self;
-    (void)channel_id;
-    (void)pin;
-    (void)kw_args;
-    return NULL;
+    if (kw_args != NULL && kw_args->used != 0) {
+        mp_raise_TypeError(MP_ERROR_TEXT("keyword args not supported"));
+    }
+
+    if (self->unit != PSOC_EDGE_ADC_BLOCK_ID) {
+        return NULL;
+    }
+
+    const machine_pin_obj_t *resolved_pin = NULL;
+    uint8_t pin_block = 0;
+    uint8_t pin_channel = 0;
+
+    if (pin != MP_HAL_PIN_OBJ_NULL) {
+        resolved_pin = pin;
+        if (!machine_adc_block_get_block_channel_from_pin(resolved_pin, &pin_block, &pin_channel)) {
+            return NULL;
+        }
+        if (pin_block != self->unit) {
+            return NULL;
+        }
+    }
+
+    if (channel_id >= 0) {
+        if ((uint8_t)channel_id >= PSOC_EDGE_ADC_NUM_CHANNELS) {
+            return NULL;
+        }
+        if (resolved_pin == NULL) {
+            resolved_pin = machine_adc_block_get_pin_from_channel((uint8_t)self->unit, (uint8_t)channel_id);
+            if (resolved_pin == NULL) {
+                return NULL;
+            }
+        } else if (pin_channel != (uint8_t)channel_id) {
+            return NULL;
+        }
+    }
+
+    if (resolved_pin == NULL) {
+        return NULL;
+    }
+
+    mp_obj_t adc_pin_obj = MP_OBJ_FROM_PTR(resolved_pin);
+    mp_obj_t adc_obj = MP_OBJ_TYPE_GET_SLOT(&machine_adc_type, make_new)(&machine_adc_type, 1, 0, &adc_pin_obj);
+    return MP_OBJ_TO_PTR(adc_obj);
 }

--- a/ports/psoc-edge/machine_adc_block.c
+++ b/ports/psoc-edge/machine_adc_block.c
@@ -30,10 +30,10 @@
 #include "machine_pin.h"
 #include "genhdr/pins_af.h"
 
-// PSoC Edge SAR ADC: 1 block, fixed 12-bit resolution
-#define PSOC_EDGE_ADC_BLOCK_ID      (0)
-#define PSOC_EDGE_ADC_BLOCK_BITS    (12)
-#define PSOC_EDGE_ADC_NUM_CHANNELS  (8)
+// SAR ADC: 1 block, fixed 12-bit resolution
+#define ADC_BLOCK_ID (0)
+#define ADC_BLOCK_BITS (12)
+#define MAX_CHANNELS (8)
 
 // ADCBlock object: unit and bits fields
 typedef struct _machine_adc_block_obj_t {
@@ -45,8 +45,8 @@ typedef struct _machine_adc_block_obj_t {
 // ADCBlock(0) singleton instance
 static machine_adc_block_obj_t machine_adc_block_obj = {
     .base = {&machine_adc_block_type},
-    .unit = PSOC_EDGE_ADC_BLOCK_ID,
-    .bits = PSOC_EDGE_ADC_BLOCK_BITS,
+    .unit = ADC_BLOCK_ID,
+    .bits = ADC_BLOCK_BITS,
 };
 
 // ADCBlock.__repr__ -> <ADCBlock 0 bits=12>
@@ -56,7 +56,7 @@ static void mp_machine_adc_block_print(const mp_print_t *print, machine_adc_bloc
 
 // ADCBlock(id) -> machine_adc_block_obj_t or NULL; only id=0 valid
 static machine_adc_block_obj_t *mp_machine_adc_block_get(mp_int_t unit) {
-    if (unit == PSOC_EDGE_ADC_BLOCK_ID) {
+    if (unit == ADC_BLOCK_ID) {
         return &machine_adc_block_obj;
     }
     return NULL;
@@ -67,7 +67,7 @@ static void mp_machine_adc_block_bits_set(machine_adc_block_obj_t *self, mp_int_
     if (bits == -1) {
         return;              // No-op
     }
-    if (bits != PSOC_EDGE_ADC_BLOCK_BITS) {
+    if (bits != ADC_BLOCK_BITS) {
         mp_raise_ValueError(MP_ERROR_TEXT("invalid bits"));
     }
     (void)self;
@@ -128,7 +128,7 @@ static machine_adc_obj_t *mp_machine_adc_block_connect(machine_adc_block_obj_t *
         mp_raise_TypeError(MP_ERROR_TEXT("keyword args not supported"));
     }
 
-    if (self->unit != PSOC_EDGE_ADC_BLOCK_ID) {
+    if (self->unit != ADC_BLOCK_ID) {
         return NULL;
     }
 
@@ -147,7 +147,7 @@ static machine_adc_obj_t *mp_machine_adc_block_connect(machine_adc_block_obj_t *
     }
 
     if (channel_id >= 0) {
-        if ((uint8_t)channel_id >= PSOC_EDGE_ADC_NUM_CHANNELS) {
+        if ((uint8_t)channel_id >= MAX_CHANNELS) {
             return NULL;
         }
         if (resolved_pin == NULL) {

--- a/ports/psoc-edge/modmachine.c
+++ b/ports/psoc-edge/modmachine.c
@@ -111,6 +111,7 @@ void machine_deinit(void) {
     #if MICROPY_PY_MACHINE_SPI_TARGET
     machine_spi_target_deinit_all();
     #endif
+    machine_adc_deinit_all();
     machine_pdm_pcm_deinit_all();
     machine_ipc_deinit_all();
     machine_timer_deinit_all();

--- a/ports/psoc-edge/modmachine.h
+++ b/ports/psoc-edge/modmachine.h
@@ -43,6 +43,7 @@ void machine_spi_deinit_all(void);
 #if MICROPY_PY_MACHINE_SPI_TARGET
 void machine_spi_target_deinit_all(void);
 #endif
+void machine_adc_deinit_all(void);
 void machine_pdm_pcm_deinit_all(void);
 void machine_ipc_deinit_all(void);
 void machine_timer_deinit_all(void);


### PR DESCRIPTION
### Summary

This change adds basic `ADCBlock` support for the PSoC Edge port.

It implements `ADC.block()` and `ADCBlock.connect()`, and updates
`ADC.deinit()` so ADC channels are released correctly when multiple ADC
objects share the same channel.

### Testing

Tested locally for ADC.block(), ADCBlock.connect(), and ADC.deinit() behavior. Test cases will be added in a separate PR soon
