### PR TITLE
Enable TCPWM slave init and deinit

### DIFF
--- a/ports/psoc-edge/machine_counter.c
+++ b/ports/psoc-edge/machine_counter.c
@@ -146,7 +146,7 @@ static void machine_counter_configure_clock(machine_counter_obj_t *self) {
         return;
     }
 
-    pclk_div_slave_init(self->pclk_dst, CY_MMIO_TCPWM0_SLAVE_NR);
+    machine_tcpwm_slave_init(self->pclk_dst);
 
     uint32_t clk_freq = pclk_div_get_input_freq(self->pclk_dst);
     if (clk_freq == 0U) {
@@ -618,14 +618,14 @@ static void machine_counter_init_helper_impl(machine_counter_obj_t *self,
 
     en_peri0_trig_input_debugreducation1_t in_trig = peri0_tr_io_input[fn_unit];
 
+    // Ensure the peripheral clock divider is configured and bound to this counter PCLK.
+    machine_counter_configure_clock(self);
+
     // Tear down any previous run before programming new pin routing.
     machine_counter_stop_hw(self);
     machine_counter_stop_irq(self);
     machine_counter_disable_aux_irqs(self);
     machine_counter_restore_src_pin(self);
-
-    // Ensure the peripheral clock divider is configured and bound to this counter PCLK.
-    machine_counter_configure_clock(self);
 
     mp_hal_periph_pins_af_init(&src_pin_af_config, 1);
 
@@ -837,7 +837,10 @@ static MP_DEFINE_CONST_FUN_OBJ_KW(machine_counter_init_obj, 1, machine_counter_i
 static mp_obj_t machine_counter_deinit(mp_obj_t self_in) {
     machine_counter_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
-    machine_counter_stop_hw(self);
+    // Only touch the TCPWM0 block if this counter actually configured it.
+    if (self->pclk_div != NULL) {
+        machine_counter_stop_hw(self);
+    }
     machine_counter_stop_irq(self);
     machine_counter_disable_aux_irqs(self);
     machine_counter_restore_src_pin(self);
@@ -853,15 +856,12 @@ static mp_obj_t machine_counter_deinit(mp_obj_t self_in) {
         self->mp_irq_obj->handler = mp_const_none;
     }
 
-    pclk_div_deinit(self->pclk_div);
-    /**
-     * TODO: The TCPWM0 MMIO slave is shared across Counter, Timer and PWM
-     * instances. Tearing it down here can break other active instances using a
-     * different counter. Review with a reference-counted shared usage of the
-     * TCPWM0 MMIO slave before enabling the slave deinit.
-     */
-    // pclk_div_slave_deinit(self->pclk_dst, CY_MMIO_TCPWM0_SLAVE_NR);
-    self->pclk_div = NULL;
+    if (self->pclk_div != NULL) {
+        pclk_div_deinit(self->pclk_div);
+        self->pclk_div = NULL;
+        // Release the shared TCPWM0 slave
+        machine_tcpwm_slave_deinit(self->pclk_dst);
+    }
 
     machine_tcpwm_counter_free(self->counter_num, MP_OBJ_FROM_PTR(self));
     if (counter_obj[self->id] == self) {

--- a/ports/psoc-edge/machine_pwm.c
+++ b/ports/psoc-edge/machine_pwm.c
@@ -201,11 +201,9 @@ static void machine_pwm_configure_clock(machine_pwm_obj_t *self) {
      * used.
      */
     if (self->pclk_div != NULL) {
-        pclk_div_deinit(self->pclk_div);
-        self->pclk_div = NULL;
+        return;
     }
-
-    pclk_div_slave_init(self->pclk_dst, CY_MMIO_TCPWM0_SLAVE_NR);
+    machine_tcpwm_slave_init(self->pclk_dst);
 
     uint32_t clock_freq = pclk_div_get_input_freq(self->pclk_dst);
     if (clock_freq == 0) {
@@ -383,7 +381,12 @@ static mp_obj_t mp_machine_pwm_make_new(const mp_obj_type_t *type, size_t n_args
         mp_machine_pwm_init_helper(self, n_args - 1, args + 1, &kw_args);
         nlr_pop();
     } else {
-        pclk_div_deinit(self->pclk_div);
+        if (self->pclk_div != NULL) {
+            pclk_div_deinit(self->pclk_div);
+            self->pclk_div = NULL;
+            // Release the shared TCPWM0 slave
+            machine_tcpwm_slave_deinit(self->pclk_dst);
+        }
         machine_tcpwm_counter_free(self->counter_num, MP_OBJ_FROM_PTR(self));
         pwm_pin_restore(self->pin);
         pwm_obj_free(self);
@@ -395,18 +398,18 @@ static mp_obj_t mp_machine_pwm_make_new(const mp_obj_type_t *type, size_t n_args
 
 // Disable the TCPWM counter, restore the GPIO pin to Hi-Z, and free the instance slot.
 static void mp_machine_pwm_deinit(machine_pwm_obj_t *self) {
-    Cy_TCPWM_PWM_Disable(TCPWM0, self->counter_num);
+    // Only touch the TCPWM0 block while if instance still holds the shared slave
+    if (self->pclk_div != NULL) {
+        Cy_TCPWM_PWM_Disable(TCPWM0, self->counter_num);
+    }
     pwm_pin_restore(self->pin);
     machine_tcpwm_counter_free(self->counter_num, MP_OBJ_FROM_PTR(self));
-    pclk_div_deinit(self->pclk_div);
-    /**
-     * TODO: The TCPWM0 MMIO slave is shared across Timer and PWM instances.
-     * Tearing it down here can break an active Timer that is using a different
-     * counter, which causes the TCPWM ownership test to hang after a fallback PWM.
-     * Review with a shared usage of the TCPWM0 MMIO slave and implement a reference counting mechanism to avoid
-     * tearing down the TCPWM0 MMIO slave when other instances are still using it.
-     */
-    // pclk_div_slave_deinit(self->pclk_dst, CY_MMIO_TCPWM0_SLAVE_NR);
+    if (self->pclk_div != NULL) {
+        pclk_div_deinit(self->pclk_div);
+        self->pclk_div = NULL;
+        // Release the shared TCPWM0 slave
+        machine_tcpwm_slave_deinit(self->pclk_dst);
+    }
     pwm_obj_free(self);
 }
 

--- a/ports/psoc-edge/machine_timer.c
+++ b/ports/psoc-edge/machine_timer.c
@@ -116,7 +116,7 @@ static void machine_timer_configure_clock(machine_timer_obj_t *self) {
         return;
     }
 
-    pclk_div_slave_init(self->pclk_dst, CY_MMIO_TCPWM0_SLAVE_NR);
+    machine_tcpwm_slave_init(self->pclk_dst);
 
     uint32_t clk_freq = pclk_div_get_input_freq(self->pclk_dst);
 
@@ -363,8 +363,11 @@ static mp_obj_t machine_timer_make_new(const mp_obj_type_t *type,
         }
         nlr_pop();
     } else {
-        pclk_div_deinit(self->pclk_div);
-        self->pclk_div = NULL;
+        if (self->pclk_div != NULL) {
+            pclk_div_deinit(self->pclk_div);
+            self->pclk_div = NULL;
+            machine_tcpwm_slave_deinit(self->pclk_dst);
+        }
         machine_tcpwm_counter_free(self->counter_num, MP_OBJ_FROM_PTR(self));
         timer_obj[id] = NULL;
         nlr_jump(nl.ret_val);
@@ -390,17 +393,21 @@ static MP_DEFINE_CONST_FUN_OBJ_KW(machine_timer_init_obj, 1, machine_timer_init)
 
 static mp_obj_t machine_timer_deinit(mp_obj_t self_in) {
     machine_timer_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    Cy_TCPWM_Counter_Disable(TCPWM0, self->counter_num);
+    // Only touch the TCPWM0 block if this timer actually configured it.
+    if (self->pclk_div != NULL) {
+        Cy_TCPWM_Counter_Disable(TCPWM0, self->counter_num);
+    }
     if (self->active) {
         sys_int_deinit(&self->irq_cfg);
     }
     self->callback = mp_const_none;
     self->ishard = false;
     self->active = false;
-    pclk_div_deinit(self->pclk_div);
-    /* TODO: Review obj initialization in general... */
-    // pclk_div_slave_deinit(self->pclk_dst, CY_MMIO_TCPWM0_SLAVE_NR);
-    self->pclk_div = NULL;
+    if (self->pclk_div != NULL) {
+        pclk_div_deinit(self->pclk_div);
+        self->pclk_div = NULL;
+        machine_tcpwm_slave_deinit(self->pclk_dst);
+    }
     machine_tcpwm_counter_free(self->counter_num, MP_OBJ_FROM_PTR(self));
     timer_obj[self->id] = NULL;
     return mp_const_none;

--- a/ports/psoc-edge/tcpwm.c
+++ b/ports/psoc-edge/tcpwm.c
@@ -26,8 +26,12 @@
 
 #include "py/runtime.h"
 #include "tcpwm.h"
+#include "clk.h"
 
 static mp_obj_t machine_tcpwm0_counter[MICROPY_PY_MACHINE_TCPWM0_NUM_COUNTERS] = { MP_OBJ_NULL };
+
+// Shared reference count for the TCPWM0 slave TCPWM_0_SLAVE_NR.
+static uint32_t machine_tcpwm0_slave_ref_count = 0;
 
 // Helper function to validate if a counter is supported
 static bool machine_tcpwm_counter_is_valid(uint32_t counter_num) {
@@ -88,4 +92,21 @@ en_clk_dst_t machine_tcpwm_counter_pclk(uint32_t counter_num) {
                 MP_ERROR_TEXT("TCPWM0 counter %lu is not supported"), counter_num);
     }
 #undef TCPWM_PCLK_CASE
+}
+
+void machine_tcpwm_slave_init(en_clk_dst_t pclk_dst) {
+    pclk_div_slave_init(pclk_dst, CY_MMIO_TCPWM0_SLAVE_NR);
+    machine_tcpwm0_slave_ref_count++;
+}
+
+void machine_tcpwm_slave_deinit(en_clk_dst_t pclk_dst) {
+    if (machine_tcpwm0_slave_ref_count == 0) {
+        return;
+    }
+    machine_tcpwm0_slave_ref_count--;
+    // Only tear the shared slave down once the last Counter/Timer/PWM using the
+    // TCPWM0 block has been deinitialised.
+    if (machine_tcpwm0_slave_ref_count == 0) {
+        pclk_div_slave_deinit(pclk_dst, CY_MMIO_TCPWM0_SLAVE_NR);
+    }
 }

--- a/ports/psoc-edge/tcpwm.h
+++ b/ports/psoc-edge/tcpwm.h
@@ -37,4 +37,7 @@ bool machine_tcpwm_counter_try_alloc(uint32_t counter_num, mp_obj_t owner);
 void machine_tcpwm_counter_free(uint32_t counter_num, mp_obj_t owner);
 en_clk_dst_t machine_tcpwm_counter_pclk(uint32_t counter_num);
 
+void machine_tcpwm_slave_init(en_clk_dst_t pclk_dst);
+void machine_tcpwm_slave_deinit(en_clk_dst_t pclk_dst);
+
 #endif // MICROPY_INCLUDED_PSOC_EDGE_MACHINE_TCPWM_H


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant,
     especially links to open issues. -->

- Introduced `machine_tcpwm_slave_init` and `machine_tcpwm_slave_deinit` with a slave reference counter in tcpwm file.
- `machine_counter `, `machine_pwm `and `machine_timer `will now be able to share the single TCPWM slave using this common init and deinit calls. 
- The TCPWM slave gets deinitialized only when there are no users of it (`machine_tcpwm0_slave_ref_count == 0`) from any of the TCPWM modules (timer, counter or PWM).
- Clean-up of the clock configuration methods in counter, timer and pwm.
  
### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this section empty then your Pull Request may be closed. -->
- Tested locally - Counter, Timer , PWM and TCPWM test cases
- HIL Testing 

### Generative AI

<!-- Please delete the answer below which doesn't apply, or write your own
     answer with more details. -->

I did not use generative AI tools when creating this PR.

<!-- We require everyone to answer this question. If you delete this section or
     ignore it then your PR may be closed.

     For more information, consult the MicroPython Generative AI Policy:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines#generative-ai-policy
     -->
