### PR TITLE
Remove bsp clk peri init

### DIFF
--- a/ports/psoc-edge/boards/KIT_PSE84_AI/bsp-cfg/cycfg.c
+++ b/ports/psoc-edge/boards/KIT_PSE84_AI/bsp-cfg/cycfg.c
@@ -37,13 +37,16 @@ void init_cycfg_all(void) {
 void cycfg_config_init(void) {
     init_cycfg_clocks();
     /**
-     * TODO: Comment init_cycfg_peripheral_clocks()
-     * & init_cycfg_peripherals() out once all machine peripherals
-     * are implemented based on `clk` lib.
+     * Handled in runtime during machine
+     * object creation and initialization
+     * via `clk` module.
      */
-    init_cycfg_peripheral_clocks();
+    #if defined(COMPONENT_SECURE_DEVICE)
+    /* Secure boot initializes minimal periph initialization */
+    init_cycfg_peripheral_clocks_s_minimal();
+    init_cycfg_peripheral_s_minimal();
+    #endif /* defined(COMPONENT_SECURE_DEVICE) */
     init_cycfg_system();
-    init_cycfg_peripherals();
     init_cycfg_routing();
     init_cycfg_pins();
     init_cycfg_protection();

--- a/ports/psoc-edge/boards/KIT_PSE84_AI/bsp-cfg/cycfg_peripheral_clocks.c
+++ b/ports/psoc-edge/boards/KIT_PSE84_AI/bsp-cfg/cycfg_peripheral_clocks.c
@@ -81,3 +81,14 @@ void init_cycfg_peripheral_clocks(void) {
     Cy_SysClk_PeriPclkSetDivider((en_clk_dst_t)CYBSP_SDHC_0_CLK_DIV_GRP_NUM, CY_SYSCLK_DIV_8_BIT, 0U, 1U);
     Cy_SysClk_PeriPclkEnableDivider((en_clk_dst_t)CYBSP_SDHC_0_CLK_DIV_GRP_NUM, CY_SYSCLK_DIV_8_BIT, 0U);
 }
+
+/**
+ * This function is not part of the generated sources.
+ * It is added by MicroPython to avoid unused peripheral default allocations.
+ */
+
+void init_cycfg_peripheral_clocks_s_minimal(void) {
+    Cy_SysClk_PeriPclkDisableDivider((en_clk_dst_t)CYBSP_SDHC_0_CLK_DIV_GRP_NUM, CY_SYSCLK_DIV_8_BIT, 0U);
+    Cy_SysClk_PeriPclkSetDivider((en_clk_dst_t)CYBSP_SDHC_0_CLK_DIV_GRP_NUM, CY_SYSCLK_DIV_8_BIT, 0U, 1U);
+    Cy_SysClk_PeriPclkEnableDivider((en_clk_dst_t)CYBSP_SDHC_0_CLK_DIV_GRP_NUM, CY_SYSCLK_DIV_8_BIT, 0U);
+}

--- a/ports/psoc-edge/boards/KIT_PSE84_AI/bsp-cfg/cycfg_peripheral_clocks.h
+++ b/ports/psoc-edge/boards/KIT_PSE84_AI/bsp-cfg/cycfg_peripheral_clocks.h
@@ -247,6 +247,7 @@ extern "C" {
 #endif /* !defined (CYBSP_SDHC_0_CLK_DIV_GRP_NUM) */
 
 void init_cycfg_peripheral_clocks(void);
+void init_cycfg_peripheral_clocks_s_minimal(void);
 
 #if defined(__cplusplus)
 }

--- a/ports/psoc-edge/boards/KIT_PSE84_AI/bsp-cfg/cycfg_peripherals.c
+++ b/ports/psoc-edge/boards/KIT_PSE84_AI/bsp-cfg/cycfg_peripherals.c
@@ -1336,3 +1336,17 @@ void init_cycfg_peripherals(void) {
     #endif /* defined (CY_DEVICE_CONFIGURATOR_IP_ENABLE_FEATURE) */
     Cy_SysClk_PeriphAssignDivider(PCLK_TCPWM0_CLOCK_COUNTER_EN7, CY_SYSCLK_DIV_8_BIT, 3U);
 }
+
+
+/**
+ * This function is not part of the generated sources.
+ * It is added by MicroPython to avoid unused peripheral default allocations.
+ */
+
+void init_cycfg_peripheral_s_minimal(void) {
+    #if defined(CY_DEVICE_CONFIGURATOR_IP_ENABLE_FEATURE)
+    Cy_SysClk_PeriGroupSlaveInit(CY_MMIO_SDHC0_PERI_NR, CY_MMIO_SDHC0_GROUP_NR, CY_MMIO_SDHC0_SLAVE_NR, CY_MMIO_SDHC0_CLK_HF_NR);
+    #endif /* defined (CY_DEVICE_CONFIGURATOR_IP_ENABLE_FEATURE) */
+    Cy_SysClk_PeriPclkAssignDivider(PCLK_SDHC0_CLK_HF, CY_SYSCLK_DIV_8_BIT, 0U);
+    Cy_SysClk_PeriGroupSlaveInit(CY_MMIO_SMIF01_PERI_NR, CY_MMIO_SMIF01_GROUP_NR, CY_MMIO_SMIF01_SLAVE_NR, CY_MMIO_SMIF01_CLK_HF_NR);
+}

--- a/ports/psoc-edge/boards/KIT_PSE84_AI/bsp-cfg/cycfg_peripherals.h
+++ b/ports/psoc-edge/boards/KIT_PSE84_AI/bsp-cfg/cycfg_peripherals.h
@@ -358,6 +358,7 @@ extern const mtb_hal_pwm_configurator_t CYBSP_DEAD_TIME_PWM_hal_config;
 #endif /* defined (COMPONENT_MTB_HAL) && (MTB_HAL_DRIVER_AVAILABLE_PWM) */
 
 void init_cycfg_peripherals(void);
+void init_cycfg_peripheral_s_minimal(void);
 
 #if defined(__cplusplus)
 }

--- a/ports/psoc-edge/machine_i2c.c
+++ b/ports/psoc-edge/machine_i2c.c
@@ -125,9 +125,6 @@ static void machine_hw_i2c_init(machine_hw_i2c_obj_t *self, uint32_t freq_hz) {
 
     mp_hal_periph_pins_af_init(i2c_pins_config, 2);
 
-    result = Cy_SCB_I2C_Init(self->scb_obj->scb, &self->cfg, &self->ctx);
-    i2c_assert_raise_val("I2C init failed: 0x%lx", result);
-
     // For desired data rate, clk_scb frequency must be in valid range (see TRM I2C Oversampling section)
     // For 100kHz: clk_scb range is 1.55 - 3.2 MHz (architecture reference manual 002-38331 Rev. P685 table 355)
     //   - clk_peri = 100 MHz, divider = 42 → clk_scb = 2.38 MHz ✓ (mid-range)
@@ -141,6 +138,9 @@ static void machine_hw_i2c_init(machine_hw_i2c_obj_t *self, uint32_t freq_hz) {
     if (self->pclk_div == NULL) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("failed to initialize clock divider for I2C(%u)"), self->scb_obj->id);
     }
+
+    result = Cy_SCB_I2C_Init(self->scb_obj->scb, &self->cfg, &self->ctx);
+    i2c_assert_raise_val("I2C init failed: 0x%lx", result);
 
     uint32_t input_freq = pclk_div_get_input_freq(self->scb_obj->clk);
     if (input_freq == 0U) {

--- a/ports/psoc-edge/machine_i2c_target.c
+++ b/ports/psoc-edge/machine_i2c_target.c
@@ -197,11 +197,6 @@ static void i2c_target_init(machine_i2c_target_obj_t *self, machine_i2c_target_d
 
     mp_hal_periph_pins_af_init(i2c_pins_config, 2);
 
-    result = Cy_SCB_I2C_Init(self->scb_obj->scb, &self->cfg, &self->ctx);
-    if (result != CY_RSLT_SUCCESS) {
-        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C target init failed: 0x%lx"), result);
-    }
-
     // Configure clock for I2C slave operation
     // For 400 khz slave, clk_scb must be 7.82 – 15.38 MHz
     // For 100 khz slave, clk_scb must be 1.55 – 12.8 MHz
@@ -213,6 +208,11 @@ static void i2c_target_init(machine_i2c_target_obj_t *self, machine_i2c_target_d
     self->pclk_div = pclk_div_init(self->scb_obj->clk, divider, 0);
     if (self->pclk_div == NULL) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("failed to initialize clock divider for I2CTarget(%u)"), self->id);
+    }
+
+    result = Cy_SCB_I2C_Init(self->scb_obj->scb, &self->cfg, &self->ctx);
+    if (result != CY_RSLT_SUCCESS) {
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C target init failed: 0x%lx"), result);
     }
 
     sys_int_init(&(self->scb_obj->irq));


### PR DESCRIPTION
* Remove peri clock slave and divider initialization and static configuration in BSP init. 
* Fixed clock initialization order in I2C classes. This was only working before, because the clocks divider were inited in the BSP. 