### PR TITLE
boards/manifest.py: Added required frozen manifests.

### DIFF
--- a/ports/psoc-edge/boards/manifest.py
+++ b/ports/psoc-edge/boards/manifest.py
@@ -1,2 +1,4 @@
 freeze("$(PORT_DIR)/modules")
+include("$(MPY_DIR)/extmod/asyncio")
+require("bundle-networking")
 require("neopixel")


### PR DESCRIPTION


### Summary

Add the two standard frozen packages used by all network-capable MicroPython ports:

[include("$(MPY_DIR)/extmod/asyncio")] — freezes the built-in asyncio implementation (mirrors esp32, rp2, and other ports)
[require("bundle-networking")] — freezes the standard networking bundle (requests, WebREPL, NTP, mip, etc.)

### Testing

Verified with upstream tests

### Generative AI

I did not use generative AI tools when creating this PR.

