### PR TITLE
psoc-edge/machine_adc: Self-init PASS peripheral clock group.

### DIFF
--- a/ports/psoc-edge/boards/KIT_PSE84_AI/bsp-cfg/cycfg_peripherals.c
+++ b/ports/psoc-edge/boards/KIT_PSE84_AI/bsp-cfg/cycfg_peripherals.c
@@ -1433,7 +1433,6 @@ void init_cycfg_peripherals(void) {
  */
 
 void init_cycfg_peripheral_s_minimal(void) {
-    Cy_SysClk_PeriGroupSlaveInit(CY_MMIO_PASS_PERI_NR, CY_MMIO_PASS_GROUP_NR, CY_MMIO_PASS_SLAVE_NR, CY_MMIO_PASS_CLK_HF_NR);
     #if defined(CY_DEVICE_CONFIGURATOR_IP_ENABLE_FEATURE)
     Cy_SysClk_PeriGroupSlaveInit(CY_MMIO_SDHC0_PERI_NR, CY_MMIO_SDHC0_GROUP_NR, CY_MMIO_SDHC0_SLAVE_NR, CY_MMIO_SDHC0_CLK_HF_NR);
     #endif /* defined (CY_DEVICE_CONFIGURATOR_IP_ENABLE_FEATURE) */

--- a/ports/psoc-edge/machine_adc.c
+++ b/ports/psoc-edge/machine_adc.c
@@ -265,6 +265,9 @@ static void machine_adc_init_autanalog(void) {
         return;
     }
 
+    // PASS peripheral clock group must be enabled before Cy_AutAnalog_Init
+    Cy_SysClk_PeriGroupSlaveInit(CY_MMIO_PASS_PERI_NR, CY_MMIO_PASS_GROUP_NR, CY_MMIO_PASS_SLAVE_NR, CY_MMIO_PASS_CLK_HF_NR);
+
     // Initialize ADC configuration structures dynamically
     machine_adc_init_configs();
 


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant,
     especially links to open issues. -->

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this section empty then your Pull Request may be closed. -->

### Trade-offs and Alternatives

<!-- If the Pull Request has some negative impact (i.e. increased code size)
     then please explain why you think the trade-off improvement is worth it.
     If you can think of alternative ways to do this, please explain that here too.

     Delete this heading if not relevant (i.e. small fixes) -->


### Generative AI

<!-- Please delete the answer below which doesn't apply, or write your own
     answer with more details. -->

I did not use generative AI tools when creating this PR.

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.

<!-- We require everyone to answer this question. If you delete this section or
     ignore it then your PR may be closed.

     For more information, consult the MicroPython Generative AI Policy:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines#generative-ai-policy
     -->
