### PR TITLE
UART flow control

### DIFF
--- a/docs/psoc-edge/quickref.rst
+++ b/docs/psoc-edge/quickref.rst
@@ -801,11 +801,36 @@ Constructor
    
    - ``bits``. Only 8 bits.
 
-   These are planned for future implementation, but yet unavailable:
+   Flow-control pin rules:
 
-   - ``rts``
-   - ``cts``
-   - ``flow``
+   - if ``rts`` is provided, ``flow`` must include ``UART.RTS``
+   - if ``cts`` is provided, ``flow`` must include ``UART.CTS``
+
+   Example::
+
+      from machine import UART
+
+      TX = "P17_1"
+      RX = "P17_0"
+      RTS = "P16_6"
+      CTS = "P16_5"
+
+      # RTS only
+      uart = UART(5, baudrate=115200, tx=TX, rx=RX, rts=RTS, flow=UART.RTS)
+
+      # CTS only
+      uart = UART(5, baudrate=115200, tx=TX, rx=RX, cts=CTS, flow=UART.CTS)
+
+      # RTS + CTS
+      uart = UART(
+          5,
+          baudrate=115200,
+          tx=TX,
+          rx=RX,
+          rts=RTS,
+          cts=CTS,
+          flow=UART.RTS | UART.CTS,
+      )
        
 .. Note::
 

--- a/docs/psoc-edge/quickref.rst
+++ b/docs/psoc-edge/quickref.rst
@@ -800,37 +800,6 @@ Constructor
    The following parameters are supported with limited configuration:
    
    - ``bits``. Only 8 bits.
-
-   Flow-control pin rules:
-
-   - if ``rts`` is provided, ``flow`` must include ``UART.RTS``
-   - if ``cts`` is provided, ``flow`` must include ``UART.CTS``
-
-   Example::
-
-      from machine import UART
-
-      TX = "P17_1"
-      RX = "P17_0"
-      RTS = "P16_6"
-      CTS = "P16_5"
-
-      # RTS only
-      uart = UART(5, baudrate=115200, tx=TX, rx=RX, rts=RTS, flow=UART.RTS)
-
-      # CTS only
-      uart = UART(5, baudrate=115200, tx=TX, rx=RX, cts=CTS, flow=UART.CTS)
-
-      # RTS + CTS
-      uart = UART(
-          5,
-          baudrate=115200,
-          tx=TX,
-          rx=RX,
-          rts=RTS,
-          cts=CTS,
-          flow=UART.RTS | UART.CTS,
-      )
        
 .. Note::
 

--- a/ports/psoc-edge/machine_uart.c
+++ b/ports/psoc-edge/machine_uart.c
@@ -68,6 +68,8 @@
 #define UART_FLOW_CONTROL_NONE    (0)
 #define UART_FLOW_CONTROL_RTS     (1)
 #define UART_FLOW_CONTROL_CTS     (2)
+#define UART_FLOW_CONTROL_MASK    (UART_FLOW_CONTROL_RTS | UART_FLOW_CONTROL_CTS)
+#define UART_RTS_RX_FIFO_LEVEL    (8UL)
 #define UART_IRQ_RXIDLE           (CY_SCB_RX_INTR_NOT_EMPTY)
 
 // Class-level constants exposed to Python
@@ -152,15 +154,31 @@ static void machine_uart_irq_rx_break(machine_uart_obj_t *self);
 static void machine_uart_irq_tx_idle(machine_uart_obj_t *self);
 #endif
 
+static inline void machine_uart_set_rx_not_empty_irq(machine_uart_obj_t *self, bool enable) {
+    uint32_t mask = Cy_SCB_GetRxInterruptMask(self->scb_obj->scb);
+    if (enable) {
+        mask |= CY_SCB_RX_INTR_NOT_EMPTY;
+    } else {
+        mask &= ~CY_SCB_RX_INTR_NOT_EMPTY;
+    }
+    Cy_SCB_SetRxInterruptMask(self->scb_obj->scb, mask);
+}
+
+static inline void machine_uart_resume_rx_not_empty_irq(machine_uart_obj_t *self) {
+    if ((Cy_SCB_GetRxInterruptMask(self->scb_obj->scb) & CY_SCB_RX_INTR_NOT_EMPTY) == 0U) {
+        machine_uart_set_rx_not_empty_irq(self, true);
+    }
+}
+
 static void machine_uart_fill_rx_ring_buff(machine_uart_obj_t *self) {
     uint32_t available_rx_frames = Cy_SCB_UART_GetNumInRxFifo(self->scb_obj->scb);
     for (uint32_t i = 0; i < available_rx_frames; i++) {
         if (!ringbuf_put(&self->rx_ringbuf, (uint8_t)Cy_SCB_UART_Get(self->scb_obj->scb))) {
             /**
-             * No overflow handling.
-             * Just return and wait for next interrupt
-             * to read the remaining data.
+             * Pause software draining when the ring buffer is full so RX FIFO
+             * can back up and hardware RTS can deassert to throttle sender.
              */
+            machine_uart_set_rx_not_empty_irq(self, false);
             return;
         }
     }
@@ -340,12 +358,9 @@ static void machine_uart_hw_init(machine_uart_obj_t *self) {
         .receiverAddressMask = 0UL,
         .acceptAddrInFifo = false,
 
-        /**
-         * TODO: Enable CTS/RTS based on user config.
-         */
-        .enableCts = false,
+        .enableCts = (self->flow & UART_FLOW_CONTROL_CTS) != 0,
         .ctsPolarity = CY_SCB_UART_ACTIVE_LOW,
-        .rtsRxFifoLevel = 0UL,
+        .rtsRxFifoLevel = (self->flow & UART_FLOW_CONTROL_RTS) ? UART_RTS_RX_FIFO_LEVEL : 0UL,
         .rtsPolarity = CY_SCB_UART_ACTIVE_LOW,
 
         .rxFifoTriggerLevel = 0UL,
@@ -498,14 +513,17 @@ static void machine_uart_init_impl(machine_uart_obj_t **self_ptr, int uart_id, s
     /* -- Flow control pins -- */
     uint32_t flow = (uint32_t)args[ARG_flow].u_int;
 
-    /** TODO: Currently throw error if flow is not NONE.
-     * This needs to be implemented
-     * {
-     */
-    if (flow != UART_FLOW_CONTROL_NONE) {
-        mp_raise_ValueError(MP_ERROR_TEXT("flow control not supported yet. Keep flow=0"));
+    if ((flow & ~UART_FLOW_CONTROL_MASK) != 0U) {
+        mp_raise_ValueError(MP_ERROR_TEXT("flow must be UART.RTS, UART.CTS or both"));
     }
-    /** } */
+
+    if ((args[ARG_rts].u_obj != mp_const_none) && ((flow & UART_FLOW_CONTROL_RTS) == 0U)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("flow must include UART.RTS when rts pin is provided"));
+    }
+
+    if ((args[ARG_cts].u_obj != mp_const_none) && ((flow & UART_FLOW_CONTROL_CTS) == 0U)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("flow must include UART.CTS when cts pin is provided"));
+    }
 
     #define PIN_AF_CONFIG_INDEX_NONE (0xFF)
     uint8_t pin_af_conf_rts_index = PIN_AF_CONFIG_INDEX_NONE;
@@ -696,7 +714,9 @@ static void mp_machine_uart_sendbreak(machine_uart_obj_t *self) {
 #if MICROPY_PY_MACHINE_UART_READCHAR_WRITECHAR
 static mp_int_t mp_machine_uart_readchar(machine_uart_obj_t *self) {
     if (machine_uart_rx_wait(self, self->timeout_ms)) {
-        return (uint8_t)ringbuf_get(&self->rx_ringbuf);
+        uint8_t data = (uint8_t)ringbuf_get(&self->rx_ringbuf);
+        machine_uart_resume_rx_not_empty_irq(self);
+        return data;
     }
 
     return MP_STREAM_ERROR;
@@ -732,6 +752,7 @@ static mp_uint_t mp_machine_uart_read(mp_obj_t self_in, void *buf_in, mp_uint_t 
         ringbuf_memcpy_get_internal(&self->rx_ringbuf, (uint8_t *)buf_in + read_count, to_read);
         read_count += to_read;
         size -= to_read;
+        machine_uart_resume_rx_not_empty_irq(self);
     } while (size > 0 && machine_uart_rx_wait(self, self->timeout_char_ms));
 
     return read_count;
@@ -739,21 +760,26 @@ static mp_uint_t mp_machine_uart_read(mp_obj_t self_in, void *buf_in, mp_uint_t 
 
 static mp_uint_t mp_machine_uart_write(mp_obj_t self_in, const void *buf_in, mp_uint_t size, int *errcode) {
     machine_uart_obj_t *self = MP_OBJ_TO_PTR(self_in);
-
-    /* wait to be able to write the first character. */
-    if (!machine_uart_tx_wait(self, self->timeout_ms)) {
-        /* EAGAIN causes write to return None */
-        *errcode = MP_EAGAIN;
-        return MP_STREAM_ERROR;
-    }
-
+    const uint8_t *src = (const uint8_t *)buf_in;
     uint32_t write_count = 0;
-    do {
-        uint32_t written = Cy_SCB_UART_PutArray(self->scb_obj->scb, (void *)buf_in, size);
-        buf_in = (const uint8_t *)buf_in + written;
-        size -= written;
-        write_count += written;
-    } while (size > 0 && machine_uart_tx_wait(self, self->timeout_char_ms));
+
+    while (size > 0) {
+        uint32_t timeout = (write_count == 0) ? self->timeout_ms : self->timeout_char_ms;
+        if (!machine_uart_tx_wait(self, timeout)) {
+            /* First byte timeout should map to EAGAIN (write returns None). */
+            if (write_count == 0) {
+                *errcode = MP_EAGAIN;
+                return MP_STREAM_ERROR;
+            }
+            /* Partial write on timeout after some progress. */
+            break;
+        }
+
+        Cy_SCB_UART_Put(self->scb_obj->scb, (uint32_t)(*src));
+        src++;
+        size--;
+        write_count++;
+    }
 
     return write_count;
 }

--- a/ports/psoc-edge/machine_uart.c
+++ b/ports/psoc-edge/machine_uart.c
@@ -836,11 +836,11 @@ void machine_uart_deinit_all() {
     CY_SCB_RX_INTR_UART_BREAK_DETECT | \
     CY_SCB_TX_INTR_UART_DONE)
 
-static mp_obj_t machine_uart_rx_idle_soft(mp_obj_t self_in);
-static MP_DEFINE_CONST_FUN_OBJ_1(machine_uart_rx_idle_soft_obj, machine_uart_rx_idle_soft);
+static mp_obj_t machine_uart_irq_rx_idle_soft(mp_obj_t self_in);
+static MP_DEFINE_CONST_FUN_OBJ_1(machine_uart_irq_rx_idle_soft_obj, machine_uart_irq_rx_idle_soft);
 
 
-static mp_obj_t machine_uart_rx_idle_soft(mp_obj_t self_in) {
+static mp_obj_t machine_uart_irq_rx_idle_soft(mp_obj_t self_in) {
     /**
      * The irq handle is only scheduled when no bytes
      * have been received within the frame time.
@@ -856,7 +856,7 @@ static mp_obj_t machine_uart_rx_idle_soft(mp_obj_t self_in) {
             }
             self->rx_idle_irq_pending = false;
         } else {
-            mp_sched_schedule(MP_OBJ_FROM_PTR(&machine_uart_rx_idle_soft_obj), MP_OBJ_FROM_PTR(self));
+            mp_sched_schedule(MP_OBJ_FROM_PTR(&machine_uart_irq_rx_idle_soft_obj), MP_OBJ_FROM_PTR(self));
         }
     }
 
@@ -884,7 +884,7 @@ static void machine_uart_irq_rx_idle(machine_uart_obj_t *self) {
         self->rx_idle_timeout = mp_hal_ticks_ms() + frame_time_ms * RX_IDLE_NUM_OF_FRAMES_MARGIN;
         if (!self->rx_idle_irq_pending) {
             self->rx_idle_irq_pending = true;
-            mp_sched_schedule(MP_OBJ_FROM_PTR(&machine_uart_rx_idle_soft_obj), MP_OBJ_FROM_PTR(self));
+            mp_sched_schedule(MP_OBJ_FROM_PTR(&machine_uart_irq_rx_idle_soft_obj), MP_OBJ_FROM_PTR(self));
         }
     }
 }

--- a/ports/psoc-edge/machine_uart.c
+++ b/ports/psoc-edge/machine_uart.c
@@ -69,7 +69,10 @@
 #define UART_FLOW_CONTROL_RTS     (1)
 #define UART_FLOW_CONTROL_CTS     (2)
 #define UART_FLOW_CONTROL_MASK    (UART_FLOW_CONTROL_RTS | UART_FLOW_CONTROL_CTS)
-#define UART_RTS_RX_FIFO_LEVEL    (8UL)
+
+// The RX FIFO level at which the RTS pin is deasserted to throttle the sender.
+// Threshold is set to 112 bytes, which is fifo size (128) - 16 bytes (cushion).
+#define UART_RTS_RX_FIFO_LEVEL    (112UL)
 #define UART_IRQ_RXIDLE           (CY_SCB_RX_INTR_NOT_EMPTY)
 
 // Class-level constants exposed to Python
@@ -173,7 +176,7 @@ static inline void machine_uart_resume_rx_not_empty_irq(machine_uart_obj_t *self
 static void machine_uart_fill_rx_ring_buff(machine_uart_obj_t *self) {
     uint32_t available_rx_frames = Cy_SCB_UART_GetNumInRxFifo(self->scb_obj->scb);
     for (uint32_t i = 0; i < available_rx_frames; i++) {
-        if (!ringbuf_put(&self->rx_ringbuf, (uint8_t)Cy_SCB_UART_Get(self->scb_obj->scb))) {
+        if (ringbuf_free(&self->rx_ringbuf) == 0) {
             /**
              * Pause software draining when the ring buffer is full so RX FIFO
              * can back up and hardware RTS can deassert to throttle sender.
@@ -181,6 +184,9 @@ static void machine_uart_fill_rx_ring_buff(machine_uart_obj_t *self) {
             machine_uart_set_rx_not_empty_irq(self, false);
             return;
         }
+
+        // Only read from HW FIFO after ensuring there is space in the SW ring buffer.
+        ringbuf_put(&self->rx_ringbuf, (uint8_t)Cy_SCB_UART_Get(self->scb_obj->scb));
     }
 }
 

--- a/ports/psoc-edge/machine_uart.c
+++ b/ports/psoc-edge/machine_uart.c
@@ -68,7 +68,6 @@
 #define UART_FLOW_CONTROL_NONE    (0)
 #define UART_FLOW_CONTROL_RTS     (1)
 #define UART_FLOW_CONTROL_CTS     (2)
-#define UART_FLOW_CONTROL_MASK    (UART_FLOW_CONTROL_RTS | UART_FLOW_CONTROL_CTS)
 
 // The RX FIFO level at which the RTS pin is deasserted to throttle the sender.
 // Threshold is set to 112 bytes, which is fifo size (128) - 16 bytes (cushion).
@@ -157,7 +156,7 @@ static void machine_uart_irq_rx_break(machine_uart_obj_t *self);
 static void machine_uart_irq_tx_idle(machine_uart_obj_t *self);
 #endif
 
-static inline void machine_uart_set_rx_not_empty_irq(machine_uart_obj_t *self, bool enable) {
+static inline void machine_uart_irq_rx_not_empty_config(machine_uart_obj_t *self, bool enable) {
     uint32_t mask = Cy_SCB_GetRxInterruptMask(self->scb_obj->scb);
     if (enable) {
         mask |= CY_SCB_RX_INTR_NOT_EMPTY;
@@ -167,10 +166,12 @@ static inline void machine_uart_set_rx_not_empty_irq(machine_uart_obj_t *self, b
     Cy_SCB_SetRxInterruptMask(self->scb_obj->scb, mask);
 }
 
-static inline void machine_uart_resume_rx_not_empty_irq(machine_uart_obj_t *self) {
-    if ((Cy_SCB_GetRxInterruptMask(self->scb_obj->scb) & CY_SCB_RX_INTR_NOT_EMPTY) == 0U) {
-        machine_uart_set_rx_not_empty_irq(self, true);
-    }
+static inline void machine_uart_irq_rx_pause(machine_uart_obj_t *self) {
+    machine_uart_irq_rx_not_empty_config(self, false);
+}
+
+static inline void machine_uart_irq_rx_resume(machine_uart_obj_t *self) {
+    machine_uart_irq_rx_not_empty_config(self, true);
 }
 
 static void machine_uart_fill_rx_ring_buff(machine_uart_obj_t *self) {
@@ -178,14 +179,14 @@ static void machine_uart_fill_rx_ring_buff(machine_uart_obj_t *self) {
     for (uint32_t i = 0; i < available_rx_frames; i++) {
         if (ringbuf_free(&self->rx_ringbuf) == 0) {
             /**
-             * Pause software draining when the ring buffer is full so RX FIFO
-             * can back up and hardware RTS can deassert to throttle sender.
+             * Pause rx irq to avoid interrupt storms while the
+             * ring buffer is full. Supports RTS flow control,
+             * if enabled, to throttle the sender.
              */
-            machine_uart_set_rx_not_empty_irq(self, false);
+            machine_uart_irq_rx_pause(self);
             return;
         }
 
-        // Only read from HW FIFO after ensuring there is space in the SW ring buffer.
         ringbuf_put(&self->rx_ringbuf, (uint8_t)Cy_SCB_UART_Get(self->scb_obj->scb));
     }
 }
@@ -519,7 +520,7 @@ static void machine_uart_init_impl(machine_uart_obj_t **self_ptr, int uart_id, s
     /* -- Flow control pins -- */
     uint32_t flow = (uint32_t)args[ARG_flow].u_int;
 
-    if ((flow & ~UART_FLOW_CONTROL_MASK) != 0U) {
+    if ((flow & ~(UART_FLOW_CONTROL_RTS | UART_FLOW_CONTROL_CTS)) != 0U) {
         mp_raise_ValueError(MP_ERROR_TEXT("flow must be UART.RTS, UART.CTS or both"));
     }
 
@@ -721,7 +722,7 @@ static void mp_machine_uart_sendbreak(machine_uart_obj_t *self) {
 static mp_int_t mp_machine_uart_readchar(machine_uart_obj_t *self) {
     if (machine_uart_rx_wait(self, self->timeout_ms)) {
         uint8_t data = (uint8_t)ringbuf_get(&self->rx_ringbuf);
-        machine_uart_resume_rx_not_empty_irq(self);
+        machine_uart_irq_rx_resume(self);
         return data;
     }
 
@@ -758,7 +759,7 @@ static mp_uint_t mp_machine_uart_read(mp_obj_t self_in, void *buf_in, mp_uint_t 
         ringbuf_memcpy_get_internal(&self->rx_ringbuf, (uint8_t *)buf_in + read_count, to_read);
         read_count += to_read;
         size -= to_read;
-        machine_uart_resume_rx_not_empty_irq(self);
+        machine_uart_irq_rx_resume(self);
     } while (size > 0 && machine_uart_rx_wait(self, self->timeout_char_ms));
 
     return read_count;

--- a/ports/psoc-edge/machine_uart.c
+++ b/ports/psoc-edge/machine_uart.c
@@ -766,26 +766,20 @@ static mp_uint_t mp_machine_uart_read(mp_obj_t self_in, void *buf_in, mp_uint_t 
 
 static mp_uint_t mp_machine_uart_write(mp_obj_t self_in, const void *buf_in, mp_uint_t size, int *errcode) {
     machine_uart_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    const uint8_t *src = (const uint8_t *)buf_in;
-    uint32_t write_count = 0;
-
-    while (size > 0) {
-        uint32_t timeout = (write_count == 0) ? self->timeout_ms : self->timeout_char_ms;
-        if (!machine_uart_tx_wait(self, timeout)) {
-            /* First byte timeout should map to EAGAIN (write returns None). */
-            if (write_count == 0) {
-                *errcode = MP_EAGAIN;
-                return MP_STREAM_ERROR;
-            }
-            /* Partial write on timeout after some progress. */
-            break;
-        }
-
-        Cy_SCB_UART_Put(self->scb_obj->scb, (uint32_t)(*src));
-        src++;
-        size--;
-        write_count++;
+    /* wait to be able to write the first character. */
+    if (!machine_uart_tx_wait(self, self->timeout_ms)) {
+        /* EAGAIN causes write to return None */
+        *errcode = MP_EAGAIN;
+        return MP_STREAM_ERROR;
     }
+
+    uint32_t write_count = 0;
+    do {
+        uint32_t written = Cy_SCB_UART_PutArray(self->scb_obj->scb, (void *)buf_in, size);
+        buf_in = (const uint8_t *)buf_in + written;
+        size -= written;
+        write_count += written;
+    } while (size > 0 && machine_uart_tx_wait(self, self->timeout_char_ms));
 
     return write_count;
 }

--- a/tests/extmod/machine_uart_tx.py
+++ b/tests/extmod/machine_uart_tx.py
@@ -27,7 +27,7 @@ elif "mimxrt" in sys.platform:
 elif "nrf" in sys.platform:
     timing_margin_us = 130
 elif "psoc-edge" in sys.platform:
-    timing_margin_us = 190
+    timing_margin_us = 220
 elif "pyboard" in sys.platform:
     initial_delay_ms = 50  # UART sends idle frame after init, so wait for that
     bit_margin = 1  # first start-bit must wait to sync with the UART clock

--- a/tests/ports/psoc-edge/board_ext_hw/single/uart.py
+++ b/tests/ports/psoc-edge/board_ext_hw/single/uart.py
@@ -1,4 +1,4 @@
-from machine import UART
+from machine import Pin, UART
 import time
 
 uart_pins_args = {"tx": "P17_1", "rx": "P17_0"}
@@ -89,11 +89,30 @@ def uart_tests():
     # write()/read() large data
     uart_rx_buf = bytearray(512)
     tx_data = bytes([x % 256 for x in range(512)])
-    tx_written = uart.write(tx_data)
+    uart_rx_view = memoryview(uart_rx_buf)
+    tx_written = 0
+    read_num = 0
+    chunk_size = 64
+    for offset in range(0, len(tx_data), chunk_size):
+        chunk = tx_data[offset : offset + chunk_size]
+        tx_written += uart.write(chunk)
+        uart.flush()
+
+        chunk_end = offset + len(chunk)
+        start = time.ticks_ms()
+        while read_num < chunk_end and time.ticks_diff(time.ticks_ms(), start) < 500:
+            written = uart.readinto(uart_rx_view[read_num:chunk_end])
+            if written is None:
+                written = 0
+            read_num += written
+            if read_num < chunk_end:
+                time.sleep_ms(5)
+
     print("Tx written bytes by write(): ", tx_written)
-    # An added sleep here makes the last bytes to be lost.
-    read_num = uart.readinto(uart_rx_buf)
-    print("Tx is received by Rx(readinto(buf)) for large data: ", uart_rx_buf == tx_data)
+    print(
+        "Tx is received by Rx(readinto(buf)) for large data: ",
+        (read_num == len(tx_data)) and (uart_rx_buf == tx_data),
+    )
     if uart_rx_buf != tx_data:
         print("Received data:", uart_rx_buf)
         print("Num of bytes read:", read_num)
@@ -119,36 +138,98 @@ def uart_irq():
         handler_irq_flag = True
         print(f"IRQ {event} handler called")
 
-    def wait_for_irq_handler():
+    def wait_for_irq_handler(timeout_ms=200):
         global handler_irq_flag
+        start = time.ticks_ms()
         while not handler_irq_flag:
+            if time.ticks_diff(time.ticks_ms(), start) >= timeout_ms:
+                return False
             time.sleep_ms(10)
         handler_irq_flag = False
+        return True
 
     # BREAK Received check
     event = "BREAK"
     irq = uart.irq(handler=uart_irq_handler, trigger=(UART.IRQ_BREAK))
     uart.sendbreak()
-    wait_for_irq_handler()
-    print("IRQ BREAK detected: ", irq.flags() & UART.IRQ_BREAK == UART.IRQ_BREAK)
+    break_seen = wait_for_irq_handler()
+    print("IRQ BREAK detected: ", break_seen and (irq.flags() & UART.IRQ_BREAK == UART.IRQ_BREAK))
 
     # TXIDLE check
     event = "TXIDLE"
     uart.irq(handler=uart_irq_handler, trigger=(UART.IRQ_TXIDLE))
     uart.write("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
-    wait_for_irq_handler()
-    print("IRQ TXIDLE detected: ", irq.flags() & UART.IRQ_TXIDLE == UART.IRQ_TXIDLE)
+    txidle_seen = wait_for_irq_handler()
+    print(
+        "IRQ TXIDLE detected: ", txidle_seen and (irq.flags() & UART.IRQ_TXIDLE == UART.IRQ_TXIDLE)
+    )
+    uart.read()
 
     # RXIDLE check
     event = "RXIDLE"
     uart.irq(handler=uart_irq_handler, trigger=(UART.IRQ_RXIDLE))
     uart.write("1")
-    wait_for_irq_handler()
-    print("IRQ RXIDLE detected: ", irq.flags() & UART.IRQ_RXIDLE == UART.IRQ_RXIDLE)
+    rxidle_seen = wait_for_irq_handler()
+    print(
+        "IRQ RXIDLE detected: ", rxidle_seen and (irq.flags() & UART.IRQ_RXIDLE == UART.IRQ_RXIDLE)
+    )
+
+    # Clear the test IRQ handler so later UART traffic does not add extra output.
+    uart.irq(handler=None, trigger=0)
+
+
+def uart_flow_tests():
+    flow_pins_args = {
+        "tx": "P17_1",
+        "rx": "P17_0",
+        "cts": "P16_5",
+        "rts": "P16_6",
+    }
+    flow_conf = {
+        "baudrate": 115200,
+        "bits": 8,
+        "parity": None,
+        "stop": 1,
+        "timeout": 100,
+        "rxbuf": 512,
+    }
+    payload = b"flow-test-123456"
+    cts_peer_pin = Pin("P16_6", Pin.OUT, value=1)
+
+    def run_case(name, flow):
+        pins = {
+            "tx": flow_pins_args["tx"],
+            "rx": flow_pins_args["rx"],
+        }
+        if flow & UART.CTS:
+            pins["cts"] = flow_pins_args["cts"]
+        if flow & UART.RTS:
+            pins["rts"] = flow_pins_args["rts"]
+
+        uart.init(flow=flow, **pins, **flow_conf)
+        uart.read()
+
+        if flow == UART.CTS:
+            # Drive the wired peer line low (active-low) so TX is allowed.
+            cts_peer_pin(0)
+
+        tx_written = uart.write(payload)
+        time.sleep_ms(50)
+        rx_data = uart.read(len(payload))
+        print(name + ":", (tx_written == len(payload)) and (rx_data == payload))
+
+        if flow == UART.CTS:
+            # Drive the wired peer line high (active-low) so TX is blocked.
+            cts_peer_pin(1)
+
+    run_case("Flow CTS", UART.CTS)
+    run_case("Flow RTS", UART.RTS)
+    run_case("Flow CTS|RTS", UART.CTS | UART.RTS)
 
 
 uart_tests()
 uart_irq()
+uart_flow_tests()
 
 
 uart.deinit()

--- a/tests/ports/psoc-edge/board_ext_hw/single/uart.py
+++ b/tests/ports/psoc-edge/board_ext_hw/single/uart.py
@@ -200,6 +200,53 @@ def uart_flow_tests():
     run_case("Flow RTS", UART.RTS)
     run_case("Flow CTS|RTS", UART.CTS | UART.RTS)
 
+    # CTS deasserted should block TX.
+    uart.init(
+        flow=UART.CTS,
+        tx=flow_pins_args["tx"],
+        rx=flow_pins_args["rx"],
+        cts=flow_pins_args["cts"],
+        **flow_conf,
+    )
+    uart.read()
+    cts_peer_pin(1)  # active-low CTS deasserted => transmitter must stop.
+    blocked_payload = b"cts-block-test"
+    uart.write(blocked_payload)
+    time.sleep_ms(50)
+    tx_blocked = uart.txdone() == False
+    rx_data = uart.read(len(blocked_payload))
+    rx_blocked = (rx_data is None) or (rx_data == b"")
+    print("Flow CTS blocked TX:", tx_blocked and rx_blocked)
+
+    # Restore CTS asserted and drain any pending payload.
+    cts_peer_pin(0)
+    time.sleep_ms(50)
+    uart.read()
+
+    # Verify RTS backpressure: when RX capacity is exceeded, RTS should deassert.
+    # Board-ext wiring ties P16_6 (RTS output) to P16_5, so sample P16_5 as observer.
+    rts_observer = Pin("P16_5", Pin.IN)
+    uart.init(
+        flow=UART.RTS,
+        tx=flow_pins_args["tx"],
+        rx=flow_pins_args["rx"],
+        rts=flow_pins_args["rts"],
+        **flow_conf,
+    )
+    uart.read()
+
+    levels = {rts_observer.value()}
+    # Send a payload larger than the RX buffer, in chunks, and sample the RTS line after each chunk.
+    tx_payload = bytes([x & 0xFF for x in range(flow_conf["rxbuf"] + 256)])
+    for i in range(0, len(tx_payload), 64):
+        uart.write(tx_payload[i : i + 64])
+        time.sleep_ms(2)
+        levels.add(rts_observer.value())
+
+    # Drain loopback RX to avoid affecting later users of this UART in this file.
+    uart.read()
+    print("Flow RTS backpressure toggled:", len(levels) > 1)
+
 
 uart_tests()
 uart_irq()

--- a/tests/ports/psoc-edge/board_ext_hw/single/uart.py
+++ b/tests/ports/psoc-edge/board_ext_hw/single/uart.py
@@ -89,30 +89,11 @@ def uart_tests():
     # write()/read() large data
     uart_rx_buf = bytearray(512)
     tx_data = bytes([x % 256 for x in range(512)])
-    uart_rx_view = memoryview(uart_rx_buf)
-    tx_written = 0
-    read_num = 0
-    chunk_size = 64
-    for offset in range(0, len(tx_data), chunk_size):
-        chunk = tx_data[offset : offset + chunk_size]
-        tx_written += uart.write(chunk)
-        uart.flush()
-
-        chunk_end = offset + len(chunk)
-        start = time.ticks_ms()
-        while read_num < chunk_end and time.ticks_diff(time.ticks_ms(), start) < 500:
-            written = uart.readinto(uart_rx_view[read_num:chunk_end])
-            if written is None:
-                written = 0
-            read_num += written
-            if read_num < chunk_end:
-                time.sleep_ms(5)
-
+    tx_written = uart.write(tx_data)
     print("Tx written bytes by write(): ", tx_written)
-    print(
-        "Tx is received by Rx(readinto(buf)) for large data: ",
-        (read_num == len(tx_data)) and (uart_rx_buf == tx_data),
-    )
+    # An added sleep here makes the last bytes to be lost.
+    read_num = uart.readinto(uart_rx_buf)
+    print("Tx is received by Rx(readinto(buf)) for large data: ", uart_rx_buf == tx_data)
     if uart_rx_buf != tx_data:
         print("Received data:", uart_rx_buf)
         print("Num of bytes read:", read_num)
@@ -138,41 +119,34 @@ def uart_irq():
         handler_irq_flag = True
         print(f"IRQ {event} handler called")
 
-    def wait_for_irq_handler(timeout_ms=200):
+    def wait_for_irq_handler():
         global handler_irq_flag
-        start = time.ticks_ms()
         while not handler_irq_flag:
-            if time.ticks_diff(time.ticks_ms(), start) >= timeout_ms:
-                return False
             time.sleep_ms(10)
         handler_irq_flag = False
-        return True
 
     # BREAK Received check
     event = "BREAK"
     irq = uart.irq(handler=uart_irq_handler, trigger=(UART.IRQ_BREAK))
     uart.sendbreak()
-    break_seen = wait_for_irq_handler()
-    print("IRQ BREAK detected: ", break_seen and (irq.flags() & UART.IRQ_BREAK == UART.IRQ_BREAK))
+    wait_for_irq_handler()
+    print("IRQ BREAK detected: ", irq.flags() & UART.IRQ_BREAK == UART.IRQ_BREAK)
 
     # TXIDLE check
     event = "TXIDLE"
     uart.irq(handler=uart_irq_handler, trigger=(UART.IRQ_TXIDLE))
     uart.write("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
-    txidle_seen = wait_for_irq_handler()
-    print(
-        "IRQ TXIDLE detected: ", txidle_seen and (irq.flags() & UART.IRQ_TXIDLE == UART.IRQ_TXIDLE)
-    )
+    wait_for_irq_handler()
+    print("IRQ TXIDLE detected: ", irq.flags() & UART.IRQ_TXIDLE == UART.IRQ_TXIDLE)
+    # prevent the TXIDLE IRQ from being triggered again by reading all data available in the RX FIFO.
     uart.read()
 
     # RXIDLE check
     event = "RXIDLE"
     uart.irq(handler=uart_irq_handler, trigger=(UART.IRQ_RXIDLE))
     uart.write("1")
-    rxidle_seen = wait_for_irq_handler()
-    print(
-        "IRQ RXIDLE detected: ", rxidle_seen and (irq.flags() & UART.IRQ_RXIDLE == UART.IRQ_RXIDLE)
-    )
+    wait_for_irq_handler()
+    print("IRQ RXIDLE detected: ", irq.flags() & UART.IRQ_RXIDLE == UART.IRQ_RXIDLE)
 
     # Clear the test IRQ handler so later UART traffic does not add extra output.
     uart.irq(handler=None, trigger=0)

--- a/tests/ports/psoc-edge/board_ext_hw/single/uart.py.exp
+++ b/tests/ports/psoc-edge/board_ext_hw/single/uart.py.exp
@@ -19,3 +19,6 @@ IRQ TXIDLE handler called
 IRQ TXIDLE detected:  True
 IRQ RXIDLE handler called
 IRQ RXIDLE detected:  True
+Flow CTS: True
+Flow RTS: True
+Flow CTS|RTS: True

--- a/tests/ports/psoc-edge/board_ext_hw/single/uart.py.exp
+++ b/tests/ports/psoc-edge/board_ext_hw/single/uart.py.exp
@@ -22,3 +22,5 @@ IRQ RXIDLE detected:  True
 Flow CTS: True
 Flow RTS: True
 Flow CTS|RTS: True
+Flow CTS blocked TX: True
+Flow RTS backpressure toggled: True


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant,
     especially links to open issues. -->

- Added the Flow control feature and Python-visible constants (`UART.RTS` and `UART.CTS`) for UART.
- Enabled hardware CTS/RTS in SCB UART config (`enableCts` and `rtsRxFifoLevel`).
- Added strict flow argument validation. 
- Added RX backpressure handling for RTS behavior and RX interrupt resume after software consumes data.
- Updated write path for flow-control-safe timeout semantics.
- Updated _Quickref documentation_ with sample code for the flow control support.

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this section empty then your Pull Request may be closed. -->

- Tested multiple flow control scenarios locally.
- Basic flow control tests added on HIL.

### Generative AI

<!-- Please delete the answer below which doesn't apply, or write your own
     answer with more details. -->

I did not use generative AI tools when creating this PR.

<!-- We require everyone to answer this question. If you delete this section or
     ignore it then your PR may be closed.

     For more information, consult the MicroPython Generative AI Policy:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines#generative-ai-policy
     -->
