### PR TITLE
Replace Board (used for SPI tests) on HIL with hirose connected board

### DIFF
--- a/tests/ports/psoc-edge/BLR-Runner-devs.yml
+++ b/tests/ports/psoc-edge/BLR-Runner-devs.yml
@@ -25,7 +25,7 @@
     - time-pulse
 
 - name: KIT_PSE84_AI
-  uid: 0C170798012D2400
+  uid: 1D1B1398012D2400
   features:
     - spi
     - bitstream


### PR DESCRIPTION
### Summary

Replace the existing SPI test board with a Hirose-connected board to enable ADC testing on the same hardware setup, eliminating the need for an additional board.

### Testing

N/A


### Trade-offs and Alternatives

N/A


### Generative AI

I did not use generative AI tools when creating this PR.


