### PR TITLE
psoc-edge: Enable global interrupt

### DIFF
--- a/ports/psoc-edge/mpconfigport.h
+++ b/ports/psoc-edge/mpconfigport.h
@@ -67,6 +67,7 @@
 // Machine module
 #define MICROPY_PY_MACHINE                      (1)
 #define MICROPY_PY_MACHINE_INCLUDEFILE          "ports/psoc-edge/modmachine.c"
+#define MICROPY_PY_MACHINE_DISABLE_IRQ_ENABLE_IRQ (1)
 
 #define MICROPY_PY_MACHINE_PIN_MAKE_NEW         mp_pin_make_new
 

--- a/tests/ports/psoc-edge/global_interrupts.py
+++ b/tests/ports/psoc-edge/global_interrupts.py
@@ -1,0 +1,29 @@
+from machine import Timer
+import machine
+import time
+
+fired = False
+
+
+def _cb(_):
+    global fired
+    fired = True
+
+
+irq_state = machine.disable_irq()
+tim = Timer(0, period=20, mode=Timer.ONE_SHOT, callback=_cb)
+
+# Busy-wait with IRQs disabled (time.ticks_* is paused on this port).
+for _ in range(500000):
+    pass
+
+# Callback should still be blocked.
+print("while_disabled:", fired)
+
+machine.enable_irq(irq_state)
+time.sleep_ms(200)
+
+# Callback should run after IRQ restore.
+print("after_enable:", fired)
+
+tim.deinit()

--- a/tests/ports/psoc-edge/global_interrupts.py.exp
+++ b/tests/ports/psoc-edge/global_interrupts.py.exp
@@ -1,0 +1,2 @@
+while_disabled: False
+after_enable: True


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant,
     especially links to open issues. -->

Enable `global_interrupt` functionality for psoc-edge.

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this section empty then your Pull Request may be closed. -->

Test files present in `tests/ports/psoc-edge`

### Generative AI

<!-- Please delete the answer below which doesn't apply, or write your own
     answer with more details. -->

I did not use generative AI tools when creating this PR.

<!-- We require everyone to answer this question. If you delete this section or
     ignore it then your PR may be closed.

     For more information, consult the MicroPython Generative AI Policy:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines#generative-ai-policy
     -->
