### PR TITLE
tests/psoc-edge: Add machine.mem8/mem16/mem32 read-write tests.

### DIFF
--- a/docs/psoc-edge/quickref.rst
+++ b/docs/psoc-edge/quickref.rst
@@ -189,6 +189,35 @@ Use :func:`machine.bitstream` directly for timing-sensitive one-wire protocols::
     - Each timing value must be at least 300 ns; smaller values raise ``ValueError``.
     - If the runtime core clock is invalid (0 Hz), transmission raises ``ValueError``.
 
+Memory access
+-------------
+
+See :mod:`machine` (``mem8``, ``mem16``, ``mem32``) for the full API.
+
+These objects allow direct read/write access to memory-mapped addresses using
+subscript notation::
+
+    from machine import mem8, mem16, mem32
+
+    # Read ARM Cortex-M33 CPUID register (read-only, always safe)
+    cpuid = mem32[0xE000ED00]
+
+    # Read SysTick reload value to derive CPU clock
+    # reload = 200000 counts at 1 kHz tick -> 200 MHz
+    reload = mem32[0xE000E014]
+
+    # Toggle two GPIO pins atomically in a single write
+    GPIO_PRT10 = 0x42810500
+    OUT_SET    = GPIO_PRT10 + 0x08   # drive HIGH
+    OUT_CLR    = GPIO_PRT10 + 0x04   # drive LOW
+    mem32[OUT_SET] = (1 << 7) | (1 << 5)  # P10_7 and P10_5 simultaneously
+
+.. note::
+    ``mem32`` returns a signed integer. For values with bit 31 set, mask with
+    ``0xFFFFFFFF`` to get the unsigned representation::
+
+        value = mem32[addr] & 0xFFFFFFFF
+
 Real time clock (RTC)
 ---------------------
 

--- a/tests/ports/psoc-edge/board_only_hw/single/machine_mem.py
+++ b/tests/ports/psoc-edge/board_only_hw/single/machine_mem.py
@@ -1,0 +1,61 @@
+from machine import mem8, mem16, mem32
+import uctypes
+
+print("*** machine.mem Tests ***")
+
+# Allocate a buffer owned by the GC - safe to read/write via mem*
+# MicroPython GC allocates 16-byte-aligned blocks, so addr is always
+# at least 4-byte aligned.
+buf = bytearray(8)
+addr = uctypes.addressof(buf)
+
+# --- mem8 write/readback ---
+print("\nmem8 write/readback:")
+for i, val in enumerate([0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88]):
+    mem8[addr + i] = val
+for i, expected in enumerate([0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88]):
+    print(mem8[addr + i] == expected)
+
+# --- mem16 write/readback ---
+print("\nmem16 write/readback:")
+mem16[addr] = 0x1234
+mem16[addr + 2] = 0x5678
+print(mem16[addr] == 0x1234)
+print(mem16[addr + 2] == 0x5678)
+
+# --- mem32 write/readback ---
+print("\nmem32 write/readback:")
+mem32[addr] = 0x12345678
+print(hex(mem32[addr]) == "0x12345678")
+
+# --- Width consistency (little-endian Cortex-M) ---
+# Write 0x44332211 via mem32, verify byte/halfword views match little-endian layout
+print("\nWidth consistency (LE):")
+mem32[addr] = 0x44332211
+print(mem8[addr] == 0x11)
+print(mem8[addr + 1] == 0x22)
+print(mem8[addr + 2] == 0x33)
+print(mem8[addr + 3] == 0x44)
+print(mem16[addr] == 0x2211)
+print(mem16[addr + 2] == 0x4433)
+
+# --- Reverse: write mem8, read back as mem16/mem32 ---
+print("\nReverse width (mem8 -> mem16/mem32):")
+mem8[addr] = 0xAA
+mem8[addr + 1] = 0xBB
+mem8[addr + 2] = 0xCC
+mem8[addr + 3] = 0xDD
+print(mem16[addr] == 0xBBAA)  # little-endian
+print(mem16[addr + 2] == 0xDDCC)
+print(hex(mem32[addr] & 0xFFFFFFFF) == "0xddccbbaa")
+
+# --- Real hardware register read (ARM Cortex-M33 CPUID) ---
+# 0xE000ED00 is a read-only CPU identification register, constant on this SoC.
+# Implementer=0x41 (ARM), Architecture=0xF (ARMv8-M), PartNo=0xD21 (Cortex-M33)
+print("\nReal HW register (CPUID):")
+cpuid = mem32[0xE000ED00]
+print((cpuid >> 24) & 0xFF == 0x41)  # ARM implementer
+print((cpuid >> 16) & 0xF == 0xF)  # ARMv8-M architecture
+print((cpuid >> 4) & 0xFFF == 0xD21)  # Cortex-M33 part number
+
+print("\nDone.")

--- a/tests/ports/psoc-edge/board_only_hw/single/machine_mem.py.exp
+++ b/tests/ports/psoc-edge/board_only_hw/single/machine_mem.py.exp
@@ -1,0 +1,38 @@
+*** machine.mem Tests ***
+
+mem8 write/readback:
+True
+True
+True
+True
+True
+True
+True
+True
+
+mem16 write/readback:
+True
+True
+
+mem32 write/readback:
+True
+
+Width consistency (LE):
+True
+True
+True
+True
+True
+True
+
+Reverse width (mem8 -> mem16/mem32):
+True
+True
+True
+
+Real HW register (CPUID):
+True
+True
+True
+
+Done.


### PR DESCRIPTION

### Summary

Machine memory functions are enabled by default. This PR adds tests to verify that. The test that exists in extmod needs the unit test module; therefore, it is not currently enabled.

```
from machine import mem32
import time

GPIO_PRT10 = 0x42810500
OUT_CLR = GPIO_PRT10 + 0x04   # LOW  = OFF
OUT_SET = GPIO_PRT10 + 0x08   # HIGH = ON
LED1 = 1 << 7
LED2 = 1 << 5

print('LED1 ON');  mem32[OUT_SET] = LED1;  time.sleep_ms(1000)
print('LED1 OFF'); mem32[OUT_CLR] = LED1;  time.sleep_ms(1000)
print('LED2 ON');  mem32[OUT_SET] = LED2;  time.sleep_ms(1000)
print('LED2 OFF'); mem32[OUT_CLR] = LED2;  time.sleep_ms(1000)
print('Both ON');  mem32[OUT_SET] = LED1 | LED2;  time.sleep_ms(1000)
print('Both OFF'); mem32[OUT_CLR] = LED1 | LED2;  time.sleep_ms(1000)
print('Done')
```

This can be used for on-board LED control, and it works

### Testing

HIL test

### Generative AI

I did not use generative AI tools when creating this PR.

