### PR TITLE
psoc-edge/mpconfigport: Remove enabler switch for Signal

### DIFF
--- a/ports/psoc-edge/mpconfigport.h
+++ b/ports/psoc-edge/mpconfigport.h
@@ -120,7 +120,6 @@
 
 #define MICROPY_PY_MACHINE_WDT                  (1)
 #define MICROPY_PY_MACHINE_WDT_INCLUDEFILE      "ports/psoc-edge/machine_wdt.c"
-#define MICROPY_PY_MACHINE_SIGNAL               (1)
 
 #define MICROPY_PY_MACHINE_BITSTREAM            (1)
 


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant,
     especially links to open issues. -->

`MICROPY_PY_MACHINE_SIGNAL ` is enabled by default when `MICROPY_PY_MACHINE` is enabled.

In this file, [micropython-psoc-edge/py/mpconfig.h](https://github.com/Infineon/micropython-psoc-edge/blob/f4d5f19cfedc8b062c26513797fc7d96a7209b45/py/mpconfig.h#L2109) , `MICROPY_PY_MACHINE_SIGNAL` is set to `MICROPY_PY_MACHINE` and we have already sets `MICROPY_PY_MACHINE` to `1` in [micropython-psoc-edge/ports/psoc-edge/mpconfigport.h](https://github.com/Infineon/micropython-psoc-edge/blob/f4d5f19cfedc8b062c26513797fc7d96a7209b45/ports/psoc-edge/mpconfigport.h#L68)

This line is then a redefinition of the same macro and can be removed!

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this section empty then your Pull Request may be closed. -->

HIL Testing

### Generative AI

<!-- Please delete the answer below which doesn't apply, or write your own
     answer with more details. -->

I did not use generative AI tools when creating this PR.

<!-- We require everyone to answer this question. If you delete this section or
     ignore it then your PR may be closed.

     For more information, consult the MicroPython Generative AI Policy:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines#generative-ai-policy
     -->
