### PR TITLE
ADC test and quickref.

### DIFF
--- a/docs/psoc-edge/quickref.rst
+++ b/docs/psoc-edge/quickref.rst
@@ -235,9 +235,6 @@ ADC (analog to digital conversion)
 See :ref:`machine.ADC <machine.ADC>` and :ref:`machine.ADCBlock <machine.ADCBlock>`.
 
 On the PSOC™ Edge, a single ADC block with id - ``0`` is available.
-The ADC functionality is available on the following pins : ``P15_0`` - ``P15_7``.
-
-Channel-to-pin routing is fixed by the board pin map.
 
 Use :class:`ADC` to read analog values from an ADC-capable pin::
 
@@ -249,8 +246,6 @@ Use :class:`ADC` to read analog values from an ADC-capable pin::
     adc.deinit()
 
 This port also supports :class:`ADCBlock` to provide control over ADC configuration.
-Currently, PSOC™ Edge supports a single SAR ADC with channel-to-pin mapping fixed
-by the board pin map.
 
 Use :class:`ADCBlock` to connect by channel, pin, or both::
 
@@ -267,21 +262,8 @@ Use :class:`ADCBlock` to connect by channel, pin, or both::
 
 .. note::
 
-    Arbitrary channel-to-GPIO routing is not supported.
-    Passing a non-ADC pin, or a mismatched channel+pin pair, raises ``ValueError``.
-
-.. note::
-
     ``ADCBlock(0, bits=12)`` is supported on this port.
     Other ``bits`` values are rejected.
-
-For a quick hardware check, use a 10k/10k divider:
-
-- Connect ``P15_3`` to GND.
-- Connect ``P15_2`` to VDD.
-- Connect midpoint of 10k/10k divider to ``P15_1``.
-
-Then ``P15_1`` should read approximately half of ``P15_2``.
 
 Real time clock (RTC)
 ---------------------

--- a/docs/psoc-edge/quickref.rst
+++ b/docs/psoc-edge/quickref.rst
@@ -229,6 +229,60 @@ subscript notation::
 
         value = mem32[addr] & 0xFFFFFFFF
 
+ADC (analog to digital conversion)
+----------------------------------
+
+See :ref:`machine.ADC <machine.ADC>` and :ref:`machine.ADCBlock <machine.ADCBlock>`.
+
+On the PSOC™ Edge, a single ADC block with id - ``0`` is available.
+The ADC functionality is available on the following pins : ``P15_0`` - ``P15_7``.
+
+Channel-to-pin routing is fixed by the board pin map.
+
+Use :class:`ADC` to read analog values from an ADC-capable pin::
+
+    from machine import ADC
+
+    adc = ADC('P15_1')
+    print(adc.read_u16())  # raw analog value in the range 0..65535
+    print(adc.read_uv())   # analog value in microvolts
+    adc.deinit()
+
+This port also supports :class:`ADCBlock` to provide control over ADC configuration.
+Currently, PSOC™ Edge supports a single SAR ADC with channel-to-pin mapping fixed
+by the board pin map.
+
+Use :class:`ADCBlock` to connect by channel, pin, or both::
+
+    from machine import ADCBlock
+
+    blk = ADCBlock(0, bits=12)
+    adc0 = blk.connect(1)
+    adc1 = blk.connect('P15_1')
+    adc2 = blk.connect(1, 'P15_1')
+    print(adc0.read_u16())
+    adc0.deinit()
+    adc1.deinit()
+    adc2.deinit()
+
+.. note::
+
+    Arbitrary channel-to-GPIO routing is not supported.
+    Passing a non-ADC pin, or a mismatched channel+pin pair, raises ``ValueError``.
+
+.. note::
+
+    ``ADCBlock(0, bits=12)`` is supported on this port.
+    Other ``bits`` values are rejected.
+
+For a quick hardware check, use a 10k/10k divider:
+
+- Connect ``P15_3`` to GND.
+- Connect ``P15_2`` to VDD.
+- Connect midpoint of 10k/10k divider to ``P15_1``.
+
+Then ``P15_1`` should read approximately half of ``P15_2``.
+
 Real time clock (RTC)
 ---------------------
 

--- a/tests/ports/psoc-edge/board_ext_hw/single/adc.py
+++ b/tests/ports/psoc-edge/board_ext_hw/single/adc.py
@@ -1,0 +1,98 @@
+# ADC test
+# Setup (single board):
+#   - Build a divider with R1=10k and R2=10k.
+#   - Connect R1 top to board VDD rail (1.8V or 3.3V).
+#   - Connect R2 bottom to GND.
+#   - Connect divider midpoint to adc_pin_mid.
+#   - Connect adc_pin_max directly to the same VDD rail.
+#   - Connect adc_pin_gnd directly to GND.
+#
+# Expected behavior:
+#   - adc_pin_gnd reads near 0V.
+#   - adc_pin_mid reads about half of adc_pin_max.
+#   - adc_pin_max reads near full-scale.
+
+from machine import ADC, ADCBlock
+import time
+
+
+adc_pin_gnd = "P15_3"
+adc_pin_mid = "P15_1"
+adc_pin_max = "P15_2"
+adc_mid_chan = 1
+adc_wrong_pin_name = "P13_7"
+
+
+def avg_read(adc_obj, count=8):
+    sum_uv = 0
+    sum_raw = 0
+    for _ in range(count):
+        sum_uv += adc_obj.read_uv()
+        sum_raw += adc_obj.read_u16()
+        time.sleep_ms(5)
+    return sum_uv // count, sum_raw // count
+
+
+print("*****ADC tests*****")
+
+# Invalid pin check.
+invalid_pin_rejected = False
+try:
+    ADC(adc_wrong_pin_name)
+except ValueError:
+    invalid_pin_rejected = True
+print("invalid_pin_rejected:", invalid_pin_rejected)
+
+# ADCBlock.connect variants.
+blk = ADCBlock(0, bits=12)
+adc_by_ch = blk.connect(adc_mid_chan)
+adc_by_pin = blk.connect(adc_pin_mid)
+adc_by_both = blk.connect(adc_mid_chan, adc_pin_mid)
+print("connect_channel_ok:", adc_by_ch is not None)
+print("connect_pin_ok:", adc_by_pin is not None)
+print("connect_channel_pin_ok:", adc_by_both is not None)
+
+# Voltage checks.
+adc_gnd = ADC(adc_pin_gnd)
+adc_mid = ADC(adc_pin_mid)
+adc_max = ADC(adc_pin_max)
+time.sleep_ms(20)
+
+g_uv, g_raw = avg_read(adc_gnd)
+m_uv, m_raw = avg_read(adc_mid)
+x_uv, x_raw = avg_read(adc_max)
+
+# Keep tolerances broad enough for board-to-board variation.
+gnd_uv_ok = g_uv <= 200000
+gnd_raw_ok = g_raw <= 5000
+
+if x_uv > 0:
+    mid_ratio = m_uv / x_uv
+else:
+    mid_ratio = 0.0
+mid_uv_ratio_ok = 0.40 <= mid_ratio <= 0.60
+
+# Midpoint should also be close to half-scale in read_u16.
+mid_raw_half_ok = abs(m_raw - 32768) <= 8000
+
+# MAX should be near top of range when tied to VDD.
+max_raw_high_ok = x_raw >= 58000
+
+# Ordering sanity check.
+monotonic_ok = g_uv < m_uv < x_uv
+
+print("gnd_uv_ok:", gnd_uv_ok)
+print("gnd_raw_ok:", gnd_raw_ok)
+print("mid_uv_ratio_ok:", mid_uv_ratio_ok)
+print("mid_raw_half_ok:", mid_raw_half_ok)
+print("max_raw_high_ok:", max_raw_high_ok)
+print("monotonic_ok:", monotonic_ok)
+
+# Cleanup.
+adc_by_ch.deinit()
+adc_by_pin.deinit()
+adc_by_both.deinit()
+adc_gnd.deinit()
+adc_mid.deinit()
+adc_max.deinit()
+print("cleanup_ok:", True)

--- a/tests/ports/psoc-edge/board_ext_hw/single/adc.py
+++ b/tests/ports/psoc-edge/board_ext_hw/single/adc.py
@@ -29,7 +29,6 @@ def avg_read(adc_obj, count=8):
     for _ in range(count):
         sum_uv += adc_obj.read_uv()
         sum_raw += adc_obj.read_u16()
-        time.sleep_ms(5)
     return sum_uv // count, sum_raw // count
 
 
@@ -62,7 +61,7 @@ g_uv, g_raw = avg_read(adc_gnd)
 m_uv, m_raw = avg_read(adc_mid)
 x_uv, x_raw = avg_read(adc_max)
 
-# Keep tolerances broad enough for board-to-board variation.
+# Broad tolerances account for leakage current and reference voltage variation across boards
 gnd_uv_ok = g_uv <= 200000
 gnd_raw_ok = g_raw <= 5000
 

--- a/tests/ports/psoc-edge/board_ext_hw/single/adc.py.exp
+++ b/tests/ports/psoc-edge/board_ext_hw/single/adc.py.exp
@@ -1,0 +1,12 @@
+*****ADC tests*****
+invalid_pin_rejected: True
+connect_channel_ok: True
+connect_pin_ok: True
+connect_channel_pin_ok: True
+gnd_uv_ok: True
+gnd_raw_ok: True
+mid_uv_ratio_ok: True
+mid_raw_half_ok: True
+max_raw_high_ok: True
+monotonic_ok: True
+cleanup_ok: True


### PR DESCRIPTION
### Summary

Add ADC test case and ADC quickref update.
This PR adds a ADC hardware test and quickref update, validating ADC plus ADCBlock channel/pin mapping, expected GND-mid-VDD reading behavior, error paths, and cleanup, with yml files integration intentionally left for a follow-up.

Image 1: local hardware divider setup
Image 2: pass output in REPL

<img width="2295" height="1682" alt="adc_hw_setup4" src="https://github.com/user-attachments/assets/27673701-6277-4411-b640-14c8c7bacc13" />
<img width="742" height="888" alt="2026-07-22_18h27_23" src="https://github.com/user-attachments/assets/d1b78cfc-0f1f-4888-853b-d7444a8ee234" />

### Testing

Tested locally on PSOC Edge board with divider wiring. (10kohm resistor)
Test output passed in repl.

### Trade-offs and Alternatives

YML files are not added in this PR for CI build and ADC HIL setup is not done yet.


### Generative AI

I did not use generative AI tools when creating this PR.
