### PR TITLE
psoc-edge: Remove machine prefix from scb lib.

### DIFF
--- a/ports/psoc-edge/Makefile
+++ b/ports/psoc-edge/Makefile
@@ -586,7 +586,6 @@ MOD_SRC_C += \
 	machine_spi_target.c \
 	machine_rtc.c \
 	machine_ipc.c \
-	machine_scb.c \
 	machine_timer.c \
 	machine_counter.c \
 	machine_bitstream.c \
@@ -607,6 +606,7 @@ SRC_C += \
 	help.c \
 	main.c \
 	mphalport.c \
+	scb.c \
 	systick.c \
 	sys_int.c \
 	tcpwm.c \

--- a/ports/psoc-edge/boards/make-pins.py
+++ b/ports/psoc-edge/boards/make-pins.py
@@ -381,7 +381,7 @@ class PSE84PinGenerator(boardgen.PinGenerator):
     def print_scb_defines(self, out_header):
         print(file=out_header)
         print(
-            f"#define MICROPY_PY_MACHINE_SCB_NUM_ENTRIES ({self._scb_max_index + 1})",
+            f"#define MICROPY_PY_SCB_NUM_ENTRIES ({self._scb_max_index + 1})",
             file=out_header,
         )
 
@@ -401,10 +401,10 @@ class PSE84PinGenerator(boardgen.PinGenerator):
         )
 
         print(file=out_header)
-        print("// The MICROPY_PY_MACHINE_FOR_ALL_SCB(DO) macro will", file=out_header)
+        print("// The MICROPY_PY_FOR_ALL_SCB(DO) macro will", file=out_header)
         print("// apply the DO macro to all user available SCB units.", file=out_header)
         print("// The DO macro takes the SCB unit as argument: DO(unit).", file=out_header)
-        print("#define MICROPY_PY_MACHINE_FOR_ALL_SCB(DO) \\", file=out_header)
+        print("#define MICROPY_PY_FOR_ALL_SCB(DO) \\", file=out_header)
 
         lines = [f"DO({scb})" for scb in self._unhidden_scb]
         macro_body = " \\\n".join(lines)

--- a/ports/psoc-edge/machine_i2c.c
+++ b/ports/psoc-edge/machine_i2c.c
@@ -45,7 +45,7 @@
 #include "clk.h"
 #include "genhdr/pins_af.h"
 #include "modmachine.h"
-#include "machine_scb.h"
+#include "scb.h"
 
 #define DEBUG_printf(...) // printf(__VA_ARGS__)
 
@@ -62,7 +62,7 @@ typedef struct _machine_hw_i2c_obj_t {
     mp_hal_pin_obj_t sda;
     uint32_t freq;
     uint32_t timeout;
-    machine_scb_obj_t *scb_obj;
+    scb_obj_t *scb_obj;
     pclk_div_obj_t *pclk_div;
     cy_stc_scb_i2c_config_t cfg;   // PDL I2C configuration
     cy_stc_scb_i2c_context_t ctx;  // PDL I2C runtime context
@@ -121,7 +121,7 @@ static void machine_hw_i2c_init(machine_hw_i2c_obj_t *self, uint32_t freq_hz) {
     machine_pin_af_unit_t af_unit = MACHINE_PIN_AF_UNIT_NONE;
     mp_hal_periph_pins_af_resolve_fn_unit(i2c_pins_config, 2, MACHINE_PIN_AF_FN_I2C, &af_unit);
 
-    self->scb_obj = machine_scb_obj_alloc(af_unit, self, machine_hw_i2c_scb_isr);
+    self->scb_obj = scb_obj_alloc(af_unit, self, machine_hw_i2c_scb_isr);
 
     mp_hal_periph_pins_af_init(i2c_pins_config, 2);
 
@@ -177,7 +177,7 @@ static void machine_hw_i2c_deinit(mp_obj_base_t *self_in) {
     pclk_div_deinit(self->pclk_div);
     pclk_div_slave_deinit(self->scb_obj->clk, self->scb_obj->mmio_slave_nr);
 
-    machine_scb_obj_free(self->scb_obj);
+    scb_obj_free(self->scb_obj);
     machine_hw_i2c_obj_free(self);
 }
 

--- a/ports/psoc-edge/machine_i2c_target.c
+++ b/ports/psoc-edge/machine_i2c_target.c
@@ -39,7 +39,7 @@
 #include "clk.h"
 #include "genhdr/pins_af.h"
 #include "modmachine.h"
-#include "machine_scb.h"
+#include "scb.h"
 
 #define DEBUG_printf(...) // printf(__VA_ARGS__)
 
@@ -53,7 +53,7 @@ typedef struct _machine_i2c_target_obj_t {
     mp_hal_pin_obj_t sda;
     uint32_t slave_addr;
     uint8_t addrsize;
-    machine_scb_obj_t *scb_obj;
+    scb_obj_t *scb_obj;
     pclk_div_obj_t *pclk_div;
     cy_stc_scb_i2c_config_t cfg;
     cy_stc_scb_i2c_context_t ctx;
@@ -193,7 +193,7 @@ static void i2c_target_init(machine_i2c_target_obj_t *self, machine_i2c_target_d
     machine_pin_af_unit_t af_unit = MACHINE_PIN_AF_UNIT_NONE;
     mp_hal_periph_pins_af_resolve_fn_unit(i2c_pins_config, 2, MACHINE_PIN_AF_FN_I2C, &af_unit);
 
-    self->scb_obj = machine_scb_obj_alloc(af_unit, self, machine_i2c_target_scb_isr);
+    self->scb_obj = scb_obj_alloc(af_unit, self, machine_i2c_target_scb_isr);
 
     mp_hal_periph_pins_af_init(i2c_pins_config, 2);
 
@@ -361,7 +361,7 @@ static void mp_machine_i2c_target_deinit(machine_i2c_target_obj_t *self) {
     pclk_div_slave_deinit(self->scb_obj->clk, self->scb_obj->mmio_slave_nr);
     self->base.type = NULL;
 
-    machine_scb_obj_free(self->scb_obj);
+    scb_obj_free(self->scb_obj);
 
     DEBUG_printf("I2C Target deinitialized\n");
 }

--- a/ports/psoc-edge/machine_spi.c
+++ b/ports/psoc-edge/machine_spi.c
@@ -33,7 +33,7 @@
 #include "cy_scb_spi.h"
 #include "clk.h"
 #include "genhdr/pins_af.h"
-#include "machine_scb.h"
+#include "scb.h"
 #include "modmachine.h"
 
 #define DEFAULT_SPI_BAUDRATE    (1000000)
@@ -58,7 +58,7 @@ typedef struct _machine_spi_obj_t {
     uint8_t firstbit;
     uint32_t timeout;
     pclk_div_obj_t *pclk_div;
-    machine_scb_obj_t *scb_obj;
+    scb_obj_t *scb_obj;
     cy_stc_scb_spi_config_t cfg;
     cy_stc_scb_spi_context_t ctx;
 } machine_spi_obj_t;
@@ -139,7 +139,7 @@ static void machine_spi_hw_init(machine_spi_obj_t *self) {
         self->sck, self->mosi, self->miso);
 
     // Allocate SCB
-    self->scb_obj = machine_scb_obj_alloc(scb_unit, self,
+    self->scb_obj = scb_obj_alloc(scb_unit, self,
         machine_spi_scb_isr);
 
     pclk_div_slave_init(self->scb_obj->clk, self->scb_obj->mmio_slave_nr);
@@ -147,7 +147,7 @@ static void machine_spi_hw_init(machine_spi_obj_t *self) {
     uint32_t clk_hf_freq = pclk_div_get_input_freq(self->scb_obj->clk);
     if (clk_hf_freq == 0U) {
         pclk_div_slave_deinit(self->scb_obj->clk, self->scb_obj->mmio_slave_nr);
-        machine_scb_obj_free(self->scb_obj);
+        scb_obj_free(self->scb_obj);
         self->scb_obj = NULL;
         mp_raise_ValueError(MP_ERROR_TEXT("failed to get SPI input clock"));
     }
@@ -165,7 +165,7 @@ static void machine_spi_hw_init(machine_spi_obj_t *self) {
     self->pclk_div = pclk_div_init(self->scb_obj->clk, div_val, 0);
     if (self->pclk_div == NULL) {
         pclk_div_slave_deinit(self->scb_obj->clk, self->scb_obj->mmio_slave_nr);
-        machine_scb_obj_free(self->scb_obj);
+        scb_obj_free(self->scb_obj);
         self->pclk_div = NULL;
         self->scb_obj = NULL;
         mp_raise_ValueError(MP_ERROR_TEXT("SPI clock dividers exhausted"));
@@ -222,7 +222,7 @@ static void machine_spi_hw_init(machine_spi_obj_t *self) {
         pclk_div_deinit(self->pclk_div);
         self->pclk_div = NULL;
         pclk_div_slave_deinit(self->scb_obj->clk, self->scb_obj->mmio_slave_nr);
-        machine_scb_obj_free(self->scb_obj);
+        scb_obj_free(self->scb_obj);
         self->scb_obj = NULL;
         mp_raise_msg_varg(&mp_type_ValueError,
             MP_ERROR_TEXT("SPI init failed: 0x%lx"), (uint32_t)result);
@@ -239,7 +239,7 @@ static void machine_spi_hw_deinit(machine_spi_obj_t *self) {
     pclk_div_deinit(self->pclk_div);
     self->pclk_div = NULL;
     pclk_div_slave_deinit(self->scb_obj->clk, self->scb_obj->mmio_slave_nr);
-    machine_scb_obj_free(self->scb_obj);
+    scb_obj_free(self->scb_obj);
     self->scb_obj = NULL;
 }
 

--- a/ports/psoc-edge/machine_spi_target.c
+++ b/ports/psoc-edge/machine_spi_target.c
@@ -32,7 +32,7 @@
 #include "cy_scb_spi.h"
 #include "clk.h"
 #include "genhdr/pins_af.h"
-#include "machine_scb.h"
+#include "scb.h"
 #include "modmachine.h"
 
 #if MICROPY_PY_MACHINE_SPI_TARGET
@@ -64,7 +64,7 @@ typedef struct _machine_spi_target_obj_t {
     uint8_t firstbit;
     uint32_t timeout;
     pclk_div_obj_t *pclk_div;
-    machine_scb_obj_t *scb_obj;
+    scb_obj_t *scb_obj;
     cy_stc_scb_spi_config_t cfg;
     cy_stc_scb_spi_context_t ctx;
 } machine_spi_target_obj_t;
@@ -143,14 +143,14 @@ static void machine_spi_target_hw_init(machine_spi_target_obj_t *self) {
 
 
     // Allocate SCB
-    self->scb_obj = machine_scb_obj_alloc(scb_unit, self,
+    self->scb_obj = scb_obj_alloc(scb_unit, self,
         machine_spi_target_scb_isr);
 
     pclk_div_slave_init(self->scb_obj->clk, self->scb_obj->mmio_slave_nr);
     self->pclk_div = pclk_div_init(self->scb_obj->clk, SPI_TARGET_CLK_DIV_BASE, 0);
     if (self->pclk_div == NULL) {
         pclk_div_slave_deinit(self->scb_obj->clk, self->scb_obj->mmio_slave_nr);
-        machine_scb_obj_free(self->scb_obj);
+        scb_obj_free(self->scb_obj);
         self->scb_obj = NULL;
         mp_raise_ValueError(MP_ERROR_TEXT("SPITarget clock dividers exhausted"));
     }
@@ -206,7 +206,7 @@ static void machine_spi_target_hw_init(machine_spi_target_obj_t *self) {
         pclk_div_deinit(self->pclk_div);
         self->pclk_div = NULL;
         pclk_div_slave_deinit(self->scb_obj->clk, self->scb_obj->mmio_slave_nr);
-        machine_scb_obj_free(self->scb_obj);
+        scb_obj_free(self->scb_obj);
         self->scb_obj = NULL;
         mp_raise_msg_varg(&mp_type_ValueError,
             MP_ERROR_TEXT("SPITarget init failed: 0x%lx"), (uint32_t)result);
@@ -223,7 +223,7 @@ static void machine_spi_target_hw_deinit(machine_spi_target_obj_t *self) {
     pclk_div_deinit(self->pclk_div);
     self->pclk_div = NULL;
     pclk_div_slave_deinit(self->scb_obj->clk, self->scb_obj->mmio_slave_nr);
-    machine_scb_obj_free(self->scb_obj);
+    scb_obj_free(self->scb_obj);
     self->scb_obj = NULL;
 }
 

--- a/ports/psoc-edge/machine_uart.c
+++ b/ports/psoc-edge/machine_uart.c
@@ -47,7 +47,7 @@
 #include "genhdr/pins_af.h"
 #include "modmachine.h"
 #include "mphalport.h"
-#include "machine_scb.h"
+#include "scb.h"
 #include "sys_int.h"
 #include "clk.h"
 
@@ -87,7 +87,7 @@
 typedef struct _machine_uart_obj_t {
     mp_obj_base_t base;
     int id;                         // id matches the SCB id.
-    machine_scb_obj_t *scb_obj;
+    scb_obj_t *scb_obj;
     pclk_div_obj_t *pclk_div;
     mp_hal_pin_obj_t tx;
     mp_hal_pin_obj_t rx;
@@ -239,11 +239,11 @@ static void machine_uart_obj_make_or_reuse(machine_uart_obj_t **self_ptr, uint8_
 
     if (*self_ptr == NULL) {
         /* Create a new object and allocate the scb instance if free.*/
-        if (machine_scb_is_free(id)) {
+        if (scb_is_free(id)) {
             (*self_ptr) = mp_machine_uart_obj_alloc();
             (*self_ptr)->id = id;
             (*self_ptr)->pclk_div = NULL;
-            (*self_ptr)->scb_obj = machine_scb_obj_alloc(id, *self_ptr, machine_uart_scb_isr);
+            (*self_ptr)->scb_obj = scb_obj_alloc(id, *self_ptr, machine_uart_scb_isr);
             pclk_div_slave_init((*self_ptr)->scb_obj->clk, (*self_ptr)->scb_obj->mmio_slave_nr);
         } else {
             mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("SCB %u is already in use by a machine.I2C or machine.SPI instance."), id);
@@ -676,7 +676,7 @@ static mp_obj_t mp_machine_uart_make_new(const mp_obj_type_t *type, size_t n_arg
     const mp_obj_t *init_args = args;
     if (n_args > 0 && mp_obj_is_int(args[0])) {
         uart_id = mp_obj_get_int(args[0]);
-        if (uart_id < 0 || uart_id >= MICROPY_PY_MACHINE_SCB_NUM_ENTRIES) {
+        if (uart_id < 0 || uart_id >= MICROPY_PY_SCB_NUM_ENTRIES) {
             mp_raise_ValueError(MP_ERROR_TEXT("UART id out of range"));
         }
         init_n_args = n_args - 1;
@@ -696,7 +696,7 @@ static void mp_machine_uart_deinit(machine_uart_obj_t *self) {
     machine_uart_hw_deinit(self);
     m_del(uint8_t, self->rx_ringbuf.buf, self->rx_ringbuf.size);
     pclk_div_slave_deinit(self->scb_obj->clk, self->scb_obj->mmio_slave_nr);
-    machine_scb_obj_free(self->scb_obj);
+    scb_obj_free(self->scb_obj);
     mp_machine_uart_obj_free(self);
 }
 
@@ -1014,7 +1014,7 @@ void machine_uart_repl_init() {
 
     uint8_t scb_unit = uart_pins_config[0].af->unit;
 
-    repl_uart_obj.scb_obj = machine_scb_obj_alloc(scb_unit, &repl_uart_obj, machine_uart_scb_isr);
+    repl_uart_obj.scb_obj = scb_obj_alloc(scb_unit, &repl_uart_obj, machine_uart_scb_isr);
     repl_uart_obj.id = scb_unit;
     mp_hal_periph_pins_af_init(uart_pins_config, 2);
 

--- a/ports/psoc-edge/scb.c
+++ b/ports/psoc-edge/scb.c
@@ -30,20 +30,20 @@
 
 #include "py/runtime.h"
 #include "genhdr/pins_af.h"
-#include "machine_scb.h"
+#include "scb.h"
 
 /* Forward declaration */
-static void machine_scb_irq_handler(uint8_t scb);
+static void scb_irq_handler(uint8_t scb);
 
 #define DEFINE_SCB_IRQ_HANDLER(scb) \
     void SCB##scb##_IRQ_Handler(void) { \
-        machine_scb_irq_handler(scb); \
+        scb_irq_handler(scb); \
     }
 
 /**
  * The file build-<board>/genhdr/pins_af.h contains the macro
  *
- *  MICROPY_PY_MACHINE_FOR_ALL_SCB(DO)
+ *  MICROPY_PY_FOR_ALL_SCB(DO)
  *
  *  which uses the X-macro (as argument) pattern to pass a worker
  *  macro DO(port) for the list of all user available ports.
@@ -58,9 +58,9 @@ static void machine_scb_irq_handler(uint8_t scb);
  * for more information.
  */
 
-MICROPY_PY_MACHINE_FOR_ALL_SCB(DEFINE_SCB_IRQ_HANDLER)
+MICROPY_PY_FOR_ALL_SCB(DEFINE_SCB_IRQ_HANDLER)
 
-#define MAP_SCB_IRQ_CONFIG(scb) \
+#define MAP_SCB_CONFIG(scb) \
     [scb] = { \
         scb, \
         SCB##scb, \
@@ -75,19 +75,19 @@ MICROPY_PY_MACHINE_FOR_ALL_SCB(DEFINE_SCB_IRQ_HANDLER)
         NULL, \
     },
 
-static machine_scb_obj_t machine_scb_obj[MICROPY_PY_MACHINE_SCB_NUM_ENTRIES] = {
-    MICROPY_PY_MACHINE_FOR_ALL_SCB(MAP_SCB_IRQ_CONFIG)
+static scb_obj_t scb_obj[MICROPY_PY_SCB_NUM_ENTRIES] = {
+    MICROPY_PY_FOR_ALL_SCB(MAP_SCB_CONFIG)
 };
 
-static void machine_scb_irq_handler(uint8_t scb) {
-    machine_scb_obj_t *scb_obj = &machine_scb_obj[scb];
-    if (scb_obj->parent != NULL && scb_obj->parent_handler != NULL) {
-        scb_obj->parent_handler(scb_obj->parent);
+static void scb_irq_handler(uint8_t scb) {
+    scb_obj_t *obj = &scb_obj[scb];
+    if (obj->parent != NULL && obj->parent_handler != NULL) {
+        obj->parent_handler(obj->parent);
     }
 }
 
-machine_scb_obj_t *machine_scb_obj_alloc(uint8_t scb, mp_obj_t parent, machine_scb_parent_irq_handler_t handler) {
-    machine_scb_obj_t *obj = &machine_scb_obj[scb];
+scb_obj_t *scb_obj_alloc(uint8_t scb, mp_obj_t parent, scb_parent_irq_handler_t handler) {
+    scb_obj_t *obj = &scb_obj[scb];
     if (obj->parent != NULL) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("SCB %u is already in use by another I2C, SPI or UART instance."), scb);
     }
@@ -95,16 +95,16 @@ machine_scb_obj_t *machine_scb_obj_alloc(uint8_t scb, mp_obj_t parent, machine_s
 
     obj->parent = parent;
     obj->parent_handler = handler;
-    return &machine_scb_obj[scb];
+    return &scb_obj[scb];
 }
 
-void machine_scb_obj_free(machine_scb_obj_t *scb) {
+void scb_obj_free(scb_obj_t *scb) {
     scb->parent = NULL;
     scb->parent_handler = NULL;
 }
 
-bool machine_scb_is_free(uint8_t scb) {
-    return machine_scb_obj[scb].parent == NULL;
+bool scb_is_free(uint8_t scb) {
+    return scb_obj[scb].parent == NULL;
 
 }
 

--- a/ports/psoc-edge/scb.h
+++ b/ports/psoc-edge/scb.h
@@ -24,26 +24,26 @@
  * THE SOFTWARE.
  */
 
-#ifndef MICROPY_INCLUDED_PSOC_EDGE_MACHINE_SCB_H
-#define MICROPY_INCLUDED_PSOC_EDGE_MACHINE_SCB_H
+#ifndef MICROPY_INCLUDED_PSOC_EDGE_SCB_H
+#define MICROPY_INCLUDED_PSOC_EDGE_SCB_H
 
 #include "sys_int.h"
 #include "py/obj.h"
 
-typedef void (*machine_scb_parent_irq_handler_t)(mp_obj_t scb_obj);
+typedef void (*scb_parent_irq_handler_t)(mp_obj_t scb_obj);
 
-typedef struct _machine_scb_obj_t {
+typedef struct _scb_obj_t {
     int8_t id;
     CySCB_Type *scb;
     sys_int_cfg_t irq;
     en_clk_dst_t clk;
     uint8_t mmio_slave_nr;
     mp_obj_t parent;
-    machine_scb_parent_irq_handler_t parent_handler;
-} machine_scb_obj_t;
+    scb_parent_irq_handler_t parent_handler;
+} scb_obj_t;
 
-machine_scb_obj_t *machine_scb_obj_alloc(uint8_t scb, mp_obj_t parent, machine_scb_parent_irq_handler_t handler);
-void machine_scb_obj_free(machine_scb_obj_t *scb);
-bool machine_scb_is_free(uint8_t scb);
+scb_obj_t *scb_obj_alloc(uint8_t scb, mp_obj_t parent, scb_parent_irq_handler_t handler);
+void scb_obj_free(scb_obj_t *scb);
+bool scb_is_free(uint8_t scb);
 
-#endif // MICROPY_INCLUDED_PSOC_EDGE_MACHINE_SCB_H
+#endif // MICROPY_INCLUDED_PSOC_EDGE_SCB_H


### PR DESCRIPTION
* Removed `machine_` prefix from serial communication block lib as per convention (clk, tcpwm...).

