### PR TITLE
Install unittest

### DIFF
--- a/.github/workflows/ports_psoc-edge-ifx.yml
+++ b/.github/workflows/ports_psoc-edge-ifx.yml
@@ -75,9 +75,6 @@ jobs:
         run: |
           cp mpy-psoc-edge_${{ matrix.board }}_${{ needs.server-build.outputs.commit_sha }}/${{ env.mpy_hex_file }} tools/psoc-edge
           source tools/ci.sh && ci_psoc_edge_deploy_hil ${{ matrix.board }} ${{ env.mpy_hex_file }} tests/ports/psoc-edge/${{ runner.name }}-devs.yml
-      - name: Dual core setup
-        run: |
-          source tools/ci.sh && ci_psoc_edge_deploy_cm55_hil ${{ matrix.board }} tests/ports/psoc-edge/${{ runner.name }}-devs.yml
       - name: Decrypt Wi-Fi secrets
         if: ${{ hashFiles('tests/ports/psoc-edge/mp_custom/secrets.py.gpg') != '' && env.LARGE_SECRET_PASSPHRASE != '' }}
         run: sh tools/psoc-edge/decrypt_secrets.sh

--- a/tests/ports/psoc-edge/test-plan.yml
+++ b/tests/ports/psoc-edge/test-plan.yml
@@ -112,9 +112,7 @@
       - extmod/socket_badconstructor.py
       - extmod/socket_fileno.py
       - extmod/socket_tcp_basic.py
-      # TODO: Re-enable tests after effectively installing unittest 
-      # only for the target boards running the affected tests.
-      # - extmod/socket_udp_nonblock.py
+      - extmod/socket_udp_nonblock.py
       - net_hosted/accept_nonblock.py
       - net_hosted/accept_timeout.py
     device:

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -403,17 +403,7 @@ function ci_psoc_edge_build_hil {
     docker exec mpy-ci make BOARD=${board}
 }
 
-function ci_psoc_edge_deploy_cm55_hil {
-    board=$1
-    devs_file=$2
-    uids=$(etdevs-query uid --filter name=${board} --devs-yml ${devs_file})
-    for uid in $uids; do
-        echo "Deploying CM55 firmware to device with UID: ${uid}"
-        docker exec mpy-ci make deploy_cm55 BOARD=${board} DEV_SERIAL_NUMBER=${uid}
-    done
-}
-
-function ci_psoc_edge_deploy_hil {
+function ci_psoc_edge_deploy_mpy_hil {
     board=$1
     # hex file including path with respect to micropython root
     hex_file=$2
@@ -425,8 +415,53 @@ function ci_psoc_edge_deploy_hil {
     else
         dev_files_arg="--devs-file ../../${devs_file}"
     fi
-    
+
     docker exec mpy-ci /bin/bash -c "cd ../../tools/psoc-edge && python3 mpy-pse.py device-setup --board ${board} --hex-file ${hex_file} ${dev_files_arg} -q"
+}
+
+function ci_psoc_edge_deploy_cm55_hil {
+    board=$1
+    devs_file=$2
+    uids=$(etdevs-query uid --filter name=${board} --devs-yml ${devs_file})
+    for uid in $uids; do
+        echo "Deploying CM55 firmware to device with UID: ${uid}"
+        docker exec mpy-ci make deploy_cm55 BOARD=${board} DEV_SERIAL_NUMBER=${uid}
+    done
+}
+
+function ci_psoc_edge_install_libs_hil {
+    board=$1
+    devs_file=$2
+    mpr_cmd="python3 tools/mpremote/mpremote.py"
+    libs=(unittest)
+
+    uids=$(etdevs-query uid --filter name=${board} --devs-yml ${devs_file})
+    for lib in "${libs[@]}"; do
+        for uid in $uids; do
+            port=$(etdevs-query address --filter uid=${uid} --devs-yml ${devs_file})
+            echo "Checking unittest on device UID ${uid} (port: ${port})"
+
+            # Only install the library if not already present in "/lib".
+            # `mpremote ls` prints size columns, so match against the final path token.
+            if ${mpr_cmd} connect ${port} ls lib 2>/dev/null | awk '{print $NF}' | grep -Eq "^${lib}/?$"; then
+                echo "${lib} already installed on ${port}"
+            else
+                echo "Installing ${lib} on ${port}"
+                ${mpr_cmd} connect ${port} mip install ${lib}
+            fi
+        done
+    done
+}
+
+function ci_psoc_edge_deploy_hil {
+    board=$1
+    # hex file including path with respect to micropython root
+    hex_file=$2
+    devs_file=$3
+
+    ci_psoc_edge_deploy_mpy_hil "${board}" "${hex_file}" "${devs_file}"
+    ci_psoc_edge_deploy_cm55_hil "${board}" "${devs_file}"
+    ci_psoc_edge_install_libs_hil "${board}" "${devs_file}"
 }
 
 function ci_psoc_edge_teardown_hil {


### PR DESCRIPTION
What about like this? 

The ci.sh provide the micropython deploy + extra testing dependencies (cm55 firmware for dual core + mpy external libraries).
The run_test_plan.py cares only about which tests can/should be run for a given board, and how to find it. 

As long as we don't discriminate as per test and board, we can just install the libraries for all boards (if they don't have it installed yet). 
Not sure if we will effectively save a ci time currently just installing it per test or boards. 

I am using [etdevs ](https://ifx-etdevs.readthedocs.io/en/latest/cli-etdevs-query.html) directly to find the relevant devices and their serial port address.

This was the [first run](https://github.com/Infineon/micropython-psoc-edge/actions/runs/30268595294/job/89985898042#step:6:463):

```
Installing unittest on /dev/ttyACM9
Install unittest
Installing unittest (latest) from https://micropython.org/pi/v2 to /lib
Installing: /lib/unittest/__init__.mpy
Done
Checking unittest on device UID 111B1698012D2400 (port: /dev/ttyACM16)
Installing unittest on /dev/ttyACM16
Install unittest
Installing unittest (latest) from https://micropython.org/pi/v2 to /lib
Installing: /lib/unittest/__init__.mpy
Done
Checking unittest on device UID 101A1398012D2400 (port: /dev/ttyACM19)
Installing unittest on /dev/ttyACM19
Install unittest
Installing unittest (latest) from https://micropython.org/pi/v2 to /lib
Installing: /lib/unittest/__init__.mpy
Done
Checking unittest on device UID 0E240C98012D2400 (port: /dev/ttyACM17)
Installing unittest on /dev/ttyACM17
Install unittest
Installing unittest (latest) from https://micropython.org/pi/v2 to /lib
Installing: /lib/unittest/__init__.mpy
Done
Checking unittest on device UID 0C170798012D2400 (port: /dev/ttyACM20)
Installing unittest on /dev/ttyACM20
Install unittest
Installing unittest (latest) from https://micropython.org/pi/v2 to /lib
Installing: /lib/unittest/__init__.mpy
```

And in the [second run](https://github.com/Infineon/micropython-psoc-edge/actions/runs/30270157648/job/89990987795#step:6:463) the libs are already installed:

```
Checking unittest on device UID 0F16025A012D2400 (port: /dev/ttyACM9)
unittest already installed on /dev/ttyACM9
Checking unittest on device UID 111B1698012D2400 (port: /dev/ttyACM16)
unittest already installed on /dev/ttyACM16
Checking unittest on device UID 101A1398012D2400 (port: /dev/ttyACM19)
unittest already installed on /dev/ttyACM19
Checking unittest on device UID 0E240C98012D2400 (port: /dev/ttyACM17)
unittest already installed on /dev/ttyACM17
Checking unittest on device UID 0C170798012D2400 (port: /dev/ttyACM20)
unittest already installed on /dev/ttyACM20

```

We can as well keep on with the other approach, but I would like to keep it as optional rather than hardcoded for all tests. And then that you can install any library. 
Via cli or/and .yml configurable option (as global). 
